### PR TITLE
Async credentials retrieval

### DIFF
--- a/src/Services/Azure/AppConfig/AppConfigService.cs
+++ b/src/Services/Azure/AppConfig/AppConfigService.cs
@@ -168,7 +168,7 @@ public class AppConfigService(ISubscriptionService subscriptionService, ITenantS
         var subscription = await _subscriptionService.GetSubscription(subscriptionId, tenant, retryPolicy);
         var configStore = await FindAppConfigStore(subscription, accountName, subscriptionId);
         var endpoint = configStore.Data.Endpoint;
-        var credential = GetCredential(tenant);
+        var credential = await GetCredential(tenant);
         AddDefaultPolicies(new ConfigurationClientOptions());
 
         return new ConfigurationClient(new Uri(endpoint), credential);

--- a/src/Services/Azure/BaseAzureService.cs
+++ b/src/Services/Azure/BaseAzureService.cs
@@ -42,9 +42,9 @@ public abstract class BaseAzureService(ITenantService? tenantService = null)
         return await _tenantService.GetTenantId(tenant);
     }
 
-    protected TokenCredential GetCredential(string? tenant = null)
+    protected async Task<TokenCredential> GetCredential(string? tenant = null)
     {
-        var tenantId = string.IsNullOrEmpty(tenant) ? null : Task.Run(() => ResolveTenantIdAsync(tenant)).GetAwaiter().GetResult();
+        var tenantId = string.IsNullOrEmpty(tenant) ? null : await ResolveTenantIdAsync(tenant);
 
         // Return cached credential if it exists and tenant ID hasn't changed
         if (_credential != null && _lastTenantId == tenantId)
@@ -91,7 +91,7 @@ public abstract class BaseAzureService(ITenantService? tenantService = null)
 
         try
         {
-            var credential = GetCredential(tenantId);
+            var credential = await GetCredential(tenantId);
             var options = AddDefaultPolicies(new ArmClientOptions());
 
             // Configure retry policy if provided

--- a/src/Services/Azure/Monitor/MonitorService.cs
+++ b/src/Services/Azure/Monitor/MonitorService.cs
@@ -42,7 +42,7 @@ public class MonitorService(ISubscriptionService subscriptionService, IResourceG
     {
         ValidateRequiredParameters(subscription, workspace, query);
 
-        var credential = GetCredential(tenant);
+        var credential = await GetCredential(tenant);
         var options = AddDefaultPolicies(new LogsQueryClientOptions());
 
         if (retryPolicy != null)

--- a/src/Services/Azure/Storage/StorageService.cs
+++ b/src/Services/Azure/Storage/StorageService.cs
@@ -64,7 +64,7 @@ public class StorageService(ISubscriptionService subscriptionService, ICacheServ
     {
         ValidateRequiredParameters(accountName, subscriptionId);
 
-        var blobServiceClient = CreateBlobServiceClient(accountName, tenant, retryPolicy);
+        var blobServiceClient = await CreateBlobServiceClient(accountName, tenant, retryPolicy);
         var containers = new List<string>();
 
         try
@@ -179,7 +179,7 @@ public class StorageService(ISubscriptionService subscriptionService, ICacheServ
     {
         ValidateRequiredParameters(accountName, containerName, subscriptionId);
 
-        var blobServiceClient = CreateBlobServiceClient(accountName, tenant, retryPolicy);
+        var blobServiceClient = await CreateBlobServiceClient(accountName, tenant, retryPolicy);
         var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
         var blobs = new List<string>();
 
@@ -207,7 +207,7 @@ public class StorageService(ISubscriptionService subscriptionService, ICacheServ
     {
         ValidateRequiredParameters(accountName, containerName);
 
-        var blobServiceClient = CreateBlobServiceClient(accountName, tenant, retryPolicy);
+        var blobServiceClient = await CreateBlobServiceClient(accountName, tenant, retryPolicy);
         var containerClient = blobServiceClient.GetBlobContainerClient(containerName);
 
         try
@@ -299,11 +299,11 @@ public class StorageService(ISubscriptionService subscriptionService, ICacheServ
             case AuthMethod.Credential:
             default:
                 var defaultUri = $"https://{accountName}.table.core.windows.net";
-                return new TableServiceClient(new Uri(defaultUri), GetCredential(tenant), options);
+                return new TableServiceClient(new Uri(defaultUri), await GetCredential(tenant), options);
         }
     }
 
-    private BlobServiceClient CreateBlobServiceClient(string accountName, string? tenant = null, RetryPolicyArguments? retryPolicy = null)
+    private async Task<BlobServiceClient> CreateBlobServiceClient(string accountName, string? tenant = null, RetryPolicyArguments? retryPolicy = null)
     {
         var uri = $"https://{accountName}.blob.core.windows.net";
         var options = AddDefaultPolicies(new BlobClientOptions());
@@ -316,6 +316,6 @@ public class StorageService(ISubscriptionService subscriptionService, ICacheServ
             options.Retry.Mode = retryPolicy.Mode;
             options.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds);
         }
-        return new BlobServiceClient(new Uri(uri), GetCredential(tenant), options);
+        return new BlobServiceClient(new Uri(uri), await GetCredential(tenant), options);
     }
 }

--- a/src/Services/Azure/Tenant/TenantService.cs
+++ b/src/Services/Azure/Tenant/TenantService.cs
@@ -28,7 +28,7 @@ public class TenantService(ICacheService cacheService)
         var results = new List<ArgumentOption>();
         
         var options = AddDefaultPolicies(new ArmClientOptions());
-        var client = new ArmClient(GetCredential(), default, options);
+        var client = new ArmClient(await GetCredential(), default, options);
 
         await foreach (var tenant in client.GetTenants())
         {


### PR DESCRIPTION
This small contribution makes the credential retrieval async to avoid the `Task.Run` and the `GetAwaiter() `call which seems unnecessary.