### PR TITLE
Refactor JSON handling in tests to access 'results' property directly

### DIFF
--- a/tests/Client/ClientToolTests.cs
+++ b/tests/Client/ClientToolTests.cs
@@ -36,7 +36,8 @@ public class ClientToolTests(McpClientFixture fixture) : IClassFixture<McpClient
         var root = JsonSerializer.Deserialize<JsonElement>(content!);
         Assert.Equal(JsonValueKind.Object, root.ValueKind);
 
-        Assert.True(root.TryGetProperty("subscriptions", out var subscriptionsArray));
+        Assert.True(root.TryGetProperty("results", out var results));
+        Assert.True(results.TryGetProperty("subscriptions", out var subscriptionsArray));
         Assert.Equal(JsonValueKind.Array, subscriptionsArray.ValueKind);
 
         Assert.NotEmpty(subscriptionsArray.EnumerateArray());

--- a/tests/Client/CommandTestsBase.cs
+++ b/tests/Client/CommandTestsBase.cs
@@ -30,7 +30,6 @@ public abstract class CommandTestsBase(McpClientFixture mcpClient, LiveTestSetti
         Output.WriteLine($"response content: {content}");
 
         var root = JsonSerializer.Deserialize<JsonElement>(content!);
-
-        return root;
+        return root.GetProperty("results");
     }
 }


### PR DESCRIPTION
Update tests and methods to directly access the 'results' property from JSON responses, improving clarity and reducing unnecessary property lookups.