### PR TITLE
Ignore ServiceBus peek tests

### DIFF
--- a/tests/Client/ServiceBusCommandTests.cs
+++ b/tests/Client/ServiceBusCommandTests.cs
@@ -24,7 +24,7 @@ namespace AzureMcp.Tests.Client
             _serviceBusNamespace = $"{Settings.ResourceBaseName}.servicebus.windows.net";
         }
 
-        [Fact]
+        [Fact(Skip = "The command for this test has been commented out until we know how to surface binary data.")]
         [Trait("Category", "Live")]
         public async Task Queue_peek_messages()
         {
@@ -47,7 +47,7 @@ namespace AzureMcp.Tests.Client
             Assert.Equal(numberOfMessages, messages.GetArrayLength());
         }
 
-        [Fact]
+        [Fact(Skip = "The command for this test has been commented out until we know how to surface binary data.")]
         [Trait("Category", "Live")]
         public async Task Topic_subscription_peek_messages()
         {


### PR DESCRIPTION
## What does this PR do?
Live tests are failing because the peek commands for Service Bus were commented out in https://github.com/Azure/azure-mcp/pull/209.
This PR skips the two tests associated with those commands.

## GitHub issue number?

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If it's a core feature, I have added thorough tests.
- [x] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
