### PR TITLE
Add App Service Plan List operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The Azure MCP Server provides tools for interacting with the following Azure ser
 - Handle labeled configurations
 - Lock/unlock configuration settings
 
+### ⚙️ Azure App Service
+- List App Service Plans
+
 ### 📦 Azure Resource Groups
 - List resource groups
 - Resource group management operations

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -114,6 +114,12 @@ azmcp appconfig kv unlock --subscription <subscription> --account-name <account-
 azmcp appconfig kv delete --subscription <subscription> --account-name <account-name> --key <key> [--label <label>]
 ```
 
+### App Service Operations
+```bash
+# List App Service Plans in a subscription
+azmcp appservice plan list --subscription <subscription>
+```
+
 ### Resource Group Operations
 ```bash
 # List resource groups in a subscription

--- a/src/Arguments/AppService/BaseAppServiceArguments.cs
+++ b/src/Arguments/AppService/BaseAppServiceArguments.cs
@@ -4,9 +4,9 @@
 using AzureMcp.Models.Argument;
 using System.Text.Json.Serialization;
 
-namespace AzureMcp.Arguments;
+namespace AzureMcp.Arguments.AppService;
 
-public class AppServiceArguments : SubscriptionArguments
+public class BaseAppServiceArguments : SubscriptionArguments
 {
 
 }

--- a/src/Arguments/AppServiceArguments.cs
+++ b/src/Arguments/AppServiceArguments.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Models.Argument;
+using System.Text.Json.Serialization;
+
+namespace AzureMcp.Arguments;
+
+public class AppServiceArguments : SubscriptionArguments
+{
+
+}

--- a/src/AzureMcp.csproj
+++ b/src/AzureMcp.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="Azure.Identity.Broker" Version="1.2.0" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.6.0" />
     <PackageReference Include="Azure.ResourceManager.AppConfiguration" Version="1.4.0" />
+    <PackageReference Include="Azure.ResourceManager.AppService" Version="1.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Azure.ResourceManager.CosmosDB" Version="1.3.2" />

--- a/src/Commands/AppService/AppServicePlanListCommand.cs
+++ b/src/Commands/AppService/AppServicePlanListCommand.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureMcp.Arguments;
-using AzureMcp.Arguments.Group;
+using AzureMcp.Arguments.AppService;
 using AzureMcp.Models.Argument;
 using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
@@ -12,7 +11,7 @@ using System.CommandLine.Parsing;
 
 namespace AzureMcp.Commands.AppService;
 
-public sealed class AppServicePlanListCommand : SubscriptionCommand<AppServiceArguments>
+public sealed class AppServicePlanListCommand : SubscriptionCommand<BaseAppServiceArguments>
 {
     private readonly ILogger<AppServicePlanListCommand> _logger;
 
@@ -26,7 +25,7 @@ public sealed class AppServicePlanListCommand : SubscriptionCommand<AppServiceAr
     protected override string GetCommandDescription() =>
         $"""
         List all app service plans in a subscription. This command retrieves all app service plans available
-        in the specified {ArgumentDefinitions.Common.SubscriptionName}. Results include app service plan names and IDs,
+        in the specified {ArgumentDefinitions.Common.SubscriptionName}. Results include app service plan names,
         returned as a JSON array.
         """;
 

--- a/src/Commands/AppService/AppServicePlanListCommand.cs
+++ b/src/Commands/AppService/AppServicePlanListCommand.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Arguments;
+using AzureMcp.Arguments.Group;
+using AzureMcp.Models.Argument;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using System.CommandLine.Parsing;
+
+namespace AzureMcp.Commands.AppService;
+
+public sealed class AppServicePlanListCommand : SubscriptionCommand<AppServiceArguments>
+{
+    private readonly ILogger<AppServicePlanListCommand> _logger;
+
+    public AppServicePlanListCommand(ILogger<AppServicePlanListCommand> logger) : base()
+    {
+        _logger = logger;
+    }
+
+    protected override string GetCommandName() => "list";
+
+    protected override string GetCommandDescription() =>
+        $"""
+        List all app service plans in a subscription. This command retrieves all app service plans available
+        in the specified {ArgumentDefinitions.Common.SubscriptionName}. Results include app service plan names and IDs,
+        returned as a JSON array.
+        """;
+
+    [McpServerTool(Destructive = false, ReadOnly = true)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var args = BindArguments(parseResult);
+
+        try
+        {
+            if (!await ProcessArguments(context, args))
+            {
+                return context.Response;
+            }
+
+            var appServicePlanService = context.GetService<IAppServiceService>();
+            var appServicePlans = await appServicePlanService.ListAppServicePlans(
+                args.Subscription!,
+                args.Tenant,
+                args.RetryPolicy);
+
+            context.Response.Results = appServicePlans?.Count > 0 ?
+                new { appServicePlans } :
+                null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred listing app service plans.");
+            HandleException(context.Response, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/src/Commands/CommandFactory.cs
+++ b/src/Commands/CommandFactory.cs
@@ -61,6 +61,7 @@ public class CommandFactory
         RegisterStorageCommands();
         RegisterMonitorCommands();
         RegisterAppConfigCommands();
+        RegisterAppServicePlanCommands();
         RegisterToolsCommands();
         RegisterExtensionCommands();
         RegisterSubscriptionCommands();
@@ -172,6 +173,20 @@ public class CommandFactory
         keyValue.AddCommand("set", new AppConfig.KeyValue.KeyValueSetCommand(GetLogger<AppConfig.KeyValue.KeyValueSetCommand>()));
         keyValue.AddCommand("show", new AppConfig.KeyValue.KeyValueShowCommand(GetLogger<AppConfig.KeyValue.KeyValueShowCommand>()));
         keyValue.AddCommand("delete", new AppConfig.KeyValue.KeyValueDeleteCommand(GetLogger<AppConfig.KeyValue.KeyValueDeleteCommand>()));
+    }
+
+    private void RegisterAppServicePlanCommands()
+    {
+        // Create Monitor command group
+        var monitor = new CommandGroup("appservice", "Azure App Service operations - Commands for managing App Service.");
+        _rootGroup.AddSubGroup(monitor);
+
+        // Create Monitor subgroups
+        var plan = new CommandGroup("plan", "Azure App Service plan operations - Commands for managing App Service plan.");
+        monitor.AddSubGroup(plan);
+
+        plan.AddCommand("list", new AppService.AppServicePlanListCommand(
+            GetLogger<AppService.AppServicePlanListCommand>()));
     }
 
     private void RegisterToolsCommands()

--- a/src/Commands/Server/ServiceStartCommand.cs
+++ b/src/Commands/Server/ServiceStartCommand.cs
@@ -177,6 +177,7 @@ public sealed class ServiceStartCommand(IServiceProvider serviceProvider) : Base
         services.AddSingleton(rootServiceProvider.GetRequiredService<IMonitorService>());
         services.AddSingleton(rootServiceProvider.GetRequiredService<IResourceGroupService>());
         services.AddSingleton(rootServiceProvider.GetRequiredService<IAppConfigService>());
+        services.AddSingleton(rootServiceProvider.GetRequiredService<IAppServiceService>());
         services.AddSingleton(rootServiceProvider.GetRequiredService<IExternalProcessService>());
     }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -62,5 +62,6 @@ static void ConfigureServices(IServiceCollection services)
     services.AddSingleton<IMonitorService, MonitorService>();
     services.AddSingleton<IResourceGroupService, ResourceGroupService>();
     services.AddSingleton<IAppConfigService, AppConfigService>();
+    services.AddSingleton<IAppServiceService, AppServiceService>();
     services.AddSingleton<CommandFactory>();
 }

--- a/src/Services/Azure/AppService/AppServiceService.cs
+++ b/src/Services/Azure/AppService/AppServiceService.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Azure.ResourceManager.AppService;
+using AzureMcp.Arguments;
+using AzureMcp.Services.Interfaces;
+
+namespace AzureMcp.Services.Azure.Cosmos;
+
+public class AppServiceService(ISubscriptionService subscriptionService, ITenantService tenantService)
+    : BaseAzureService(tenantService), IAppServiceService
+{
+    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
+
+    public async Task<List<string>> ListAppServicePlans (string subscriptionId, string? tenant = null, RetryPolicyArguments? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscriptionId);
+
+        var subscription = await _subscriptionService.GetSubscription(subscriptionId, tenant, retryPolicy);
+        var appServicePlans = subscription.GetAppServicePlans(false).Select(p => p.Data.Name).ToList();
+        return (List<string>)appServicePlans;
+    }
+
+}

--- a/src/Services/Interfaces/IAppServiceService.cs
+++ b/src/Services/Interfaces/IAppServiceService.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Arguments;
+using System.Text.Json;
+
+namespace AzureMcp.Services.Interfaces;
+
+public interface IAppServiceService
+{
+
+    Task<List<string>> ListAppServicePlans(
+        string subscriptionId,
+        string? tenant = null,
+        RetryPolicyArguments? retryPolicy = null);
+
+}

--- a/tests/Client/AppServiceCommandTests.cs
+++ b/tests/Client/AppServiceCommandTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Tests.Client.Helpers;
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AzureMcp.Tests.Client;
+
+public class AppServiceCommandTests(McpClientFixture mcpClient, LiveTestSettingsFixture liveTestSettings, ITestOutputHelper output)
+    : CommandTestsBase(mcpClient, liveTestSettings, output),
+    IClassFixture<McpClientFixture>, IClassFixture<LiveTestSettingsFixture>
+{
+    [Fact]
+    [Trait("Category", "Live")]
+    public async Task Should_list_appservice_plans()
+    {
+        var result = await CallToolAsync(
+            "azmcp-appservice-plan-list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId }
+            });
+
+        Assert.True(result.TryGetProperty("appServicePlans", out var appServicePlans));
+        Assert.Equal(JsonValueKind.Array, appServicePlans.ValueKind);
+        Assert.NotEmpty(appServicePlans.EnumerateArray());
+    }
+
+}

--- a/tests/Commands/Server/ServiceStartCommandTests.cs
+++ b/tests/Commands/Server/ServiceStartCommandTests.cs
@@ -24,6 +24,7 @@ public class ServiceStartCommandTests
         services.AddSingleton(Substitute.For<IMonitorService>());
         services.AddSingleton(Substitute.For<IResourceGroupService>());
         services.AddSingleton(Substitute.For<IAppConfigService>());
+        services.AddSingleton(Substitute.For<IAppServiceService>());
         services.AddSingleton<CommandFactory>();
 
         _serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
This pull request introduces support for Azure App Service operations, specifically for listing App Service Plans. The changes include updates to documentation, new classes and interfaces, command registration, and corresponding tests.

`azmcp appservice plan list --subscription <subscription>`

### Documentation Updates:
* Added a new section for Azure App Service operations in `README.md` and `docs/azmcp-commands.md`, including the `azmcp appservice plan list` command for listing App Service Plans. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R77) [[2]](diffhunk://#diff-283e9b8fdb9b26594fc5f304e94484623572b7597b029d95f0ce0d4b33f22a2fR117-R122)

### Core Implementation:
* Introduced `BaseAppServiceArguments` class in `src/Arguments/AppService/BaseAppServiceArguments.cs` to handle arguments for App Service commands.
* Added `AppServicePlanListCommand` in `src/Commands/AppService/AppServicePlanListCommand.cs` to implement the logic for listing App Service Plans.
* Registered the new App Service command group and its subcommands in `CommandFactory.cs`. [[1]](diffhunk://#diff-1c09cb6d702765452b8d0f39acbe2b55f72b2751d9003e49895b49a285cc2069R64) [[2]](diffhunk://#diff-1c09cb6d702765452b8d0f39acbe2b55f72b2751d9003e49895b49a285cc2069R178-R191)

### Service Layer:
* Created `AppServiceService` in `src/Services/Azure/AppService/AppServiceService.cs` to interact with Azure Resource Manager for App Service Plans.
* Defined `IAppServiceService` interface in `src/Services/Interfaces/IAppServiceService.cs` for abstraction.
* Updated dependency injection in `ServiceStartCommand.cs` and `Program.cs` to include `IAppServiceService`. [[1]](diffhunk://#diff-f61b7c0e5632e56e1bcfe5f0e60b78db15626b9c31b7ffe6fe13dc17a1133b32R180) [[2]](diffhunk://#diff-4a4588302b6b6704e8d835eeae2bc4e72d329487921efe11aa2c30c4ee345e3fR65)

### Testing:
* Added unit tests in `tests/Client/AppServiceCommandTests.cs` to verify the functionality of listing App Service Plans.
* Updated `ServiceStartCommandTests.cs` to include mock setup for `IAppServiceService`.

### Dependency Updates:
* Added a new package reference for `Azure.ResourceManager.AppService` in `AzureMcp.csproj` to enable interaction with Azure App Service resources.