### PR TITLE
Don't release packages in PR triggered runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,13 +128,21 @@ The Azure MCP Server implements the [Model Context Protocol specification](https
 3. Reference the original issue
 4. Wait for review and address any feedback
 
-## Builds and releases
+## Builds and releases (Internal)
 
 The internal pipeline [azure-mcp](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7571) is used for all official
 releases and CI builds. On every merge to main, a build will run and will produce a dynamically named prerelease
 package on the public dev feed, e.g. [@azure/mcp@0.0.10-beta.4799791](https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-js/Npm/@azure%2Fmcp/overview/0.0.10-beta.4799791).
 
 Only manual runs of the pipeline sign and publish packages.  Building `main` or `hotfix/*` will publish to `npmjs.com`, all other refs will publish to the [public dev feed](https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-js).
+
+### PR Validation
+
+To run live tests for a PR, inspect the PR code for any suspicious changes, then add the comment `/azp run azure - mcp` to the pull request.  This will queue a PR triggered run which will build, run unit tests, deploy test resources and run live tests.
+
+If you would like to see the product of a PR as a package on the dev feed, after thoroughly inspecting the change, create a branch in the main repo and manually trigger an [azure - mcp](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7571) pipeline run against that branch. This will queue a manually triggered run which will build, run unit tests, deploy test resources, run live tests, sign and publish the packages to the dev feed.
+
+Instructions for consuming the package from the dev feed can be found in the "Extensions" tab of the pipeline run page.
 
 ## Questions and Support
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,13 +128,13 @@ The Azure MCP Server implements the [Model Context Protocol specification](https
 3. Reference the original issue
 4. Wait for review and address any feedback
 
-## Official builds and releases
+## Builds and releases
 
 The internal pipeline [azure-mcp](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7571) is used for all official
 releases and CI builds. On every merge to main, a build will run and will produce a dynamically named prerelease
 package on the public dev feed, e.g. [@azure/mcp@0.0.10-beta.4799791](https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-js/Npm/@azure%2Fmcp/overview/0.0.10-beta.4799791).
 
-Only manual runs of the pipeline publish official versions to npmjs.com.
+Only manual runs of the pipeline sign and publish packages.  Building `main` or `hotfix/*` will publish to `npmjs.com`, all other refs will publish to the [public dev feed](https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-js).
 
 ## Questions and Support
 

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -3,7 +3,7 @@ parameters:
   displayName: Skip signing
   type: boolean
   default: false
-  
+
 trigger:
   branches:
     include:
@@ -21,9 +21,9 @@ pr:
 extends:
   template: /eng/pipelines/templates/common.yml
   parameters:
-    SkipSigning: ${{ parameters.SkipSigning }}
+    SkipSigning: ${{ or(parameters.SkipSigning, eq(variables['Build.Reason'], 'PullRequest')) }}
     # We release signed, manual runs from main and hotfix branches
     # All other runs get -alpha prerelease labels
-    PublishPackages: true
+    PublishPackages: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
     RunLiveTests: true
     ReleaseRun: ${{ and(eq(variables['Build.Reason'], 'Manual'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startswith(variables['Build.SourceBranch'], 'refs/heads/hotfix/')), not(parameters.SkipSigning)) }}


### PR DESCRIPTION
## What does this PR do?
For security reasons, we shouldn't be signing or publishing (even to dev feeds) the product of pull requests runs.  This change ensures that no PR triggered run is signed or published.

## GitHub issue number?
none

## Checklist before merging
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
