### PR TITLE
Fix JSON output parsing and enhance tests for non-JSON handling

### DIFF
--- a/src/Services/ProcessExecution/ExternalProcessService.cs
+++ b/src/Services/ProcessExecution/ExternalProcessService.cs
@@ -94,7 +94,8 @@ public class ExternalProcessService : IExternalProcessService
     }
 
     public JsonElement ParseJsonOutput(ProcessResult result)
-    {        if (result.ExitCode != 0)
+    {
+        if (result.ExitCode != 0)
         {
             var error = new ParseError(
                 result.ExitCode,

--- a/src/Services/ProcessExecution/ExternalProcessService.cs
+++ b/src/Services/ProcessExecution/ExternalProcessService.cs
@@ -94,15 +94,13 @@ public class ExternalProcessService : IExternalProcessService
     }
 
     public JsonElement ParseJsonOutput(ProcessResult result)
-    {
-        if (result.ExitCode != 0)
+    {        if (result.ExitCode != 0)
         {
-            var error = new
-            {
+            var error = new ParseError(
                 result.ExitCode,
                 result.Error,
                 result.Command
-            };
+            );
             return JsonSerializer.SerializeToElement(error, ServicesJsonContext.Default.ParseError);
         }
 

--- a/tests/Commands/Extension/AzCommandTests.cs
+++ b/tests/Commands/Extension/AzCommandTests.cs
@@ -172,16 +172,17 @@ public sealed class AzCommandTests
         var context = new CommandContext(_serviceProvider);
 
         var nonJsonOutput = "test-rg1\ntest-rg2";
-        
+
         _processService.ExecuteAsync(
             Arg.Any<string>(),
             "group list --query name",
             Arg.Any<int>(),
             Arg.Any<IEnumerable<string>>())
-            .Returns(new ProcessResult(0, nonJsonOutput, string.Empty, "group list --query name"));        var expectedJsonOutput = JsonSerializer.SerializeToElement(
+            .Returns(new ProcessResult(0, nonJsonOutput, string.Empty, "group list --query name"));
+        var expectedJsonOutput = JsonSerializer.SerializeToElement(
             new { output = nonJsonOutput },
             new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-            
+
         _processService.ParseJsonOutput(Arg.Any<ProcessResult>())
             .Returns(expectedJsonOutput);
 

--- a/tests/Commands/Extension/AzCommandTests.cs
+++ b/tests/Commands/Extension/AzCommandTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using AzureMcp.Commands.Extension;
 using AzureMcp.Models.Command;
 using AzureMcp.Services.Interfaces;
+using AzureMcp.Services.ProcessExecution;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -159,6 +160,38 @@ public sealed class AzCommandTests
         // Assert
         Assert.NotNull(response);
         Assert.Equal(400, response.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesNonJsonOutput_AndWrapsInParseOutput()
+    {
+        // Arrange
+        var command = new AzCommand(_logger);
+        var parser = new Parser(command.GetCommand());
+        var args = parser.Parse("--command \"group list --query name\"");
+        var context = new CommandContext(_serviceProvider);
+
+        var nonJsonOutput = "test-rg1\ntest-rg2";
+        
+        _processService.ExecuteAsync(
+            Arg.Any<string>(),
+            "group list --query name",
+            Arg.Any<int>(),
+            Arg.Any<IEnumerable<string>>())
+            .Returns(new ProcessResult(0, nonJsonOutput, string.Empty, "group list --query name"));        var expectedJsonOutput = JsonSerializer.SerializeToElement(
+            new { output = nonJsonOutput },
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            
+        _processService.ParseJsonOutput(Arg.Any<ProcessResult>())
+            .Returns(expectedJsonOutput);
+
+        // Act
+        var response = await command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
     }
 
     private sealed class AzResult


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-mcp/issues/194

Improve the formatting in the `ParseJsonOutput` method and refactor it to utilize a `ParseError` record. Add a test to ensure proper handling of non-JSON output in the `AzCommandTests`.