### PR TITLE
Add all activity sources when exporting to Azure Monitor

### DIFF
--- a/src/Extensions/OpenTelemetryExtensions.cs
+++ b/src/Extensions/OpenTelemetryExtensions.cs
@@ -57,7 +57,12 @@ public static class OpenTelemetryExtensions
         var appInsightsConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
         if (!string.IsNullOrEmpty(appInsightsConnectionString))
         {
-            services.AddOpenTelemetry().UseAzureMonitor();
+            services
+                .ConfigureOpenTelemetryTracerProvider((_, b) => b.AddSource("*"))
+                .ConfigureOpenTelemetryMeterProvider((_, b) => b.AddMeter("*"))
+                .AddOpenTelemetry()
+                    .ConfigureResource(r => r.AddService("azmcp", serviceVersion: Assembly.GetExecutingAssembly()?.GetName()?.Version?.ToString()))
+                    .UseAzureMonitor();
             return true;
         }
 


### PR DESCRIPTION
Adding missing telemetry for MCP when using Azure Monitor 

I forgot to enable MCP telemetry sources in case Azure Monitor is configured. Fixing it

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/2f21ff8b-1422-401a-a56b-e97ed0d06ff6" />
