### PR TITLE
Conditionally set the TenantId property in DefaultAzureCredentialOptions

### DIFF
--- a/src/Services/Azure/Authentication/CustomChainedCredential.cs
+++ b/src/Services/Azure/Authentication/CustomChainedCredential.cs
@@ -96,11 +96,17 @@ public class CustomChainedCredential(string? tenantId = null) : TokenCredential
     {
         var includeProdCreds = EnvironmentHelpers.GetEnvironmentVariableAsBool(IncludeProductionCredentialEnvVarName);
 
-        return new DefaultAzureCredential(new DefaultAzureCredentialOptions
+        var defaultCredentialOptions = new DefaultAzureCredentialOptions
         {
-            TenantId = string.IsNullOrEmpty(tenantId) ? null : tenantId,
             ExcludeWorkloadIdentityCredential = !includeProdCreds,
             ExcludeManagedIdentityCredential = !includeProdCreds
-        });
+        };
+
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            defaultCredentialOptions.TenantId = tenantId;
+        }
+        
+        return new DefaultAzureCredential(defaultCredentialOptions);
     }
 }


### PR DESCRIPTION
## What does this PR do?
The change addresses an issue where explicitly setting TenantId = null in DefaultAzureCredentialOptions overrides the default behavior of reading the tenant ID from the AZURE_TENANT_ID environment variable. By modifying the code to only set TenantId when a non-null value is provided, we allow DefaultAzureCredential to fall back to the environment variable as intended.
## GitHub issue number?
#53 
## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
