### PR TITLE
Cache CosmosClient by account name

### DIFF
--- a/src/Services/Azure/Cosmos/CosmosService.cs
+++ b/src/Services/Azure/Cosmos/CosmosService.cs
@@ -281,7 +281,6 @@ public class CosmosService(ISubscriptionService subscriptionService, ITenantServ
         {
             if (disposing)
             {
-               
             }
             _disposed = true;
         }


### PR DESCRIPTION
This PR adds Caching for CosmosClient objects based on the requested account name (#102)

Also fixes a minor bug by validating the CosmosClient object upon creation so the auth key method actually gets re-triggered when credentials cannot be found.