### PR TITLE
Small fixes to powershell scripts

### DIFF
--- a/eng/scripts/Build-Local.ps1
+++ b/eng/scripts/Build-Local.ps1
@@ -59,12 +59,13 @@ else {
 if ($VerifyNpx) {
     Push-Location -Path $RepoRoot
     try {
-        $tgzFile = Get-ChildItem -Path $distPath
-        | Where-Object -Property 'Name' -Match '^azure-mcp-[\d\.]+\.tgz$'
+        $tgzFile = Get-ChildItem -Path "$distPath/wrapper" -Filter '*.tgz'
         | Select-Object -ExpandProperty 'Name' -First 1
-    
-        Write-Host "> npx -y .dist/$tgzFile --help"
-        npx -y ".dist/$tgzFile" --help
+
+        Write-Host "> npx -y clear-npx-cache"
+        npx -y clear-npx-cache
+        Write-Host "> npx -y `".dist/wrapper/$tgzFile`" tools list"
+        npx -y ".dist/wrapper/$tgzFile" tools list
     }
     finally {
         Pop-Location

--- a/eng/scripts/Install-GitHooks.ps1
+++ b/eng/scripts/Install-GitHooks.ps1
@@ -46,10 +46,8 @@ foreach ($file in $hookFiles) {
     Copy-Item -Path $file.FullName -Destination $targetFile -Force
 
     # Make hook files executable
-    Write-Host "  Setting executable permission for $($file.Name)..."
-    if ($IsWindows) {
-        & attrib +x $targetFile
-    } else {
+    if (!$IsWindows) {
+        Write-Host "  Setting executable permission for $($file.Name)..."
         & chmod +x $targetFile
     }
 }

--- a/eng/scripts/Test-ModulePerformance.ps1
+++ b/eng/scripts/Test-ModulePerformance.ps1
@@ -2,7 +2,7 @@
 #Requires -Version 7
 
 param(
-    [string] $Command = 'azmcp subscription list'
+    [string] $Command = 'azmcp tools list'
 )
 
 . "$PSScriptRoot/../common/scripts/common.ps1"
@@ -13,7 +13,7 @@ $combinations = @()
     @($false, $true) | ForEach-Object {
         $ReadyToRun = $_
         $combinations += @{
-            Name = "$($Trimmed ? 'Trimmed' : '')$($ReadyToRun ? 'ReadyToRun' : '')"
+            Name = "$($Trimmed ? 'aot' : 'no-aot')/$($ReadyToRun ? 'r2r' : 'no-r2r')"
             Trimmed = $Trimmed
             ReadyToRun = $ReadyToRun
         }
@@ -68,8 +68,8 @@ try {
             npm uninstall -g azmcp | Out-Null
 
             $start = Get-Date
-            Write-Host "> npm install -g .dist/azure-mcp-$version.tgz"
-            npm install -g ".dist/azure-mcp-$version.tgz" | Out-Null
+            Write-Host "> npm install -g .dist/wrapper/azure-mcp-$version.tgz"
+            npm install -g ".dist/wrapper/azure-mcp-$version.tgz" | Out-Null
             $installation = ((Get-Date) - $start).TotalMilliseconds
 
             $runs = @()
@@ -83,8 +83,8 @@ try {
                 $runs += ((Get-Date) - $start).TotalMilliseconds
             }
 
-            $tgzSize = (Get-Item -Path ".dist/azure-mcp-$nodeRid-$version.tgz").Length / 1MB
-            $packageSize = (Get-ChildItem -Path ".work/packages/$rid" -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
+            $tgzSize = (Get-Item -Path ".dist/platform/azure-mcp-$nodeRid-$version.tgz").Length / 1MB
+            $packageSize = (Get-ChildItem -Path ".work/platform/$rid" -File -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
 
             $results[$combination.Name] += @{
                 Compilation = $compilation


### PR DESCRIPTION
- fix paths to packages in Build-Local and Test-ModulePerformance
- remove windows `attrib +x` from Install-GitHooks
  - attrib `x` in windows is data scrub, not executable
  - windows executes files by extension, not attribute