### PR TITLE
Add DynamicallyAccessedMember annotations for AOT

### DIFF
--- a/src/Commands/AppConfig/BaseAppConfigCommand.cs
+++ b/src/Commands/AppConfig/BaseAppConfigCommand.cs
@@ -6,10 +6,13 @@ using AzureMcp.Models.Argument;
 using AzureMcp.Services.Interfaces;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands.AppConfig;
 
-public abstract class BaseAppConfigCommand<T> : SubscriptionCommand<T> where T : BaseAppConfigArguments, new()
+public abstract class BaseAppConfigCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] T>
+    : SubscriptionCommand<T> where T : BaseAppConfigArguments, new()
 {
     protected readonly Option<string> _accountOption = ArgumentDefinitions.AppConfig.Account.ToOption();
 

--- a/src/Commands/AppConfig/KeyValue/BaseKeyValueCommand.cs
+++ b/src/Commands/AppConfig/KeyValue/BaseKeyValueCommand.cs
@@ -5,10 +5,13 @@ using AzureMcp.Arguments.AppConfig.KeyValue;
 using AzureMcp.Models.Argument;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands.AppConfig.KeyValue;
 
-public abstract class BaseKeyValueCommand<T> : BaseAppConfigCommand<T> where T : BaseKeyValueArguments, new()
+public abstract class BaseKeyValueCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] T>
+    : BaseAppConfigCommand<T> where T : BaseKeyValueArguments, new()
 {
     protected readonly Option<string> _keyOption = ArgumentDefinitions.AppConfig.Key.ToOption();
     protected readonly Option<string> _labelOption = ArgumentDefinitions.AppConfig.Label.ToOption();

--- a/src/Commands/Cosmos/BaseCosmosCommand.cs
+++ b/src/Commands/Cosmos/BaseCosmosCommand.cs
@@ -8,10 +8,13 @@ using AzureMcp.Services.Interfaces;
 using Microsoft.Azure.Cosmos;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands.Cosmos;
 
-public abstract class BaseCosmosCommand<TArgs> : SubscriptionCommand<TArgs> where TArgs : BaseCosmosArguments, new()
+public abstract class BaseCosmosCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs>
+    : SubscriptionCommand<TArgs> where TArgs : BaseCosmosArguments, new()
 {
     protected readonly Option<string> _accountOption = ArgumentDefinitions.Cosmos.Account.ToOption();
 

--- a/src/Commands/Cosmos/BaseDatabaseCommand.cs
+++ b/src/Commands/Cosmos/BaseDatabaseCommand.cs
@@ -5,10 +5,13 @@ using AzureMcp.Arguments.Cosmos;
 using AzureMcp.Models.Argument;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands.Cosmos;
 
-public abstract class BaseDatabaseCommand<TArgs> : BaseCosmosCommand<TArgs> where TArgs : BaseDatabaseArguments, new()
+public abstract class BaseDatabaseCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs>
+    : BaseCosmosCommand<TArgs> where TArgs : BaseDatabaseArguments, new()
 {
     protected readonly Option<string> _databaseOption = ArgumentDefinitions.Cosmos.Database.ToOption();
 

--- a/src/Commands/GlobalCommand.cs
+++ b/src/Commands/GlobalCommand.cs
@@ -12,12 +12,21 @@ using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 namespace AzureMcp.Commands;
 
-public abstract class GlobalCommand<TArgs> : BaseCommand
+internal static class TrimAnnotations
+{
+    public const DynamicallyAccessedMemberTypes CommandAnnotations =
+        DynamicallyAccessedMemberTypes.PublicProperties
+        | DynamicallyAccessedMemberTypes.NonPublicProperties;
+}
+
+public abstract class GlobalCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs> : BaseCommand
     where TArgs : GlobalArguments, new()
 {
     protected readonly Option<string> _tenantOption = ArgumentDefinitions.Common.Tenant.ToOption();

--- a/src/Commands/IBaseCommand.cs
+++ b/src/Commands/IBaseCommand.cs
@@ -5,12 +5,14 @@ using AzureMcp.Models.Argument;
 using AzureMcp.Models.Command;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands;
 
 /// <summary>
 /// Interface for all commands
 /// </summary>
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
 public interface IBaseCommand
 {
     /// <summary>

--- a/src/Commands/Monitor/BaseMonitorCommand.cs
+++ b/src/Commands/Monitor/BaseMonitorCommand.cs
@@ -8,10 +8,13 @@ using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands.Monitor;
 
-public abstract class BaseMonitorCommand<TArgs>() : SubscriptionCommand<TArgs>
+public abstract class BaseMonitorCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs>
+    : SubscriptionCommand<TArgs>
     where TArgs : SubscriptionArguments, IWorkspaceArguments, new()
 {
     protected readonly Option<string> _workspaceOption = ArgumentDefinitions.Monitor.Workspace.ToOption();

--- a/src/Commands/Storage/BaseStorageCommand.cs
+++ b/src/Commands/Storage/BaseStorageCommand.cs
@@ -6,10 +6,13 @@ using AzureMcp.Models.Argument;
 using AzureMcp.Services.Interfaces;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands.Storage;
 
-public abstract class BaseStorageCommand<T> : SubscriptionCommand<T>
+public abstract class BaseStorageCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] T>
+    : SubscriptionCommand<T>
     where T : BaseStorageArguments, new()
 {
     protected readonly Option<string> _accountOption = ArgumentDefinitions.Storage.Account.ToOption();

--- a/src/Commands/Storage/Blob/Container/BaseContainerCommand.cs
+++ b/src/Commands/Storage/Blob/Container/BaseContainerCommand.cs
@@ -6,10 +6,13 @@ using AzureMcp.Models.Argument;
 using AzureMcp.Services.Interfaces;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands.Storage.Blob.Container;
 
-public abstract class BaseContainerCommand<TArgs> : BaseStorageCommand<TArgs> where TArgs : BaseContainerArguments, new()
+public abstract class BaseContainerCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs>
+    : BaseStorageCommand<TArgs> where TArgs : BaseContainerArguments, new()
 {
     protected readonly Option<string> _containerOption = ArgumentDefinitions.Storage.Container.ToOption();
 

--- a/src/Commands/Subscription/BaseSubscriptionCommand.cs
+++ b/src/Commands/Subscription/BaseSubscriptionCommand.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 using AzureMcp.Arguments.Subscription;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands.Subscription;
 
-public abstract class BaseSubscriptionCommand<TArgs> : GlobalCommand<TArgs>
+public abstract class BaseSubscriptionCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs> : GlobalCommand<TArgs>
     where TArgs : BaseSubscriptionArguments, new()
 {
     protected BaseSubscriptionCommand()

--- a/src/Commands/SubscriptionCommand.cs
+++ b/src/Commands/SubscriptionCommand.cs
@@ -7,10 +7,12 @@ using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AzureMcp.Commands;
 
-public abstract class SubscriptionCommand<TArgs> : GlobalCommand<TArgs>
+public abstract class SubscriptionCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs> : GlobalCommand<TArgs>
     where TArgs : SubscriptionArguments, new()
 {
     protected readonly Option<string> _subscriptionOption = ArgumentDefinitions.Common.Subscription.ToOption();


### PR DESCRIPTION
Azure MCP uses some very simple reflection, which is compatible with AOT. However, AOT requires that the reflection info is propagated up so that the compiler can determine what info is used. The DynamicallyAccessedMembersAttribute does that by acting like a generic constraint, and pushing the info up the call stack to the substitution point.