### PR TITLE
Add Kusto service team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,3 +24,14 @@
 /eng/                                  @Azure/azure-mcp @Azure/azure-sdk-eng
 /.github/                              @Azure/azure-mcp @Azure/azure-sdk-eng
 /.config/                              @Azure/azure-mcp @Azure/azure-sdk-eng
+
+##################
+# Services
+##################
+# PRLabel: %area-Kusto
+/src/Arguments/Kusto/                @danield137 @xiangyan99
+/src/Commands/Kusto/                 @danield137 @xiangyan99
+/src/Services/Azure/Kusto/           @danield137 @xiangyan99
+
+# ServiceLabel: %area-Kusto
+# ServiceOwners:                     @danield137


### PR DESCRIPTION
## What does this PR do?

Add Kusto service team to CODEOWNERS for the github issue and pr bots which are triggered off of %labels referenced in CODEOWNERS.

Related: https://github.com/Azure/azure-mcp/pull/21

## GitHub issue number?

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [x] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
