### PR TITLE
Fix Storage and Monitor service/tools auth.

### DIFF
--- a/src/Services/Azure/Authentication/CustomChainedCredential.cs
+++ b/src/Services/Azure/Authentication/CustomChainedCredential.cs
@@ -27,11 +27,12 @@ public class CustomChainedCredential(string? tenantId = null) : TokenCredential
         _chainedCredential.GetTokenAsync(requestContext, cancellationToken);
 
     private static ChainedTokenCredential CreateChainedCredential(string? tenantId) =>
-        new(CreateDefaultCredential(tenantId), CreateBrowserCredential());
+        new(CreateDefaultCredential(tenantId), CreateBrowserCredential(tenantId));
 
-    private static InteractiveBrowserCredential CreateBrowserCredential() =>
+    private static InteractiveBrowserCredential CreateBrowserCredential(string? tenantId) =>
         new(new InteractiveBrowserCredentialBrokerOptions(IntPtr.Zero)
         {
+            TenantId = string.IsNullOrEmpty(tenantId) ? null : tenantId,
             UseDefaultBrokerAccount = true
         });
 

--- a/src/Services/Azure/Monitor/MonitorService.cs
+++ b/src/Services/Azure/Monitor/MonitorService.cs
@@ -11,8 +11,8 @@ using System.Text.Json;
 
 namespace AzureMcp.Services.Azure.Monitor;
 
-public class MonitorService(ISubscriptionService subscriptionService, IResourceGroupService resourceGroupService)
-    : BaseAzureService, IMonitorService
+public class MonitorService(ISubscriptionService subscriptionService, ITenantService tenantService, IResourceGroupService resourceGroupService)
+    : BaseAzureService(tenantService), IMonitorService
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly IResourceGroupService _resourceGroupService = resourceGroupService ?? throw new ArgumentNullException(nameof(resourceGroupService));

--- a/src/Services/Azure/Storage/StorageService.cs
+++ b/src/Services/Azure/Storage/StorageService.cs
@@ -14,7 +14,7 @@ using AzureMcp.Services.Interfaces;
 
 namespace AzureMcp.Services.Azure.Storage;
 
-public class StorageService(ISubscriptionService subscriptionService, ICacheService cacheService) : BaseAzureService, IStorageService
+public class StorageService(ISubscriptionService subscriptionService, ITenantService tenantService,ICacheService cacheService) : BaseAzureService(tenantService), IStorageService
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly ICacheService _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));


### PR DESCRIPTION
Storage and Monitor Service doesn't have Tenant service injected.
Results in tenant arg (tenant name) not being resolved tenant ID and that breaks DAC auth.

Also, Browser Broker auth currently doesn't honor tenant ID, this PR fixes that too.