### PR TITLE
Adds support for Azure Database for PostgreSQL

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,11 +10,12 @@
     <PackageVersion Include="Azure.Identity.Broker" Version="1.2.0" />
     <PackageVersion Include="Azure.Monitor.Query" Version="1.6.0" />
     <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.4.0" />
+    <PackageVersion Include="Azure.ResourceManager.PostgreSql" Version="1.2.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="1.3.2" />
     <PackageVersion Include="Azure.ResourceManager.OperationalInsights" Version="1.2.2" />
-	<PackageVersion Include="Azure.ResourceManager.Search" Version="1.2.3" />
+    <PackageVersion Include="Azure.ResourceManager.Search" Version="1.2.3" />
     <PackageVersion Include="Azure.ResourceManager.Storage" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.67.2" />
     <PackageVersion Include="ModelContextProtocol" Version="0.1.0-preview.11" />
@@ -24,6 +25,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.4" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0-preview.3.25171.5" />
@@ -31,7 +33,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.11.0" />
-	<PackageVersion Include="Azure.Search.Documents" Version="11.7.0-beta.3" />
+    <PackageVersion Include="Azure.Search.Documents" Version="11.7.0-beta.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ The Azure MCP Server provides tools for interacting with the following Azure ser
 - Manage containers and items
 - Execute SQL queries against containers
 
+### 🐘 Azure Database for PostgreSQL - Flexible Server
+- List and query databases.
+- List and get schema for tables.
+- List, get configuration and get parameters for servers.
+
 ### 💾 Azure Storage
 - List Storage accounts
 - Manage blob containers and blobs

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -54,29 +54,29 @@ azmcp cosmos database container item query --subscription <subscription> \
 ## Databae commands
 
 # List all databases in a PostgreSQL server
-azmcp postgres database list --subscription <subscription> --resource-group <resource-group> --user <user> --server <server>
+azmcp postgres database list --subscription <subscription> --resource-group <resource-group> --user-name <user> --server <server>
 
 # Execute a query on a PostgreSQL database
-azmcp postgres database query --subscription <subscription> --resource-group <resource-group> --user <user> --server <server> --database <database> --query <query>
+azmcp postgres database query --subscription <subscription> --resource-group <resource-group> --user-name <user> --server <server> --database <database> --query <query>
 
 ## Table Commands
 
 # List all tables in a PostgreSQL database
-azmcp postgres table list --subscription <subscription> --resource-group <resource-group> --user <user> --server <server> --database <database>
+azmcp postgres table list --subscription <subscription> --resource-group <resource-group> --user-name <user> --server <server> --database <database>
 
 # Get the schema of a specific table in a PostgreSQL database
-azmcp postgres table schema --subscription <subscription> --resource-group <resource-group> --user <user> --server <server> --database <database> --table <table>
+azmcp postgres table schema --subscription <subscription> --resource-group <resource-group> --user-name <user> --server <server> --database <database> --table <table>
 
 ## Server Commands
 
-# List all PostgreSQL servers in a subscription
-azmcp postgres server list --subscription <subscription> --resource-group <resource-group> --user <user>
+# List all PostgreSQL servers in a subscription & resource group
+azmcp postgres server list --subscription <subscription> --resource-group <resource-group> --user-name <user>
 
 # Retrieve the configuration of a PostgreSQL server
-azmcp postgres server config --subscription <subscription> --resource-group <resource-group> --user <user> --server <server>
+azmcp postgres server config --subscription <subscription> --resource-group <resource-group> ----user-name <user> --server <server>
 
 # Retrieve a specific parameter of a PostgreSQL server
-azmcp postgres server parameter --subscription <subscription> --resource-group <resource-group> --user <user> --server <server> --param <parameter>
+azmcp postgres server param --subscription <subscription> --resource-group <resource-group> --user-name <user> --server <server> --param <parameter>
 ```
 
 ### Storage Operations

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -48,6 +48,37 @@ azmcp cosmos database container item query --subscription <subscription> \
                        [--query "SELECT * FROM c"]
 ```
 
+### PostgreSQL Operations
+
+```bash
+## Databae commands
+
+# List all databases in a PostgreSQL server
+azmcp postgres database list --subscription <subscription> --resource-group <resource-group> --user <user> --server <server>
+
+# Execute a query on a PostgreSQL database
+azmcp postgres database query --subscription <subscription> --resource-group <resource-group> --user <user> --server <server> --database <database> --query <query>
+
+## Table Commands
+
+# List all tables in a PostgreSQL database
+azmcp postgres table list --subscription <subscription> --resource-group <resource-group> --user <user> --server <server> --database <database>
+
+# Get the schema of a specific table in a PostgreSQL database
+azmcp postgres table schema --subscription <subscription> --resource-group <resource-group> --user <user> --server <server> --database <database> --table <table>
+
+## Server Commands
+
+# List all PostgreSQL servers in a subscription
+azmcp postgres server list --subscription <subscription> --resource-group <resource-group> --user <user>
+
+# Retrieve the configuration of a PostgreSQL server
+azmcp postgres server config --subscription <subscription> --resource-group <resource-group> --user <user> --server <server>
+
+# Retrieve a specific parameter of a PostgreSQL server
+azmcp postgres server parameter --subscription <subscription> --resource-group <resource-group> --user <user> --server <server> --param <parameter>
+```
+
 ### Storage Operations
 ```bash
 # List Storage accounts in a subscription

--- a/src/Arguments/Postgres/BasePostgresArguments.cs
+++ b/src/Arguments/Postgres/BasePostgresArguments.cs
@@ -1,22 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+using AzureMcp.Models.Argument;
+
 namespace AzureMcp.Arguments.Postgres;
 
 public class BasePostgresArguments : SubscriptionArguments
 {
+    [JsonPropertyName(ArgumentDefinitions.Postgres.UserName)]
     public string? User { get; set; }
-    public string? Server { get; set; }
-    public string? Database { get; set; }
 
-    protected static void ValidateProperties((string? Property, string Name)[] properties)
-    {
-        foreach (var (property, name) in properties)
-        {
-            if (string.IsNullOrEmpty(property))
-            {
-                throw new ArgumentNullException(name, $"{name} cannot be null or empty.");
-            }
-        }
-    }
+    [JsonPropertyName(ArgumentDefinitions.Postgres.ServerName)]
+    public string? Server { get; set; }
+
+    [JsonPropertyName(ArgumentDefinitions.Postgres.DatabaseName)]
+    public string? Database { get; set; }
 }

--- a/src/Arguments/Postgres/BasePostgresArguments.cs
+++ b/src/Arguments/Postgres/BasePostgresArguments.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Arguments.Postgres;
+
+public class BasePostgresArguments : SubscriptionArguments
+{
+    public string? User { get; set; }
+    public string? Server { get; set; }
+    public string? Database { get; set; }
+
+    protected static void ValidateProperties((string? Property, string Name)[] properties)
+    {
+        foreach (var (property, name) in properties)
+        {
+            if (string.IsNullOrEmpty(property))
+            {
+                throw new ArgumentNullException(name, $"{name} cannot be null or empty.");
+            }
+        }
+    }
+}

--- a/src/Arguments/Postgres/Database/DatabaseListArguments.cs
+++ b/src/Arguments/Postgres/Database/DatabaseListArguments.cs
@@ -3,16 +3,4 @@
 
 namespace AzureMcp.Arguments.Postgres.Database;
 
-public class DatabaseListArguments : BasePostgresArguments
-{
-    public void Validate()
-    {
-        ValidateProperties(
-        [
-            (Subscription, nameof(Subscription)),
-            (ResourceGroup, nameof(ResourceGroup)),
-            (User, nameof(User)),
-            (Server, nameof(Server))
-        ]);
-    }
-}
+public class DatabaseListArguments : BasePostgresArguments;

--- a/src/Arguments/Postgres/Database/DatabaseListArguments.cs
+++ b/src/Arguments/Postgres/Database/DatabaseListArguments.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Arguments.Postgres.Database;
+
+public class DatabaseListArguments : BasePostgresArguments
+{
+    public void Validate()
+    {
+        ValidateProperties(
+        [
+            (Subscription, nameof(Subscription)),
+            (ResourceGroup, nameof(ResourceGroup)),
+            (User, nameof(User)),
+            (Server, nameof(Server))
+        ]);
+    }
+}

--- a/src/Arguments/Postgres/Database/DatabaseQueryArguments.cs
+++ b/src/Arguments/Postgres/Database/DatabaseQueryArguments.cs
@@ -1,22 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+using AzureMcp.Models.Argument;
+
 namespace AzureMcp.Arguments.Postgres.Database;
 
 public class DatabaseQueryArguments : BasePostgresArguments
 {
+    [JsonPropertyName(ArgumentDefinitions.Postgres.QueryText)]
     public string? Query { get; set; }
 
-    public void Validate()
-    {
-        ValidateProperties(
-        [
-            (Subscription, nameof(Subscription)),
-            (ResourceGroup, nameof(ResourceGroup)),
-            (User, nameof(User)),
-            (Server, nameof(Server)),
-            (Database, nameof(Database)),
-            (Query, nameof(Query))
-        ]);
-    }
 }

--- a/src/Arguments/Postgres/Database/DatabaseQueryArguments.cs
+++ b/src/Arguments/Postgres/Database/DatabaseQueryArguments.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Arguments.Postgres.Database;
+
+public class DatabaseQueryArguments : BasePostgresArguments
+{
+    public string? Query { get; set; }
+
+    public void Validate()
+    {
+        ValidateProperties(
+        [
+            (Subscription, nameof(Subscription)),
+            (ResourceGroup, nameof(ResourceGroup)),
+            (User, nameof(User)),
+            (Server, nameof(Server)),
+            (Database, nameof(Database)),
+            (Query, nameof(Query))
+        ]);
+    }
+}

--- a/src/Arguments/Postgres/Server/GetConfigArguments.cs
+++ b/src/Arguments/Postgres/Server/GetConfigArguments.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Arguments.Postgres.Server;
+
+public class GetConfigArguments : BasePostgresArguments
+{
+    public void Validate()
+    {
+        ValidateProperties(
+        [
+            (Subscription, nameof(Subscription)),
+            (ResourceGroup, nameof(ResourceGroup)),
+            (User, nameof(User)),
+            (Server, nameof(Server))
+        ]);
+    }
+}

--- a/src/Arguments/Postgres/Server/GetConfigArguments.cs
+++ b/src/Arguments/Postgres/Server/GetConfigArguments.cs
@@ -3,16 +3,4 @@
 
 namespace AzureMcp.Arguments.Postgres.Server;
 
-public class GetConfigArguments : BasePostgresArguments
-{
-    public void Validate()
-    {
-        ValidateProperties(
-        [
-            (Subscription, nameof(Subscription)),
-            (ResourceGroup, nameof(ResourceGroup)),
-            (User, nameof(User)),
-            (Server, nameof(Server))
-        ]);
-    }
-}
+public class GetConfigArguments : BasePostgresArguments;

--- a/src/Arguments/Postgres/Server/GetParamArguments.cs
+++ b/src/Arguments/Postgres/Server/GetParamArguments.cs
@@ -1,21 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+using AzureMcp.Models.Argument;
+
 namespace AzureMcp.Arguments.Postgres.Server;
 
 public class GetParamArguments : BasePostgresArguments
 {
+    [JsonPropertyName(ArgumentDefinitions.Postgres.ParamName)]
     public string? Param { get; set; }
-
-    public void Validate()
-    {
-        ValidateProperties(
-        [
-            (Subscription, nameof(Subscription)),
-            (ResourceGroup, nameof(ResourceGroup)),
-            (User, nameof(User)),
-            (Server, nameof(Server)),
-            (Param, nameof(Param))
-        ]);
-    }
 }

--- a/src/Arguments/Postgres/Server/GetParamArguments.cs
+++ b/src/Arguments/Postgres/Server/GetParamArguments.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Arguments.Postgres.Server;
+
+public class GetParamArguments : BasePostgresArguments
+{
+    public string? Param { get; set; }
+
+    public void Validate()
+    {
+        ValidateProperties(
+        [
+            (Subscription, nameof(Subscription)),
+            (ResourceGroup, nameof(ResourceGroup)),
+            (User, nameof(User)),
+            (Server, nameof(Server)),
+            (Param, nameof(Param))
+        ]);
+    }
+}

--- a/src/Arguments/Postgres/Server/ServerListArguments.cs
+++ b/src/Arguments/Postgres/Server/ServerListArguments.cs
@@ -3,14 +3,4 @@
 
 namespace AzureMcp.Arguments.Postgres.Server;
 
-public class ServerListArguments : BasePostgresArguments
-{
-    public void Validate()
-    {
-        ValidateProperties([
-                (Subscription, nameof(Subscription)),
-                (ResourceGroup, nameof(ResourceGroup)),
-                (User, nameof(User))
-        ]);
-    }
-}
+public class ServerListArguments : BasePostgresArguments;

--- a/src/Arguments/Postgres/Server/ServerListArguments.cs
+++ b/src/Arguments/Postgres/Server/ServerListArguments.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Arguments.Postgres.Server;
+
+public class ServerListArguments : BasePostgresArguments
+{
+    public void Validate()
+    {
+        ValidateProperties([
+                (Subscription, nameof(Subscription)),
+                (ResourceGroup, nameof(ResourceGroup)),
+                (User, nameof(User))
+        ]);
+    }
+}

--- a/src/Arguments/Postgres/Table/GetSchemaArguments.cs
+++ b/src/Arguments/Postgres/Table/GetSchemaArguments.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Arguments.Postgres.Table;
+
+public class GetSchemaArguments : BasePostgresArguments
+{
+    public string? Table { get; set; }
+
+    public void Validate()
+    {
+        ValidateProperties(
+        [
+            (Subscription, nameof(Subscription)),
+            (ResourceGroup, nameof(ResourceGroup)),
+            (User, nameof(User)),
+            (Server, nameof(Server)),
+            (Database, nameof(Database)),
+            (Table, nameof(Table))
+        ]);
+    }
+}

--- a/src/Arguments/Postgres/Table/GetSchemaArguments.cs
+++ b/src/Arguments/Postgres/Table/GetSchemaArguments.cs
@@ -1,22 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+using AzureMcp.Models.Argument;
+
 namespace AzureMcp.Arguments.Postgres.Table;
 
 public class GetSchemaArguments : BasePostgresArguments
 {
+    [JsonPropertyName(ArgumentDefinitions.Postgres.TableName)]
     public string? Table { get; set; }
-
-    public void Validate()
-    {
-        ValidateProperties(
-        [
-            (Subscription, nameof(Subscription)),
-            (ResourceGroup, nameof(ResourceGroup)),
-            (User, nameof(User)),
-            (Server, nameof(Server)),
-            (Database, nameof(Database)),
-            (Table, nameof(Table))
-        ]);
-    }
 }

--- a/src/Arguments/Postgres/Table/TableListArguments.cs
+++ b/src/Arguments/Postgres/Table/TableListArguments.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Arguments.Postgres.Table;
+
+public class TableListArguments : BasePostgresArguments
+{
+    public void Validate()
+    {
+        ValidateProperties(new[]
+        {
+            (Subscription, nameof(Subscription)),
+            (ResourceGroup, nameof(ResourceGroup)),
+            (User, nameof(User)),
+            (Server, nameof(Server)),
+            (Database, nameof(Database))
+        });
+    }
+}

--- a/src/Arguments/Postgres/Table/TableListArguments.cs
+++ b/src/Arguments/Postgres/Table/TableListArguments.cs
@@ -3,17 +3,4 @@
 
 namespace AzureMcp.Arguments.Postgres.Table;
 
-public class TableListArguments : BasePostgresArguments
-{
-    public void Validate()
-    {
-        ValidateProperties(new[]
-        {
-            (Subscription, nameof(Subscription)),
-            (ResourceGroup, nameof(ResourceGroup)),
-            (User, nameof(User)),
-            (Server, nameof(Server)),
-            (Database, nameof(Database))
-        });
-    }
-}
+public class TableListArguments : BasePostgresArguments;

--- a/src/AzureMcp.csproj
+++ b/src/AzureMcp.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Azure.Identity.Broker" />
     <PackageReference Include="Azure.Monitor.Query" />
     <PackageReference Include="Azure.ResourceManager.AppConfiguration" />
+    <PackageReference Include="Azure.ResourceManager.PostgreSql" Version="1.2.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.ResourceManager.CosmosDB" />
@@ -62,6 +63,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="System.Linq.AsyncEnumerable" />

--- a/src/AzureMcp.csproj
+++ b/src/AzureMcp.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Azure.Identity.Broker" />
     <PackageReference Include="Azure.Monitor.Query" />
     <PackageReference Include="Azure.ResourceManager.AppConfiguration" />
-    <PackageReference Include="Azure.ResourceManager.PostgreSql" Version="1.2.0" />
+    <PackageReference Include="Azure.ResourceManager.PostgreSql" />    
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.ResourceManager.CosmosDB" />
@@ -63,7 +63,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="Npgsql" />    
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="System.Linq.AsyncEnumerable" />
@@ -79,16 +79,12 @@
     <Message Text="Installing Git hooks..." Importance="high" />
 
     <!-- Run the Install-GitHooks.ps1 script using PowerShell Core -->
-    <Exec Command="pwsh -ExecutionPolicy Bypass -NoProfile -File &quot;$(MSBuildProjectDirectory)/../eng/scripts/Install-GitHooks.ps1&quot;"
-          ContinueOnError="true"
-          ConsoleToMsBuild="true"
-          IgnoreExitCode="true">
-      <Output TaskParameter="ExitCode" PropertyName="ExitCode"/>
+    <Exec Command="pwsh -ExecutionPolicy Bypass -NoProfile -File &quot;$(MSBuildProjectDirectory)/../eng/scripts/Install-GitHooks.ps1&quot;" ContinueOnError="true" ConsoleToMsBuild="true" IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
 
     <!-- Display informative message if pwsh fails -->
-    <Warning Text="Could not install Git hooks. PowerShell Core (pwsh) is required to install Git hooks:\nhttps://learn.microsoft.com/powershell/scripting/install/installing-powershell"
-             Condition="'$(ExitCode)' != '0'" />
+    <Warning Text="Could not install Git hooks. PowerShell Core (pwsh) is required to install Git hooks:\nhttps://learn.microsoft.com/powershell/scripting/install/installing-powershell" Condition="'$(ExitCode)' != '0'" />
   </Target>
 
   <!-- Remove Cosmos native files from the build output directory -->

--- a/src/Commands/CommandFactory.cs
+++ b/src/Commands/CommandFactory.cs
@@ -114,7 +114,7 @@ public class CommandFactory
 
     private void RegisterPostgresCommands()
     {
-        var pg = new CommandGroup("pg", "PostgreSQL operations - Commands for listing and managing Azure Database for PostgreSQL - Flexible server.");
+        var pg = new CommandGroup("postgres", "PostgreSQL operations - Commands for listing and managing Azure Database for PostgreSQL - Flexible server.");
         _rootGroup.AddSubGroup(pg);
 
         var database = new CommandGroup("database", "PostgreSQL database operations");
@@ -125,13 +125,13 @@ public class CommandFactory
         var table = new CommandGroup("table", "PostgreSQL table operations");
         pg.AddSubGroup(table);
         table.AddCommand("list", new Postgres.Table.TableListCommand(GetLogger<Postgres.Table.TableListCommand>()));
-        table.AddCommand("get-schema", new Postgres.Table.GetSchemaCommand(GetLogger<Postgres.Table.GetSchemaCommand>()));
+        table.AddCommand("schema", new Postgres.Table.GetSchemaCommand(GetLogger<Postgres.Table.GetSchemaCommand>()));
 
         var server = new CommandGroup("server", "PostgreSQL server operations");
         pg.AddSubGroup(server);
         server.AddCommand("list", new Postgres.Server.ServerListCommand(GetLogger<Postgres.Server.ServerListCommand>()));
-        server.AddCommand("get-config", new Postgres.Server.GetConfigCommand(GetLogger<Postgres.Server.GetConfigCommand>()));
-        server.AddCommand("get-param", new Postgres.Server.GetParamCommand(GetLogger<Postgres.Server.GetParamCommand>()));
+        server.AddCommand("config", new Postgres.Server.GetConfigCommand(GetLogger<Postgres.Server.GetConfigCommand>()));
+        server.AddCommand("param", new Postgres.Server.GetParamCommand(GetLogger<Postgres.Server.GetParamCommand>()));
     }
 
     private void RegisterStorageCommands()

--- a/src/Commands/CommandFactory.cs
+++ b/src/Commands/CommandFactory.cs
@@ -77,6 +77,7 @@ public class CommandFactory
         RegisterMonitorCommands();
         RegisterAppConfigCommands();
         RegisterSearchCommands();
+        RegisterPostgresCommands();
         RegisterToolsCommands();
         RegisterExtensionCommands();
         RegisterSubscriptionCommands();
@@ -109,6 +110,28 @@ public class CommandFactory
         cosmosContainer.AddCommand("list", new Cosmos.ContainerListCommand(GetLogger<Cosmos.ContainerListCommand>()));
         cosmosAccount.AddCommand("list", new Cosmos.AccountListCommand(GetLogger<Cosmos.AccountListCommand>()));
         cosmosItem.AddCommand("query", new ItemQueryCommand(GetLogger<ItemQueryCommand>()));
+    }
+
+    private void RegisterPostgresCommands()
+    {
+        var pg = new CommandGroup("pg", "PostgreSQL operations - Commands for listing and managing Azure Database for PostgreSQL - Flexible server.");
+        _rootGroup.AddSubGroup(pg);
+
+        var database = new CommandGroup("database", "PostgreSQL database operations");
+        pg.AddSubGroup(database);
+        database.AddCommand("list", new Postgres.Database.DatabaseListCommand(GetLogger<Postgres.Database.DatabaseListCommand>()));
+        database.AddCommand("query", new Postgres.Database.DatabaseQueryCommand(GetLogger<Postgres.Database.DatabaseQueryCommand>()));
+
+        var table = new CommandGroup("table", "PostgreSQL table operations");
+        pg.AddSubGroup(table);
+        table.AddCommand("list", new Postgres.Table.TableListCommand(GetLogger<Postgres.Table.TableListCommand>()));
+        table.AddCommand("get-schema", new Postgres.Table.GetSchemaCommand(GetLogger<Postgres.Table.GetSchemaCommand>()));
+
+        var server = new CommandGroup("server", "PostgreSQL server operations");
+        pg.AddSubGroup(server);
+        server.AddCommand("list", new Postgres.Server.ServerListCommand(GetLogger<Postgres.Server.ServerListCommand>()));
+        server.AddCommand("get-config", new Postgres.Server.GetConfigCommand(GetLogger<Postgres.Server.GetConfigCommand>()));
+        server.AddCommand("get-param", new Postgres.Server.GetParamCommand(GetLogger<Postgres.Server.GetParamCommand>()));
     }
 
     private void RegisterStorageCommands()

--- a/src/Commands/Postgres/BaseDatabaseCommand.cs
+++ b/src/Commands/Postgres/BaseDatabaseCommand.cs
@@ -1,0 +1,45 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
+using AzureMcp.Arguments.Postgres;
+using AzureMcp.Models.Argument;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Commands.Postgres;
+
+public abstract class BaseDatabaseCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs>(ILogger<BasePostgresCommand<TArgs>> logger)
+    : BaseServerCommand<TArgs>(logger) where TArgs : BasePostgresArguments, new()
+{
+    private readonly Option<string> _databaseOption = ArgumentDefinitions.Postgres.Database.ToOption();
+
+    protected override string GetCommandName() => "database";
+
+    protected override string GetCommandDescription() =>
+        "Retrieves information about a PostgreSQL database.";
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_databaseOption);
+    }
+
+    protected override void RegisterArguments()
+    {
+        base.RegisterArguments();
+        AddArgument(CreateDatabaseArgument());
+    }
+
+    protected override TArgs BindArguments(ParseResult parseResult)
+    {
+        var args = base.BindArguments(parseResult);
+        args.Database = parseResult.GetValueForOption(_databaseOption);
+        return args;
+    }
+
+    protected ArgumentBuilder<TArgs> CreateDatabaseArgument() =>
+        ArgumentBuilder<TArgs>
+            .Create(ArgumentDefinitions.Postgres.Database.Name, ArgumentDefinitions.Postgres.Database.Description)
+            .WithValueAccessor(args => args.Database ?? string.Empty)
+            .WithIsRequired(ArgumentDefinitions.Postgres.Database.Required);
+}

--- a/src/Commands/Postgres/BasePostgresCommand.cs
+++ b/src/Commands/Postgres/BasePostgresCommand.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Arguments.Postgres;
+using AzureMcp.Models.Argument;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Commands.Postgres;
+
+public abstract class BasePostgresCommand<TArgs> : SubscriptionCommand<TArgs> where TArgs : BasePostgresArguments, new()
+{
+    protected readonly Option<string> _userOption = ArgumentDefinitions.Postgres.User.ToOption();
+    protected readonly Option<string> _serverOption = ArgumentDefinitions.Postgres.Server.ToOption();
+    protected readonly Option<string> _databaseOption = ArgumentDefinitions.Postgres.Database.ToOption();
+
+    protected readonly ILogger<BasePostgresCommand<TArgs>> _logger;
+
+    protected BasePostgresCommand(ILogger<BasePostgresCommand<TArgs>> logger)
+    {
+        _logger = logger;
+    }
+
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_resourceGroupOption);
+        command.AddOption(_userOption);
+        command.AddOption(_serverOption);
+        command.AddOption(_databaseOption);
+    }
+
+    protected override void RegisterArguments()
+    {
+        base.RegisterArguments();
+        AddArgument(CreateUserArgument());
+        AddArgument(CreateServerArgument());
+        AddArgument(CreateDatabaseArgument());
+    }
+    protected override TArgs BindArguments(ParseResult parseResult)
+    {
+        var args = base.BindArguments(parseResult);
+        args.ResourceGroup = parseResult.GetValueForOption(_resourceGroupOption);
+        args.User = parseResult.GetValueForOption(_userOption);
+        args.Server = parseResult.GetValueForOption(_serverOption);
+        args.Database = parseResult.GetValueForOption(_databaseOption);
+        return args;
+    }
+
+    // Helper methods for creating Postgres-specific arguments
+
+    // Over ride the need to have subscription and resource group as mandatory 
+    // parameters. PostgreSQL database can be accessed directly using Npgsql 
+    // by using host, user, database and password.
+    protected new ArgumentBuilder<TArgs> CreateSubscriptionArgument() =>
+        ArgumentBuilder<TArgs>
+            .Create(ArgumentDefinitions.Common.Subscription.Name, ArgumentDefinitions.Common.Subscription.Description)
+            .WithValueAccessor(args => args.Subscription ?? string.Empty)
+            .WithIsRequired(false);
+    protected new ArgumentBuilder<TArgs> CreateResourceGroupArgument() =>
+        ArgumentBuilder<TArgs>
+            .Create(ArgumentDefinitions.Common.ResourceGroup.Name, ArgumentDefinitions.Common.ResourceGroup.Description)
+            .WithValueAccessor(args => args.ResourceGroup ?? string.Empty)
+            .WithIsRequired(false);
+
+    protected ArgumentBuilder<TArgs> CreateUserArgument() =>
+        ArgumentBuilder<TArgs>
+            .Create(ArgumentDefinitions.Postgres.User.Name, ArgumentDefinitions.Postgres.User.Description)
+            .WithValueAccessor(args => args.User ?? string.Empty)
+            .WithIsRequired(ArgumentDefinitions.Postgres.User.Required);
+
+    protected ArgumentBuilder<TArgs> CreateServerArgument() =>
+        ArgumentBuilder<TArgs>
+            .Create(ArgumentDefinitions.Postgres.Server.Name, ArgumentDefinitions.Postgres.Server.Description)
+            .WithValueAccessor(args => args.Server ?? string.Empty)
+            .WithIsRequired(ArgumentDefinitions.Postgres.Server.Required);
+
+    protected ArgumentBuilder<TArgs> CreateDatabaseArgument() =>
+        ArgumentBuilder<TArgs>
+            .Create(ArgumentDefinitions.Postgres.Database.Name, ArgumentDefinitions.Postgres.Database.Description)
+            .WithValueAccessor(args => args.Database ?? string.Empty)
+            .WithIsRequired(ArgumentDefinitions.Postgres.Database.Required);
+
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        _ => base.GetErrorMessage(ex)
+    };
+
+    protected override int GetStatusCode(Exception ex) => ex switch
+    {
+        _ => base.GetStatusCode(ex)
+    };
+}

--- a/src/Commands/Postgres/BasePostgresCommand.cs
+++ b/src/Commands/Postgres/BasePostgresCommand.cs
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureMcp.Arguments.Postgres;
-using AzureMcp.Models.Argument;
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
+using AzureMcp.Arguments.Postgres;
+using AzureMcp.Models.Argument;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.Commands.Postgres;
 
-public abstract class BasePostgresCommand<TArgs> : SubscriptionCommand<TArgs> where TArgs : BasePostgresArguments, new()
+public abstract class BasePostgresCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs>
+    : SubscriptionCommand<TArgs> where TArgs : BasePostgresArguments, new()
 {
     protected readonly Option<string> _userOption = ArgumentDefinitions.Postgres.User.ToOption();
-    protected readonly Option<string> _serverOption = ArgumentDefinitions.Postgres.Server.ToOption();
-    protected readonly Option<string> _databaseOption = ArgumentDefinitions.Postgres.Database.ToOption();
 
     protected readonly ILogger<BasePostgresCommand<TArgs>> _logger;
 
@@ -28,68 +29,26 @@ public abstract class BasePostgresCommand<TArgs> : SubscriptionCommand<TArgs> wh
         base.RegisterOptions(command);
         command.AddOption(_resourceGroupOption);
         command.AddOption(_userOption);
-        command.AddOption(_serverOption);
-        command.AddOption(_databaseOption);
     }
 
     protected override void RegisterArguments()
     {
         base.RegisterArguments();
+        AddArgument(CreateResourceGroupArgument());
         AddArgument(CreateUserArgument());
-        AddArgument(CreateServerArgument());
-        AddArgument(CreateDatabaseArgument());
     }
+
     protected override TArgs BindArguments(ParseResult parseResult)
     {
         var args = base.BindArguments(parseResult);
         args.ResourceGroup = parseResult.GetValueForOption(_resourceGroupOption);
         args.User = parseResult.GetValueForOption(_userOption);
-        args.Server = parseResult.GetValueForOption(_serverOption);
-        args.Database = parseResult.GetValueForOption(_databaseOption);
         return args;
     }
-
-    // Helper methods for creating Postgres-specific arguments
-
-    // Over ride the need to have subscription and resource group as mandatory 
-    // parameters. PostgreSQL database can be accessed directly using Npgsql 
-    // by using host, user, database and password.
-    protected new ArgumentBuilder<TArgs> CreateSubscriptionArgument() =>
-        ArgumentBuilder<TArgs>
-            .Create(ArgumentDefinitions.Common.Subscription.Name, ArgumentDefinitions.Common.Subscription.Description)
-            .WithValueAccessor(args => args.Subscription ?? string.Empty)
-            .WithIsRequired(false);
-    protected new ArgumentBuilder<TArgs> CreateResourceGroupArgument() =>
-        ArgumentBuilder<TArgs>
-            .Create(ArgumentDefinitions.Common.ResourceGroup.Name, ArgumentDefinitions.Common.ResourceGroup.Description)
-            .WithValueAccessor(args => args.ResourceGroup ?? string.Empty)
-            .WithIsRequired(false);
 
     protected ArgumentBuilder<TArgs> CreateUserArgument() =>
         ArgumentBuilder<TArgs>
             .Create(ArgumentDefinitions.Postgres.User.Name, ArgumentDefinitions.Postgres.User.Description)
             .WithValueAccessor(args => args.User ?? string.Empty)
             .WithIsRequired(ArgumentDefinitions.Postgres.User.Required);
-
-    protected ArgumentBuilder<TArgs> CreateServerArgument() =>
-        ArgumentBuilder<TArgs>
-            .Create(ArgumentDefinitions.Postgres.Server.Name, ArgumentDefinitions.Postgres.Server.Description)
-            .WithValueAccessor(args => args.Server ?? string.Empty)
-            .WithIsRequired(ArgumentDefinitions.Postgres.Server.Required);
-
-    protected ArgumentBuilder<TArgs> CreateDatabaseArgument() =>
-        ArgumentBuilder<TArgs>
-            .Create(ArgumentDefinitions.Postgres.Database.Name, ArgumentDefinitions.Postgres.Database.Description)
-            .WithValueAccessor(args => args.Database ?? string.Empty)
-            .WithIsRequired(ArgumentDefinitions.Postgres.Database.Required);
-
-    protected override string GetErrorMessage(Exception ex) => ex switch
-    {
-        _ => base.GetErrorMessage(ex)
-    };
-
-    protected override int GetStatusCode(Exception ex) => ex switch
-    {
-        _ => base.GetStatusCode(ex)
-    };
 }

--- a/src/Commands/Postgres/BaseServerCommand.cs
+++ b/src/Commands/Postgres/BaseServerCommand.cs
@@ -1,0 +1,46 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
+using AzureMcp.Arguments.Postgres;
+using AzureMcp.Models.Argument;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Commands.Postgres;
+
+public abstract class BaseServerCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TArgs>(ILogger<BasePostgresCommand<TArgs>> logger)
+    : BasePostgresCommand<TArgs>(logger) where TArgs : BasePostgresArguments, new()
+
+{
+    private readonly Option<string> _serverOption = ArgumentDefinitions.Postgres.Server.ToOption();
+
+    protected override string GetCommandName() => "server";
+
+    protected override string GetCommandDescription() =>
+        "Retrieves information about a PostgreSQL server.";
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_serverOption);
+    }
+
+    protected override void RegisterArguments()
+    {
+        base.RegisterArguments();
+        AddArgument(CreateServerArgument());
+    }
+
+    protected override TArgs BindArguments(ParseResult parseResult)
+    {
+        var args = base.BindArguments(parseResult);
+        args.Server = parseResult.GetValueForOption(_serverOption);
+        return args;
+    }
+
+    protected ArgumentBuilder<TArgs> CreateServerArgument() =>
+        ArgumentBuilder<TArgs>
+            .Create(ArgumentDefinitions.Postgres.Server.Name, ArgumentDefinitions.Postgres.Server.Description)
+            .WithValueAccessor(args => args.Server ?? string.Empty)
+            .WithIsRequired(ArgumentDefinitions.Postgres.Server.Required);
+}

--- a/src/Commands/Postgres/Database/DatabaseListCommand.cs
+++ b/src/Commands/Postgres/Database/DatabaseListCommand.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using AzureMcp.Arguments.Postgres.Database;
+using Microsoft.Extensions.Logging;
+using AzureMcp.Models.Command;
+using ModelContextProtocol.Server;
+using AzureMcp.Services.Interfaces;
+
+namespace AzureMcp.Commands.Postgres.Database;
+
+public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : BasePostgresCommand<DatabaseListArguments>(logger)
+{
+
+    protected override string GetCommandName() => "list";
+
+    protected override string GetCommandDescription() => "Lists all databases in the PostgreSQL server.";
+
+    [McpServerTool(Destructive = false, ReadOnly = true)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        try
+        {
+            var args = BindArguments(parseResult);
+            args.Validate();
+
+            if (!await ProcessArguments(context, args))
+            {
+                return context.Response;
+            }
+
+            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            var databases = await pgService.ListDatabasesAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!);
+            if (databases == null || databases.Count == 0)
+            {
+                context.Response.Results = null;
+                return context.Response;
+            }
+            context.Response.Results = databases;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred listing databases.");
+            HandleException(context.Response, ex);
+        }
+        return context.Response;
+    }
+}

--- a/src/Commands/Postgres/Database/DatabaseQueryCommand.cs
+++ b/src/Commands/Postgres/Database/DatabaseQueryCommand.cs
@@ -12,7 +12,7 @@ using ModelContextProtocol.Server;
 
 namespace AzureMcp.Commands.Postgres.Database;
 
-public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) : BasePostgresCommand<DatabaseQueryArguments>(logger)
+public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) : BaseDatabaseCommand<DatabaseQueryArguments>(logger)
 {
     private readonly Option<string> _queryOption = ArgumentDefinitions.Postgres.Query.ToOption();
     protected override string GetCommandName() => "query";
@@ -45,16 +45,18 @@ public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) :
         try
         {
             var args = BindArguments(parseResult);
-            args.Validate();
-
             if (!await ProcessArguments(context, args))
             {
                 return context.Response;
             }
 
-            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            var result = await pgService.ExecuteQueryAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!, args.Query!);
-            context.Response.Results = new { QueryResult = result };
+            IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            List<string> queryResult = await pgService.ExecuteQueryAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!, args.Query!);
+            context.Response.Results = queryResult?.Count > 0 ?
+                ResponseResult.Create(
+                    new DatabaseQueryCommandResult(queryResult),
+                    PostgresJsonContext.Default.DatabaseQueryCommandResult) :
+                null;
         }
         catch (Exception ex)
         {
@@ -70,4 +72,6 @@ public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) :
             .Create(ArgumentDefinitions.Postgres.Query.Name, ArgumentDefinitions.Postgres.Query.Description)
             .WithValueAccessor(args => args.Query ?? string.Empty)
             .WithIsRequired(true);
+
+    internal record DatabaseQueryCommandResult(List<string> QueryResult);
 }

--- a/src/Commands/Postgres/Database/DatabaseQueryCommand.cs
+++ b/src/Commands/Postgres/Database/DatabaseQueryCommand.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using AzureMcp.Arguments.Postgres.Database;
+using AzureMcp.Models.Argument;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace AzureMcp.Commands.Postgres.Database;
+
+public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) : BasePostgresCommand<DatabaseQueryArguments>(logger)
+{
+    private readonly Option<string> _queryOption = ArgumentDefinitions.Postgres.Query.ToOption();
+    protected override string GetCommandName() => "query";
+
+    protected override string GetCommandDescription() => "Executes a query on the PostgreSQL database.";
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_queryOption);
+    }
+
+    protected override void RegisterArguments()
+    {
+        base.RegisterArguments();
+        AddArgument(CreateQueryArgument());
+    }
+
+    protected override DatabaseQueryArguments BindArguments(ParseResult parseResult)
+    {
+        var args = base.BindArguments(parseResult);
+        args.Query = parseResult.GetValueForOption(_queryOption);
+        return args;
+    }
+
+
+    [McpServerTool(Destructive = false, ReadOnly = true)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        try
+        {
+            var args = BindArguments(parseResult);
+            args.Validate();
+
+            if (!await ProcessArguments(context, args))
+            {
+                return context.Response;
+            }
+
+            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            var result = await pgService.ExecuteQueryAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!, args.Query!);
+            context.Response.Results = new { QueryResult = result };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred while executing the query.");
+            HandleException(context.Response, ex);
+        }
+
+        return context.Response;
+    }
+
+    private static ArgumentBuilder<DatabaseQueryArguments> CreateQueryArgument() =>
+        ArgumentBuilder<DatabaseQueryArguments>
+            .Create(ArgumentDefinitions.Postgres.Query.Name, ArgumentDefinitions.Postgres.Query.Description)
+            .WithValueAccessor(args => args.Query ?? string.Empty)
+            .WithIsRequired(true);
+}

--- a/src/Commands/Postgres/PostgresJsonContext.cs
+++ b/src/Commands/Postgres/PostgresJsonContext.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+using AzureMcp.Commands.Postgres.Database;
+using AzureMcp.Commands.Postgres.Server;
+using AzureMcp.Commands.Postgres.Table;
+
+namespace AzureMcp.Commands.Postgres;
+
+[JsonSerializable(typeof(DatabaseListCommand.DatabaseListCommandResult))]
+[JsonSerializable(typeof(DatabaseQueryCommand.DatabaseQueryCommandResult))]
+[JsonSerializable(typeof(GetConfigCommand.GetConfigCommandResult))]
+[JsonSerializable(typeof(GetParamCommand.GetParamCommandResult))]
+[JsonSerializable(typeof(ServerListCommand.ServerListCommandResult))]
+[JsonSerializable(typeof(GetSchemaCommand.GetSchemaCommandResult))]
+[JsonSerializable(typeof(TableListCommand.TableListCommandResult))]
+
+internal sealed partial class PostgresJsonContext : JsonSerializerContext
+{
+}

--- a/src/Commands/Postgres/Server/GetConfigCommand.cs
+++ b/src/Commands/Postgres/Server/GetConfigCommand.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using AzureMcp.Arguments.Postgres.Server;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace AzureMcp.Commands.Postgres.Server;
+
+public sealed class GetConfigCommand(ILogger<GetConfigCommand> logger) : BasePostgresCommand<GetConfigArguments>(logger)
+{
+    protected override string GetCommandName() => "get-config";
+    protected override string GetCommandDescription() =>
+        "Retrieve the configuration of a PostgreSQL server.";
+
+    [McpServerTool(Destructive = false, ReadOnly = true)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        try
+        {
+            var args = BindArguments(parseResult);
+            args.Validate();
+
+            if (!await ProcessArguments(context, args))
+            {
+                return context.Response;
+            }
+
+            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            var config = await pgService.GetServerConfigAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!);
+            if (config == null || config.Length == 0)
+            {
+                context.Response.Results = null;
+                return context.Response;
+            }
+            context.Response.Results = config;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred retrieving server configuration.");
+            HandleException(context.Response, ex);
+        }
+        return context.Response;
+    }
+}

--- a/src/Commands/Postgres/Server/GetParamCommand.cs
+++ b/src/Commands/Postgres/Server/GetParamCommand.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using AzureMcp.Arguments.Postgres.Server;
+using AzureMcp.Models.Argument;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace AzureMcp.Commands.Postgres.Server;
+
+public sealed class GetParamCommand(ILogger<GetParamCommand> logger) : BasePostgresCommand<GetParamArguments>(logger)
+{
+    private readonly Option<string> _paramOption = ArgumentDefinitions.Postgres.Param.ToOption();
+    protected override string GetCommandName() => "get-param";
+
+    protected override string GetCommandDescription() =>
+        "Retrieves a specific parameter of a PostgreSQL server.";
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_paramOption);
+    }
+
+    protected override void RegisterArguments()
+    {
+        base.RegisterArguments();
+        AddArgument(CreateParamArgument());
+    }
+
+    protected override GetParamArguments BindArguments(ParseResult parseResult)
+    {
+        var args = base.BindArguments(parseResult);
+        args.Param = parseResult.GetValueForOption(_paramOption);
+        return args;
+    }
+
+
+    [McpServerTool(Destructive = false, ReadOnly = true)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        try
+        {
+            var args = BindArguments(parseResult);
+            args.Validate();
+
+            if (!await ProcessArguments(context, args))
+            {
+                return context.Response;
+            }
+
+            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            var parameterValue = await pgService.GetServerParameterAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Param!);
+            if (string.IsNullOrEmpty(parameterValue))
+            {
+                context.Response.Results = null;
+                return context.Response;
+            }
+
+            context.Response.Results = parameterValue;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred retrieving the parameter.");
+            HandleException(context.Response, ex);
+        }
+        return context.Response;
+    }
+
+    private static ArgumentBuilder<GetParamArguments> CreateParamArgument() =>
+        ArgumentBuilder<GetParamArguments>
+            .Create(ArgumentDefinitions.Postgres.Param.Name, ArgumentDefinitions.Postgres.Param.Description)
+            .WithValueAccessor(args => args.Param ?? string.Empty)
+            .WithIsRequired(true);
+}

--- a/src/Commands/Postgres/Server/ServerListCommand.cs
+++ b/src/Commands/Postgres/Server/ServerListCommand.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using AzureMcp.Arguments.Postgres.Server;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace AzureMcp.Commands.Postgres.Server;
+
+public sealed class ServerListCommand(ILogger<ServerListCommand> logger) : BasePostgresCommand<ServerListArguments>(logger)
+{
+    protected override string GetCommandName() => "list";
+
+    protected override string GetCommandDescription() =>
+        "Lists all PostgreSQL servers in the specified subscription.";
+
+    [McpServerTool(Destructive = false, ReadOnly = true)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        try
+        {
+            var args = BindArguments(parseResult);
+            args.Validate();
+
+            if (!await ProcessArguments(context, args))
+            {
+                return context.Response;
+            }
+
+            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            var servers = await pgService.ListServersAsync(args.Subscription!, args.ResourceGroup!, args.User!);
+            if (servers == null || servers.Count == 0)
+            {
+                context.Response.Results = null;
+                return context.Response;
+            }
+            context.Response.Results = servers;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred while listing servers");
+            HandleException(context.Response, ex);
+        }
+
+        return context.Response;
+    }
+}

--- a/src/Commands/Postgres/Server/ServerListCommand.cs
+++ b/src/Commands/Postgres/Server/ServerListCommand.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System.CommandLine.Parsing;
+using Azure.ResourceManager.Resources.Models;
 using AzureMcp.Arguments.Postgres.Server;
+using AzureMcp.Models.Argument;
 using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -23,21 +25,18 @@ public sealed class ServerListCommand(ILogger<ServerListCommand> logger) : BaseP
         try
         {
             var args = BindArguments(parseResult);
-            args.Validate();
-
             if (!await ProcessArguments(context, args))
             {
                 return context.Response;
             }
 
-            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            var servers = await pgService.ListServersAsync(args.Subscription!, args.ResourceGroup!, args.User!);
-            if (servers == null || servers.Count == 0)
-            {
-                context.Response.Results = null;
-                return context.Response;
-            }
-            context.Response.Results = servers;
+            IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            List<string> servers = await pgService.ListServersAsync(args.Subscription!, args.ResourceGroup!, args.User!);
+            context.Response.Results = servers?.Count > 0 ?
+                ResponseResult.Create(
+                    new ServerListCommandResult(servers),
+                    PostgresJsonContext.Default.ServerListCommandResult) :
+                null;
         }
         catch (Exception ex)
         {
@@ -47,4 +46,6 @@ public sealed class ServerListCommand(ILogger<ServerListCommand> logger) : BaseP
 
         return context.Response;
     }
+
+    internal record ServerListCommandResult(List<string> Servers);
 }

--- a/src/Commands/Postgres/Table/GetSchemaCommand.cs
+++ b/src/Commands/Postgres/Table/GetSchemaCommand.cs
@@ -12,10 +12,10 @@ using ModelContextProtocol.Server;
 
 namespace AzureMcp.Commands.Postgres.Table;
 
-public sealed class GetSchemaCommand(ILogger<GetSchemaCommand> logger) : BasePostgresCommand<GetSchemaArguments>(logger)
+public sealed class GetSchemaCommand(ILogger<GetSchemaCommand> logger) : BaseDatabaseCommand<GetSchemaArguments>(logger)
 {
     private readonly Option<string> _tableOption = ArgumentDefinitions.Postgres.Table.ToOption();
-    protected override string GetCommandName() => "get-schema";
+    protected override string GetCommandName() => "schema";
 
     protected override string GetCommandDescription() =>
         "Retrieves the schema of a specified table in a PostgreSQL database.";
@@ -39,29 +39,25 @@ public sealed class GetSchemaCommand(ILogger<GetSchemaCommand> logger) : BasePos
         return args;
     }
 
-
     [McpServerTool(Destructive = false, ReadOnly = true)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try
         {
             var args = BindArguments(parseResult);
-            args.Validate();
 
             if (!await ProcessArguments(context, args))
             {
                 return context.Response;
             }
 
-            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            var schema = await pgService.GetTableSchemaAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!, args.Table!);
-            if (schema == null || schema.Count == 0)
-            {
-                context.Response.Results = null;
-                return context.Response;
-            }
-
-            context.Response.Results = schema;
+            IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            List<string> schema = await pgService.GetTableSchemaAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!, args.Table!);
+            context.Response.Results = schema?.Count > 0 ?
+                ResponseResult.Create(
+                    new GetSchemaCommandResult(schema),
+                    PostgresJsonContext.Default.GetSchemaCommandResult) :
+                null;
         }
         catch (Exception ex)
         {
@@ -77,4 +73,6 @@ public sealed class GetSchemaCommand(ILogger<GetSchemaCommand> logger) : BasePos
             .Create(ArgumentDefinitions.Postgres.Table.Name, ArgumentDefinitions.Postgres.Table.Description)
             .WithValueAccessor(args => args.Table ?? string.Empty)
             .WithIsRequired(true);
+
+    internal record GetSchemaCommandResult(List<string> Schema);
 }

--- a/src/Commands/Postgres/Table/GetSchemaCommand.cs
+++ b/src/Commands/Postgres/Table/GetSchemaCommand.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using AzureMcp.Arguments.Postgres.Table;
+using AzureMcp.Models.Argument;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace AzureMcp.Commands.Postgres.Table;
+
+public sealed class GetSchemaCommand(ILogger<GetSchemaCommand> logger) : BasePostgresCommand<GetSchemaArguments>(logger)
+{
+    private readonly Option<string> _tableOption = ArgumentDefinitions.Postgres.Table.ToOption();
+    protected override string GetCommandName() => "get-schema";
+
+    protected override string GetCommandDescription() =>
+        "Retrieves the schema of a specified table in a PostgreSQL database.";
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_tableOption);
+    }
+
+    protected override void RegisterArguments()
+    {
+        base.RegisterArguments();
+        AddArgument(CreateTableArgument());
+    }
+
+    protected override GetSchemaArguments BindArguments(ParseResult parseResult)
+    {
+        var args = base.BindArguments(parseResult);
+        args.Table = parseResult.GetValueForOption(_tableOption);
+        return args;
+    }
+
+
+    [McpServerTool(Destructive = false, ReadOnly = true)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        try
+        {
+            var args = BindArguments(parseResult);
+            args.Validate();
+
+            if (!await ProcessArguments(context, args))
+            {
+                return context.Response;
+            }
+
+            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            var schema = await pgService.GetTableSchemaAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!, args.Table!);
+            if (schema == null || schema.Count == 0)
+            {
+                context.Response.Results = null;
+                return context.Response;
+            }
+
+            context.Response.Results = schema;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred retrieving the schema for table");
+            HandleException(context.Response, ex);
+        }
+
+        return context.Response;
+    }
+
+    private static ArgumentBuilder<GetSchemaArguments> CreateTableArgument() =>
+        ArgumentBuilder<GetSchemaArguments>
+            .Create(ArgumentDefinitions.Postgres.Table.Name, ArgumentDefinitions.Postgres.Table.Description)
+            .WithValueAccessor(args => args.Table ?? string.Empty)
+            .WithIsRequired(true);
+}

--- a/src/Commands/Postgres/Table/TableListCommand.cs
+++ b/src/Commands/Postgres/Table/TableListCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine.Parsing;
 using AzureMcp.Arguments.Postgres.Table;
+using AzureMcp.Models.Argument;
 using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -11,7 +12,7 @@ using ModelContextProtocol.Server;
 
 namespace AzureMcp.Commands.Postgres.Table;
 
-public sealed class TableListCommand(ILogger<TableListCommand> logger) : BasePostgresCommand<TableListArguments>(logger)
+public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseDatabaseCommand<TableListArguments>(logger)
 {
     protected override string GetCommandName() => "list";
     protected override string GetCommandDescription() => "Lists all tables in the PostgreSQL database.";
@@ -22,21 +23,18 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BasePos
         try
         {
             var args = BindArguments(parseResult);
-            args.Validate();
-
             if (!await ProcessArguments(context, args))
             {
                 return context.Response;
             }
 
-            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
-            var tables = await pgService.ListTablesAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!);
-            if (tables == null || tables.Count == 0)
-            {
-                context.Response.Results = null;
-                return context.Response;
-            }
-            context.Response.Results = tables;
+            IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            List<string> tables = await pgService.ListTablesAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!);
+            context.Response.Results = tables?.Count > 0 ?
+                ResponseResult.Create(
+                    new TableListCommandResult(tables),
+                    PostgresJsonContext.Default.TableListCommandResult) :
+                null;
         }
         catch (Exception ex)
         {
@@ -45,4 +43,6 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BasePos
         }
         return context.Response;
     }
+
+    internal record TableListCommandResult(List<string> Tables);
 }

--- a/src/Commands/Postgres/Table/TableListCommand.cs
+++ b/src/Commands/Postgres/Table/TableListCommand.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using AzureMcp.Arguments.Postgres.Table;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+
+namespace AzureMcp.Commands.Postgres.Table;
+
+public sealed class TableListCommand(ILogger<TableListCommand> logger) : BasePostgresCommand<TableListArguments>(logger)
+{
+    protected override string GetCommandName() => "list";
+    protected override string GetCommandDescription() => "Lists all tables in the PostgreSQL database.";
+
+    [McpServerTool(Destructive = false, ReadOnly = true)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        try
+        {
+            var args = BindArguments(parseResult);
+            args.Validate();
+
+            if (!await ProcessArguments(context, args))
+            {
+                return context.Response;
+            }
+
+            var pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
+            var tables = await pgService.ListTablesAsync(args.Subscription!, args.ResourceGroup!, args.User!, args.Server!, args.Database!);
+            if (tables == null || tables.Count == 0)
+            {
+                context.Response.Results = null;
+                return context.Response;
+            }
+            context.Response.Results = tables;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An exception occurred listing tables.");
+            HandleException(context.Response, ex);
+        }
+        return context.Response;
+    }
+}

--- a/src/Models/Argument/ArgumentDefinitions.cs
+++ b/src/Models/Argument/ArgumentDefinitions.cs
@@ -150,8 +150,7 @@ public static class ArgumentDefinitions
 
     public static class Postgres
     {
-        public const string UserName = "user";
-        public const string Password = "password";
+        public const string UserName = "user-name";
         public const string ServerName = "server";
         public const string DatabaseName = "database";
         public const string TableName = "table";
@@ -164,41 +163,34 @@ public static class ArgumentDefinitions
             required: true
         );
 
-        public static readonly ArgumentDefinition<string> Pass = new(
-            Password,
-            "The password to access PostgreSQL server.",
-            required: true
-        );
-
         public static readonly ArgumentDefinition<string> Server = new(
             ServerName,
             "The PostgreSQL server to be accessed.",
-            required: false
+            required: true
         );
 
         public static readonly ArgumentDefinition<string> Database = new(
             DatabaseName,
             "The PostgreSQL database to be access.",
-            required: false,
-            defaultValue: "postgres"
+            required: true
         );
 
         public static readonly ArgumentDefinition<string> Table = new(
             TableName,
             "The PostgreSQL table to be access.",
-            required: false
+            required: true
         );
 
         public static readonly ArgumentDefinition<string> Query = new(
             QueryText,
             "Query to be executed against a PostgreSQL database.",
-            required: false
+            required: true
         );
 
         public static readonly ArgumentDefinition<string> Param = new(
             ParamName,
             "The PostgreSQL parameter to be accessed.",
-            required: false
+            required: true
         );
     }
 

--- a/src/Models/Argument/ArgumentDefinitions.cs
+++ b/src/Models/Argument/ArgumentDefinitions.cs
@@ -148,6 +148,60 @@ public static class ArgumentDefinitions
         );
     }
 
+    public static class Postgres
+    {
+        public const string UserName = "user";
+        public const string Password = "password";
+        public const string ServerName = "server";
+        public const string DatabaseName = "database";
+        public const string TableName = "table";
+        public const string QueryText = "query";
+        public const string ParamName = "param";
+
+        public static readonly ArgumentDefinition<string> User = new(
+            UserName,
+            "The user name to access PostgreSQL server.",
+            required: true
+        );
+
+        public static readonly ArgumentDefinition<string> Pass = new(
+            Password,
+            "The password to access PostgreSQL server.",
+            required: true
+        );
+
+        public static readonly ArgumentDefinition<string> Server = new(
+            ServerName,
+            "The PostgreSQL server to be accessed.",
+            required: false
+        );
+
+        public static readonly ArgumentDefinition<string> Database = new(
+            DatabaseName,
+            "The PostgreSQL database to be access.",
+            required: false,
+            defaultValue: "postgres"
+        );
+
+        public static readonly ArgumentDefinition<string> Table = new(
+            TableName,
+            "The PostgreSQL table to be access.",
+            required: false
+        );
+
+        public static readonly ArgumentDefinition<string> Query = new(
+            QueryText,
+            "Query to be executed against a PostgreSQL database.",
+            required: false
+        );
+
+        public static readonly ArgumentDefinition<string> Param = new(
+            ParamName,
+            "The PostgreSQL parameter to be accessed.",
+            required: false
+        );
+    }
+
     public static class Search
     {
         public const string ServiceName = "service-name";

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -10,6 +10,7 @@ using AzureMcp.Models.Command;
 using AzureMcp.Services.Azure.AppConfig;
 using AzureMcp.Services.Azure.Cosmos;
 using AzureMcp.Services.Azure.Monitor;
+using AzureMcp.Services.Azure.Postgres;
 using AzureMcp.Services.Azure.ResourceGroup;
 using AzureMcp.Services.Azure.Search;
 using AzureMcp.Services.Azure.Storage;
@@ -70,6 +71,7 @@ internal class Program
         services.AddSingleton<IResourceGroupService, ResourceGroupService>();
         services.AddSingleton<IAppConfigService, AppConfigService>();
         services.AddSingleton<ISearchService, SearchService>();
+        services.AddSingleton<IPostgresService, PostgresService>();
         services.AddSingleton<CommandFactory>();
     }
 }

--- a/src/Services/Azure/Postgres/PostgresService.cs
+++ b/src/Services/Azure/Postgres/PostgresService.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.PostgreSql.FlexibleServers;
+using Azure.ResourceManager.Resources;
+using AzureMcp.Services.Interfaces;
+using Npgsql;
+using System.Text.Json;
+
+namespace AzureMcp.Services.Azure.Postgres;
+
+public class PostgresService : IPostgresService
+{
+    private readonly ArmClient _armClient;
+    private readonly TokenCredential _tokenCredential;
+    private string? _cachedAccessToken;
+    private DateTime _tokenExpiryTime;
+
+    public PostgresService()
+    {
+        _tokenCredential = new DefaultAzureCredential();
+        _armClient = new ArmClient(_tokenCredential);
+    }
+
+    private async Task<string> GetAccessTokenAsync()
+    {
+        if (_cachedAccessToken != null && DateTime.UtcNow < _tokenExpiryTime)
+        {
+            return _cachedAccessToken;
+        }
+
+        var tokenRequestContext = new TokenRequestContext(new[] { "https://ossrdbms-aad.database.windows.net/.default" });
+        var accessToken = await _tokenCredential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
+
+        _cachedAccessToken = accessToken.Token;
+        _tokenExpiryTime = accessToken.ExpiresOn.UtcDateTime.AddSeconds(-60); // Subtract 60 seconds as a buffer.
+
+        return _cachedAccessToken;
+    }
+
+    private static string NormalizeServerName(string server)
+    {
+        if (!server.Contains('.'))
+        {
+            return server + ".postgres.database.azure.com";
+        }
+        return server;
+    }
+
+    public async Task<List<string>> ListDatabasesAsync(string subscriptionId, string resourceGroup, string user, string server)
+    {
+        var accessToken = await GetAccessTokenAsync();
+
+        var host = NormalizeServerName(server);
+        var connectionString = $"Host={host};Database=postgres;Username={user};Password={accessToken};";
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        var query = "SELECT datname FROM pg_database WHERE datistemplate = false;";
+        await using var command = new NpgsqlCommand(query, connection);
+        await using var reader = await command.ExecuteReaderAsync();
+        var dbs = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            dbs.Add(reader.GetString(0));
+        }
+        return dbs;
+    }
+
+    public async Task<string> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string query)
+    {
+        var accessToken = await GetAccessTokenAsync();
+
+        var host = NormalizeServerName(server);
+        var connectionString = $"Host={host};Database={database};Username={user};Password={accessToken};";
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+
+        await using var command = new NpgsqlCommand(query, connection);
+        await using var reader = await command.ExecuteReaderAsync();
+
+        var columnNames = Enumerable.Range(0, reader.FieldCount)
+                               .Select(reader.GetName)
+                               .ToArray();
+        var rows = new List<object?[]>();
+        while (await reader.ReadAsync())
+        {
+            var row = Enumerable.Range(0, reader.FieldCount)
+                                .Select(i => reader.IsDBNull(i) ? null : reader.GetValue(i))
+                                .ToArray();
+            rows.Add(row);
+        }
+
+        return JsonSerializer.Serialize(new { columnNames, rows });
+    }
+
+    public async Task<List<string>> ListTablesAsync(string subscriptionId, string resourceGroup, string user, string server, string database)
+    {
+        var accessToken = await GetAccessTokenAsync();
+
+        var host = NormalizeServerName(server);
+        var connectionString = $"Host={host};Database={database};Username={user};Password={accessToken};";
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        var query = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';";
+        await using var command = new NpgsqlCommand(query, connection);
+        await using var reader = await command.ExecuteReaderAsync();
+        var tables = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            tables.Add(reader.GetString(0));
+        }
+        return tables;
+    }
+
+    public async Task<List<string>> GetTableSchemaAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string table)
+    {
+        var accessToken = await GetAccessTokenAsync();
+
+        var host = NormalizeServerName(server);
+        var connectionString = $"Host={host};Database={database};Username={user};Password={accessToken};";
+
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        var query = $"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{table}';";
+        await using var command = new NpgsqlCommand(query, connection);
+        await using var reader = await command.ExecuteReaderAsync();
+        var schema = new List<string>();
+        while (await reader.ReadAsync())
+        {
+            schema.Add($"{reader.GetString(0)}: {reader.GetString(1)}");
+        }
+        return schema;
+    }
+
+    public async Task<List<string>> ListServersAsync(string subscriptionId, string resourceGroup, string user)
+    {
+        ResourceIdentifier resourceGroupId = ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroup);
+        var rg = _armClient.GetResourceGroupResource(resourceGroupId);
+        var serverList = new List<string>();
+        await foreach (PostgreSqlFlexibleServerResource server in rg.GetPostgreSqlFlexibleServers().GetAllAsync())
+        {
+            serverList.Add(server.Data.Name);
+        }
+        return serverList;
+    }
+
+    public async Task<string> GetServerConfigAsync(string subscriptionId, string resourceGroup, string user, string server)
+    {
+        ResourceIdentifier resourceGroupId = ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroup);
+        var rg = _armClient.GetResourceGroupResource(resourceGroupId);
+        var pgServer = await rg.GetPostgreSqlFlexibleServerAsync(server);
+        var pgServerData = pgServer.Value.Data;
+        var result = new
+        {
+            server = new
+            {
+                name = pgServerData.Name,
+                location = pgServerData.Location,
+                version = pgServerData.Version,
+                sku = pgServerData.Sku?.Name,
+                storage_profile = new
+                {
+                    storage_size_gb = pgServerData.Storage?.StorageSizeInGB,
+                    backup_retention_days = pgServerData.Backup?.BackupRetentionDays,
+                    geo_redundant_backup = pgServerData.Backup?.GeoRedundantBackup
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(result);
+    }
+
+    public async Task<string> GetServerParameterAsync(string subscriptionId, string resourceGroup, string user, string server, string param)
+    {
+        ResourceIdentifier resourceGroupId = ResourceGroupResource.CreateResourceIdentifier(subscriptionId, resourceGroup);
+        var rg = _armClient.GetResourceGroupResource(resourceGroupId);
+        var pgServer = await rg.GetPostgreSqlFlexibleServerAsync(server);
+
+        var configResponse = await pgServer.Value.GetPostgreSqlFlexibleServerConfigurationAsync(param);
+        if (configResponse?.Value?.Data == null)
+        {
+            throw new Exception($"Parameter '{param}' not found.");
+        }
+        return configResponse.Value.Data.Value;
+    }
+}

--- a/src/Services/Interfaces/IPostgresService.cs
+++ b/src/Services/Interfaces/IPostgresService.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace AzureMcp.Services.Interfaces;
+
+public interface IPostgresService
+{
+    Task<List<string>> ListDatabasesAsync(string subscriptionId, string resourceGroup, string user, string server);
+    Task<string> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string query);
+
+    Task<List<string>> ListTablesAsync(string subscriptionId, string resourceGroup, string user, string server, string database);
+    Task<List<string>> GetTableSchemaAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string table);
+
+    Task<List<string>> ListServersAsync(string subscriptionId, string resourceGroup, string user);
+    Task<string> GetServerConfigAsync(string subscriptionId, string resourceGroup, string user, string server);
+    Task<string> GetServerParameterAsync(string subscriptionId, string resourceGroup, string user, string server, string param);
+
+}

--- a/src/Services/Interfaces/IPostgresService.cs
+++ b/src/Services/Interfaces/IPostgresService.cs
@@ -16,5 +16,4 @@ public interface IPostgresService
     Task<List<string>> ListServersAsync(string subscriptionId, string resourceGroup, string user);
     Task<string> GetServerConfigAsync(string subscriptionId, string resourceGroup, string user, string server);
     Task<string> GetServerParameterAsync(string subscriptionId, string resourceGroup, string user, string server, string param);
-
 }

--- a/src/Services/Interfaces/IPostgresService.cs
+++ b/src/Services/Interfaces/IPostgresService.cs
@@ -8,7 +8,7 @@ namespace AzureMcp.Services.Interfaces;
 public interface IPostgresService
 {
     Task<List<string>> ListDatabasesAsync(string subscriptionId, string resourceGroup, string user, string server);
-    Task<string> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string query);
+    Task<List<string>> ExecuteQueryAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string query);
 
     Task<List<string>> ListTablesAsync(string subscriptionId, string resourceGroup, string user, string server, string database);
     Task<List<string>> GetTableSchemaAsync(string subscriptionId, string resourceGroup, string user, string server, string database, string table);

--- a/tests/Commands/Postgres/Database/DatabaseListCommandTests.cs
+++ b/tests/Commands/Postgres/Database/DatabaseListCommandTests.cs
@@ -1,12 +1,16 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Storage.Sas;
 using AzureMcp.Commands.Postgres.Database;
+using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using System.CommandLine.Parsing;
-using Xunit;
-using AzureMcp.Models.Command;
 using NSubstitute.ExceptionExtensions;
+using Xunit;
 
 namespace AzureMcp.Tests.Commands.Postgres.Database;
 
@@ -34,14 +38,20 @@ public class DatabaseListCommandTests
         _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").Returns(expectedDatabases);
 
         var command = new DatabaseListCommand(_logger);
-        var parser = new Parser(command.GetCommand());
-        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1"]);
         var context = new CommandContext(_serviceProvider);
 
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
-        Assert.Equal(expectedDatabases, response.Results);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<DatabaseListResult>(json);
+        Assert.NotNull(result);
+        Assert.Equal(expectedDatabases, result.Databases);
     }
 
     [Fact]
@@ -50,13 +60,14 @@ public class DatabaseListCommandTests
         _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").Returns([]);
 
         var command = new DatabaseListCommand(_logger);
-        var parser = new Parser(command.GetCommand());
-        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1"]);
         var context = new CommandContext(_serviceProvider);
 
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
         Assert.Null(response.Results);
     }
 
@@ -66,12 +77,43 @@ public class DatabaseListCommandTests
         _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").ThrowsAsync(new Exception("Test exception"));
 
         var command = new DatabaseListCommand(_logger);
-        var parser = new Parser(command.GetCommand());
-        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1"]);
         var context = new CommandContext(_serviceProvider);
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
+        Assert.Equal(500, response.Status);
         Assert.Contains("Test exception", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--subscription")]
+    [InlineData("--resource-group")]
+    [InlineData("--user-name")]
+    [InlineData("--server")]
+    public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
+    {
+        var command = new DatabaseListCommand(_logger);
+        var args = command.GetCommand().Parse(new string[]
+        {
+            missingParameter == "--subscription" ? "" : "--subscription", "sub123",
+            missingParameter == "--resource-group" ? "" : "--resource-group", "rg1",
+            missingParameter == "--user-name" ? "" : "--user-name", "user1",
+            missingParameter == "--server" ? "" : "--server", "server123",
+        });
+
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(400, response.Status);
+        Assert.Equal($"Missing required arguments: {missingParameter.TrimStart('-')}", response.Message);
+    }
+
+
+    private class DatabaseListResult
+    {
+        [JsonPropertyName("Databases")]
+        public List<string> Databases { get; set; } = new List<string>();
     }
 }

--- a/tests/Commands/Postgres/Database/DatabaseListCommandTests.cs
+++ b/tests/Commands/Postgres/Database/DatabaseListCommandTests.cs
@@ -1,0 +1,77 @@
+using AzureMcp.Commands.Postgres.Database;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.CommandLine.Parsing;
+using Xunit;
+using AzureMcp.Models.Command;
+using NSubstitute.ExceptionExtensions;
+
+namespace AzureMcp.Tests.Commands.Postgres.Database;
+
+public class DatabaseListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPostgresService _postgresService;
+    private readonly ILogger<DatabaseListCommand> _logger;
+
+    public DatabaseListCommandTests()
+    {
+        _postgresService = Substitute.For<IPostgresService>();
+        _logger = Substitute.For<ILogger<DatabaseListCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_postgresService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsDatabases_WhenDatabasesExist()
+    {
+        var expectedDatabases = new List<string> { "db1", "db2" };
+        _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").Returns(expectedDatabases);
+
+        var command = new DatabaseListCommand(_logger);
+        var parser = new Parser(command.GetCommand());
+        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
+        var context = new CommandContext(_serviceProvider);
+
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(expectedDatabases, response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsMessage_WhenNoDatabasesExist()
+    {
+        _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").Returns([]);
+
+        var command = new DatabaseListCommand(_logger);
+        var parser = new Parser(command.GetCommand());
+        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
+        var context = new CommandContext(_serviceProvider);
+
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesException()
+    {
+        _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").ThrowsAsync(new Exception("Test exception"));
+
+        var command = new DatabaseListCommand(_logger);
+        var parser = new Parser(command.GetCommand());
+        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Contains("Test exception", response.Message);
+    }
+}

--- a/tests/Commands/Postgres/Database/DatabaseQueryCommandTests.cs
+++ b/tests/Commands/Postgres/Database/DatabaseQueryCommandTests.cs
@@ -1,15 +1,15 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using AzureMcp.Commands.Postgres.Database;
+using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using System.CommandLine.Parsing;
 using Xunit;
-using AzureMcp.Models.Command;
-using System.Diagnostics;
-using System.CommandLine;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace AzureMcp.Tests.Commands.Postgres.Database;
 
@@ -36,51 +36,78 @@ public class DatabaseQueryCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsQueryResults_WhenQueryIsValid()
     {
-        var expectedResults = "[{\"id\":2}]";
+        var expectedResults = new List<string> { "result1", "result2" };
 
         _postgresService.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db123", "SELECT * FROM test;")
-            .Returns(Task.FromResult(expectedResults));
+            .Returns(expectedResults);
 
         var command = new DatabaseQueryCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123", "--query", "SELECT * FROM test;"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1", "--database", "db123", "--query", "SELECT * FROM test;"]);
         var context = new CommandContext(_serviceProvider);
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
         Assert.NotNull(response.Results);
 
         var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<QueryResult>(json);
+        var result = JsonSerializer.Deserialize<DatabaseQueryResult>(json);
         Assert.NotNull(result);
-        Assert.Equal(expectedResults, result.QueryResults);
+        Assert.Equal(expectedResults, result.QueryResult);
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsEmpty_WhenQueryFails()
     {
-        var expectedResults = "";
+        var expectedResults = new List<string>();
 
-        _postgresService.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db123", "SELECT * FROM test;").Returns(expectedResults);
+        _postgresService.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db123", "SELECT * FROM test;")
+            .Returns(expectedResults);
 
         var command = new DatabaseQueryCommand(_logger);
         var parser = new Parser(command.GetCommand());
-        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123", "--query", "SELECT * FROM test;"]);
+        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1", "--database", "db123", "--query", "SELECT * FROM test;"]);
         var context = new CommandContext(_serviceProvider);
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
-        Assert.NotNull(response.Results);
-
-        var json = JsonSerializer.Serialize(response.Results);
-        var result = JsonSerializer.Deserialize<QueryResult>(json);
-        Assert.NotNull(result);
-        Assert.Equal(expectedResults, result.QueryResults);
+        Assert.Equal(200, response.Status);
+        Assert.Null(response.Results);
     }
 
-    private class QueryResult
+    [Theory]
+    [InlineData("--subscription")]
+    [InlineData("--resource-group")]
+    [InlineData("--user-name")]
+    [InlineData("--server")]
+    [InlineData("--database")]
+    [InlineData("--query")]
+    public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
+    {
+        var command = new DatabaseQueryCommand(_logger);
+        var args = command.GetCommand().Parse(new string[]
+        {
+            missingParameter == "--subscription" ? "" : "--subscription", "sub123",
+            missingParameter == "--resource-group" ? "" : "--resource-group", "rg1",
+            missingParameter == "--user-name" ? "" : "--user-name", "user1",
+            missingParameter == "--server" ? "" : "--server", "server123",
+            missingParameter == "--database" ? "" : "--database", "db123",
+            missingParameter == "--query" ? "" : "--query", "SELECT * FROM test;"
+        });
+
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(400, response.Status);
+        Assert.Equal($"Missing required arguments: {missingParameter.TrimStart('-')}", response.Message);
+    }
+
+    private class DatabaseQueryResult
     {
         [JsonPropertyName("QueryResult")]
-        public required string QueryResults { get; set; }
+        public List<string> QueryResult { get; set; } = new List<string>();
+
     }
 
 }

--- a/tests/Commands/Postgres/Database/DatabaseQueryCommandTests.cs
+++ b/tests/Commands/Postgres/Database/DatabaseQueryCommandTests.cs
@@ -1,0 +1,86 @@
+using AzureMcp.Commands.Postgres.Database;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.CommandLine.Parsing;
+using Xunit;
+using AzureMcp.Models.Command;
+using System.Diagnostics;
+using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AzureMcp.Tests.Commands.Postgres.Database;
+
+[DebuggerStepThrough]
+public class DatabaseQueryCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPostgresService _postgresService;
+    private readonly ILogger<DatabaseQueryCommand> _logger;
+    private readonly ITestOutputHelper _output;
+
+    public DatabaseQueryCommandTests(ITestOutputHelper output)
+    {
+        _logger = Substitute.For<ILogger<DatabaseQueryCommand>>();
+        _postgresService = Substitute.For<IPostgresService>();
+        _output = output;
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_postgresService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsQueryResults_WhenQueryIsValid()
+    {
+        var expectedResults = "[{\"id\":2}]";
+
+        _postgresService.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db123", "SELECT * FROM test;")
+            .Returns(Task.FromResult(expectedResults));
+
+        var command = new DatabaseQueryCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123", "--query", "SELECT * FROM test;"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<QueryResult>(json);
+        Assert.NotNull(result);
+        Assert.Equal(expectedResults, result.QueryResults);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsEmpty_WhenQueryFails()
+    {
+        var expectedResults = "";
+
+        _postgresService.ExecuteQueryAsync("sub123", "rg1", "user1", "server1", "db123", "SELECT * FROM test;").Returns(expectedResults);
+
+        var command = new DatabaseQueryCommand(_logger);
+        var parser = new Parser(command.GetCommand());
+        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123", "--query", "SELECT * FROM test;"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<QueryResult>(json);
+        Assert.NotNull(result);
+        Assert.Equal(expectedResults, result.QueryResults);
+    }
+
+    private class QueryResult
+    {
+        [JsonPropertyName("QueryResult")]
+        public required string QueryResults { get; set; }
+    }
+
+}

--- a/tests/Commands/Postgres/Server/GetConfigCommandTests.cs
+++ b/tests/Commands/Postgres/Server/GetConfigCommandTests.cs
@@ -1,0 +1,59 @@
+using AzureMcp.Commands.Postgres.Server;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Xunit;
+
+namespace AzureMcp.Tests.Commands.Postgres.Server;
+
+public class GetConfigCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPostgresService _postgresService;
+    private readonly ILogger<GetConfigCommand> _logger;
+
+    public GetConfigCommandTests()
+    {
+        _postgresService = Substitute.For<IPostgresService>();
+        _logger = Substitute.For<ILogger<GetConfigCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_postgresService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsConfig_WhenConfigExists()
+    {
+        var expectedConfig = "config123";
+        _postgresService.GetServerConfigAsync("sub123", "rg1", "user1", "server123").Returns(expectedConfig);
+
+        var command = new GetConfigCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123"]);
+        var context = new CommandContext(_serviceProvider);
+
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(expectedConfig, response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenConfigDoesNotExist()
+    {
+        _postgresService.GetServerConfigAsync("sub123", "rg1", "user1", "server123").Returns("");
+
+        var command = new GetConfigCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+}

--- a/tests/Commands/Postgres/Server/GetParamCommandTests.cs
+++ b/tests/Commands/Postgres/Server/GetParamCommandTests.cs
@@ -1,11 +1,13 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using AzureMcp.Commands.Postgres.Server;
 using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using System.CommandLine;
-using System.CommandLine.Parsing;
 using Xunit;
 
 namespace AzureMcp.Tests.Commands.Postgres.Server;
@@ -34,12 +36,20 @@ public class GetParamCommandTests
         _postgresService.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123").Returns(expectedValue);
 
         var command = new GetParamCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "param123"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server123", "--param", "param123"]);
         var context = new CommandContext(_serviceProvider);
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
-        Assert.Equal(expectedValue, response.Results);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<GetParamResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedValue, result.Param);
     }
 
     [Fact]
@@ -47,11 +57,45 @@ public class GetParamCommandTests
     {
         _postgresService.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123").Returns("");
         var command = new GetParamCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "param123"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server123", "--param", "param123"]);
         var context = new CommandContext(_serviceProvider);
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
         Assert.Null(response.Results);
+    }
+
+    [Theory]
+    [InlineData("--subscription")]
+    [InlineData("--resource-group")]
+    [InlineData("--user-name")]
+    [InlineData("--server")]
+    [InlineData("--param")]
+    public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
+    {
+        var command = new GetParamCommand(_logger);
+        var args = command.GetCommand().Parse(new string[]
+        {
+            missingParameter == "--subscription" ? "" : "--subscription", "sub123",
+            missingParameter == "--resource-group" ? "" : "--resource-group", "rg1",
+            missingParameter == "--user-name" ? "" : "--user-name", "user1",
+            missingParameter == "--server" ? "" : "--server", "server123",
+            missingParameter == "--param" ? "" : "--param", "param123"
+        });
+
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(400, response.Status);
+        Assert.Equal($"Missing required arguments: {missingParameter.TrimStart('-')}", response.Message);
+    }
+
+    private class GetParamResult
+    {
+        [JsonPropertyName("ParameterValue")]
+        public string Param { get; set; } = string.Empty;
     }
 }

--- a/tests/Commands/Postgres/Server/GetParamCommandTests.cs
+++ b/tests/Commands/Postgres/Server/GetParamCommandTests.cs
@@ -1,0 +1,57 @@
+using AzureMcp.Commands.Postgres.Server;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Xunit;
+
+namespace AzureMcp.Tests.Commands.Postgres.Server;
+
+public class GetParamCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPostgresService _postgresService;
+    private readonly ILogger<GetParamCommand> _logger;
+
+    public GetParamCommandTests()
+    {
+        _postgresService = Substitute.For<IPostgresService>();
+        _logger = Substitute.For<ILogger<GetParamCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_postgresService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsParamValue_WhenParamExists()
+    {
+        var expectedValue = "value123";
+        _postgresService.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123").Returns(expectedValue);
+
+        var command = new GetParamCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "param123"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(expectedValue, response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenParamDoesNotExist()
+    {
+        _postgresService.GetServerParameterAsync("sub123", "rg1", "user1", "server123", "param123").Returns("");
+        var command = new GetParamCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server123", "--param", "param123"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+}

--- a/tests/Commands/Postgres/Server/ServerListCommandTests.cs
+++ b/tests/Commands/Postgres/Server/ServerListCommandTests.cs
@@ -1,0 +1,82 @@
+using AzureMcp.Commands.Postgres.Server;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using Xunit;
+
+namespace AzureMcp.Tests.Commands.Postgres.Server;
+
+public class ServerListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPostgresService _postgresService;
+    private readonly ILogger<ServerListCommand> _logger;
+
+    public ServerListCommandTests()
+    {
+        _postgresService = Substitute.For<IPostgresService>();
+        _logger = Substitute.For<ILogger<ServerListCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_postgresService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsServers_WhenServersExist()
+    {
+        // Arrange
+        var expectedServers = new List<string> { "server1", "server2" };
+
+        _postgresService.ListServersAsync("sub123", "rg1", "user1").Returns(expectedServers);
+
+        var command = new ServerListCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(expectedServers, response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenNoServers()
+    {
+        _postgresService.ListServersAsync("sub123", "rg1", "user1").Returns([]);
+
+        var command = new ServerListCommand(_logger);
+        var parser = new Parser(command.GetCommand());
+        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesException()
+    {
+        var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
+        _postgresService.ListServersAsync("sub123", "rg1", "user1")
+            .ThrowsAsync(new Exception("Test error"));
+
+        var command = new ServerListCommand(_logger);
+        var parser = new Parser(command.GetCommand());
+        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1"]);
+        var context = new CommandContext(_serviceProvider);
+
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(500, response.Status);
+        Assert.Equal(expectedError, response.Message);
+    }
+}

--- a/tests/Commands/Postgres/Table/GetSchemaCommandTests.cs
+++ b/tests/Commands/Postgres/Table/GetSchemaCommandTests.cs
@@ -1,12 +1,13 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using AzureMcp.Commands.Postgres.Table;
 using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using System.CommandLine;
-using System.CommandLine.Parsing;
-using System.Text.Json;
 using Xunit;
 
 namespace AzureMcp.Tests.Commands.Postgres.Table;
@@ -35,13 +36,17 @@ public class GetSchemaCommandTests
         _postgresService.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db123", "table123").Returns(expectedSchema);
 
         var command = new GetSchemaCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123", "--table", "table123"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1", "--database", "db123", "--table", "table123"]);
         var context = new CommandContext(_serviceProvider);
 
         var response = await command.ExecuteAsync(context, args);
-
         Assert.NotNull(response);
-        Assert.Equal(expectedSchema, response.Results);
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<GetSchemaResult>(json);
+        Assert.NotNull(result);
+        Assert.Equal(expectedSchema, result.Schema);
     }
 
     [Fact]
@@ -50,12 +55,48 @@ public class GetSchemaCommandTests
         _postgresService.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db123", "table123").Returns([]);
 
         var command = new GetSchemaCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123", "--table", "table123"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1", "--database", "db123", "--table", "table123"]);
         var context = new CommandContext(_serviceProvider);
 
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
         Assert.Null(response.Results);
+    }
+
+    [Theory]
+    [InlineData("--subscription")]
+    [InlineData("--resource-group")]
+    [InlineData("--user-name")]
+    [InlineData("--server")]
+    [InlineData("--database")]
+    [InlineData("--table")]
+    public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
+    {
+        var command = new GetSchemaCommand(_logger);
+        var args = command.GetCommand().Parse(new string[]
+        {
+            missingParameter == "--subscription" ? "" : "--subscription", "sub123",
+            missingParameter == "--resource-group" ? "" : "--resource-group", "rg1",
+            missingParameter == "--user-name" ? "" : "--user-name", "user1",
+            missingParameter == "--server" ? "" : "--server", "server123",
+            missingParameter == "--database" ? "" : "--database", "db123",
+            missingParameter == "--table" ? "" : "--table", "table123"
+        });
+
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(400, response.Status);
+        Assert.Equal($"Missing required arguments: {missingParameter.TrimStart('-')}", response.Message);
+    }
+
+    private class GetSchemaResult
+    {
+        [JsonPropertyName("Schema")]
+        public List<string> Schema { get; set; } = new List<string>();
     }
 }

--- a/tests/Commands/Postgres/Table/GetSchemaCommandTests.cs
+++ b/tests/Commands/Postgres/Table/GetSchemaCommandTests.cs
@@ -1,0 +1,61 @@
+using AzureMcp.Commands.Postgres.Table;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using Xunit;
+
+namespace AzureMcp.Tests.Commands.Postgres.Table;
+
+public class GetSchemaCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPostgresService _postgresService;
+    private readonly ILogger<GetSchemaCommand> _logger;
+
+    public GetSchemaCommandTests()
+    {
+        _postgresService = Substitute.For<IPostgresService>();
+        _logger = Substitute.For<ILogger<GetSchemaCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_postgresService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsSchema_WhenSchemaExists()
+    {
+        var expectedSchema = new List<string>(["CREATE TABLE test (id INT);"]);
+        _postgresService.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db123", "table123").Returns(expectedSchema);
+
+        var command = new GetSchemaCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123", "--table", "table123"]);
+        var context = new CommandContext(_serviceProvider);
+
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(expectedSchema, response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenSchemaDoesNotExist()
+    {
+        _postgresService.GetTableSchemaAsync("sub123", "rg1", "user1", "server1", "db123", "table123").Returns([]);
+
+        var command = new GetSchemaCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123", "--table", "table123"]);
+        var context = new CommandContext(_serviceProvider);
+
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+}

--- a/tests/Commands/Postgres/Table/TableListCommandTests.cs
+++ b/tests/Commands/Postgres/Table/TableListCommandTests.cs
@@ -1,0 +1,59 @@
+using AzureMcp.Commands.Postgres.Table;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using Xunit;
+using AzureMcp.Models.Command;
+using System.CommandLine;
+
+namespace AzureMcp.Tests.Commands.Postgres.Table;
+
+public class TableListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IPostgresService _postgresService;
+    private readonly ILogger<TableListCommand> _logger;
+
+    public TableListCommandTests()
+    {
+        _postgresService = Substitute.For<IPostgresService>();
+        _logger = Substitute.For<ILogger<TableListCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_postgresService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTables_WhenTablesExist()
+    {
+        var expectedTables = new List<string> { "table1", "table2" };
+        _postgresService.ListTablesAsync("sub123", "rg1", "user1", "server1", "db123").Returns(expectedTables);
+
+        var command = new TableListCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(expectedTables, response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoTablesExist()
+    {
+        _postgresService.ListTablesAsync("sub123", "rg1", "user1", "server1", "db123").Returns([]);
+
+        var command = new TableListCommand(_logger);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123"]);
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+    }
+}

--- a/tests/Commands/Postgres/Table/TableListCommandTests.cs
+++ b/tests/Commands/Postgres/Table/TableListCommandTests.cs
@@ -1,13 +1,14 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using AzureMcp.Commands.Postgres.Table;
+using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using System.CommandLine.Parsing;
-using System.Text.Json;
 using Xunit;
-using AzureMcp.Models.Command;
-using System.CommandLine;
 
 namespace AzureMcp.Tests.Commands.Postgres.Table;
 
@@ -35,12 +36,19 @@ public class TableListCommandTests
         _postgresService.ListTablesAsync("sub123", "rg1", "user1", "server1", "db123").Returns(expectedTables);
 
         var command = new TableListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1", "--database", "db123"]);
         var context = new CommandContext(_serviceProvider);
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
-        Assert.Equal(expectedTables, response.Results);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<TableListResult>(json);
+        Assert.NotNull(result);
+        Assert.Equal(expectedTables, result.Tables);
     }
 
     [Fact]
@@ -49,11 +57,45 @@ public class TableListCommandTests
         _postgresService.ListTablesAsync("sub123", "rg1", "user1", "server1", "db123").Returns([]);
 
         var command = new TableListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123"]);
+        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user-name", "user1", "--server", "server1", "--database", "db123"]);
         var context = new CommandContext(_serviceProvider);
         var response = await command.ExecuteAsync(context, args);
 
         Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
         Assert.Null(response.Results);
+    }
+
+    [Theory]
+    [InlineData("--subscription")]
+    [InlineData("--resource-group")]
+    [InlineData("--user-name")]
+    [InlineData("--server")]
+    [InlineData("--database")]
+    public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
+    {
+        var command = new TableListCommand(_logger);
+        var args = command.GetCommand().Parse(new string[]
+        {
+            missingParameter == "--subscription" ? "" : "--subscription", "sub123",
+            missingParameter == "--resource-group" ? "" : "--resource-group", "rg1",
+            missingParameter == "--user-name" ? "" : "--user-name", "user1",
+            missingParameter == "--server" ? "" : "--server", "server123",
+            missingParameter == "--database" ? "" : "--database", "db123"
+        });
+
+        var context = new CommandContext(_serviceProvider);
+        var response = await command.ExecuteAsync(context, args);
+
+        Assert.NotNull(response);
+        Assert.Equal(400, response.Status);
+        Assert.Equal($"Missing required arguments: {missingParameter.TrimStart('-')}", response.Message);
+    }
+
+    private class TableListResult
+    {
+        [JsonPropertyName("Tables")]
+        public List<string> Tables { get; set; } = [];
     }
 }


### PR DESCRIPTION
- Adds support for Azure Database for PostgreSQL - Flexible Server (https://github.com/Azure/azure-mcp-pr/issues/242) 
- Implements the following PostgreSQL commands:
    - Server
        - List
        - GetConfig
        - GetParam
    - Database
        - List
        - Query
    - Table
        - List
        - GetSchema
- Adds service and interface for PostgreSQL.
- Adds commands and arguments for PostgreSQL
- Registers the new commands in the CommandFactory.
- Registers the new service to start during service initialization.
- Updates the ArgumentDefinitions to include PostgreSQL commands.
- Updates the AzureMcp project file to include the new dependencies.
- Adds tests for newly added commands.
- Updates README and azmcp docs with PostgresQL capabilities.

Notes:
- Inherits from SubscriptionCommand.
- Adds resource group explicitly to options and arguments.