### PR TITLE
feat: more robust az path resolution

### DIFF
--- a/src/Commands/Extension/AzCommand.cs
+++ b/src/Commands/Extension/AzCommand.cs
@@ -97,15 +97,20 @@ Your job is to answer questions about an Azure environment by executing Azure CL
                     _cachedAzPath = cmdPath;
                     return cmdPath;
                 }
-            }
-            else
-            {
-                var fullPath = Path.Combine(dir, "az");
-                if (File.Exists(fullPath))
+
+                cmdPath = Path.Combine(dir, "az.bat");
+                if (File.Exists(cmdPath))
                 {
-                    _cachedAzPath = fullPath;
-                    return fullPath;
+                    _cachedAzPath = cmdPath;
+                    return cmdPath;
                 }
+            }
+
+            var fullPath = Path.Combine(dir, "az");
+            if (File.Exists(fullPath))
+            {
+                _cachedAzPath = fullPath;
+                return fullPath;
             }
         }
 


### PR DESCRIPTION
When Az CLI is installed via `pip` on Windows, it will be in `Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs", "Python", "Python39", "Scripts"),` as both `az` and `az.bat`. The proposed changes look these up in a more robust and non breaking manner by 1/ when `isWindows` also checking for `az.bat` and regardless of OS also checking for `az` 