### PR TITLE
Refactor test namespaces and update assertions in command tests

### DIFF
--- a/tests/Commands/Search/Index/IndexDescribeCommandTests.cs
+++ b/tests/Commands/Search/Index/IndexDescribeCommandTests.cs
@@ -15,7 +15,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Xunit;
 
-namespace AzureMcp.Tests.Commands.Search.Index;
+namespace AzureMcp.Tests.Commands.Search;
 
 public class IndexDescribeCommandTests
 {
@@ -140,9 +140,9 @@ public class IndexDescribeCommandTests
         // Assert
         Assert.NotNull(response);
         Assert.Equal(400, response.Status);
-        Assert.NotNull(response.Arguments);
-        Assert.Contains(response.Arguments ?? [], a => a.Name == "service-name" && a.Required);
-        Assert.Contains(response.Arguments ?? [], a => a.Name == "index-name" && a.Required);
+        Assert.NotNull(response.Message);
+        Assert.Contains("service-name", response.Message);
+        Assert.Contains("index-name", response.Message);
     }
 
     [Fact]

--- a/tests/Commands/Search/Index/IndexListCommandTests.cs
+++ b/tests/Commands/Search/Index/IndexListCommandTests.cs
@@ -15,7 +15,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Xunit;
 
-namespace AzureMcp.Tests.Commands.Search.Index;
+namespace AzureMcp.Tests.Commands.Search;
 
 public class IndexListCommandTests
 {

--- a/tests/Commands/Search/Index/IndexQueryCommandTests.cs
+++ b/tests/Commands/Search/Index/IndexQueryCommandTests.cs
@@ -14,7 +14,7 @@ using System.CommandLine.Parsing;
 using System.Text.Json;
 using Xunit;
 
-namespace AzureMcp.Tests.Commands.Search.Index;
+namespace AzureMcp.Tests.Commands.Search;
 
 public class IndexQueryCommandTests
 {
@@ -121,10 +121,10 @@ public class IndexQueryCommandTests
         // Assert
         Assert.NotNull(response);
         Assert.Equal(400, response.Status);
-        Assert.NotNull(response.Arguments);
-        Assert.Contains(response.Arguments ?? [], a => a.Name == "service-name" && a.Required);
-        Assert.Contains(response.Arguments ?? [], a => a.Name == "index-name" && a.Required);
-        Assert.Contains(response.Arguments ?? [], a => a.Name == "query" && a.Required);
+        Assert.NotNull(response.Message);
+        Assert.Contains("service-name", response.Message);
+        Assert.Contains("index-name", response.Message);
+        Assert.Contains("query", response.Message);
     }
 
     [Fact]

--- a/tests/Commands/Search/Service/ServiceListCommandTests.cs
+++ b/tests/Commands/Search/Service/ServiceListCommandTests.cs
@@ -15,7 +15,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Xunit;
 
-namespace AzureMcp.Tests.Commands.Search.Service;
+namespace AzureMcp.Tests.Commands.Search;
 
 public class ServiceListCommandTests
 {


### PR DESCRIPTION
Standardize test namespaces for consistency and enhance assertions to validate response messages instead of arguments.