### PR TITLE
Fix casing in app-config live test

### DIFF
--- a/src/AzureMcp.csproj
+++ b/src/AzureMcp.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" GeneratePathProperty="true" ExcludeAssets="runtime;native" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" GeneratePathProperty="true" ExcludeAssets="native" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/tests/Client/AppConfigCommandTests.cs
+++ b/tests/Client/AppConfigCommandTests.cs
@@ -248,7 +248,7 @@ public class AppConfigCommandTests : CommandTestsBase,
         var setting = result.AssertProperty("setting");
         Assert.Equal(JsonValueKind.Object, setting.ValueKind);
 
-        var value = setting.AssertProperty("Value");
+        var value = setting.AssertProperty("value");
         Assert.Equal(JsonValueKind.String, value.ValueKind);
         Assert.Equal("foo-value", value.GetString());
     }


### PR DESCRIPTION
The json serialization / AOT pr added a camelCase property naming pattern that broke 1 live test.