### PR TITLE
fix(server): bind to 0.0.0.0 instead of localhost to support Docker access

### DIFF
--- a/src/Commands/Server/ServiceStartCommand.cs
+++ b/src/Commands/Server/ServiceStartCommand.cs
@@ -75,7 +75,7 @@ public sealed class ServiceStartCommand : BaseCommand
             ConfigureMcpServer(builder.Services, serverArguments.Transport);
 
             builder.WebHost
-                .ConfigureKestrel(server => server.ListenLocalhost(serverArguments.Port))
+                .ConfigureKestrel(server => server.ListenAnyIP(serverArguments.Port))
                 .ConfigureLogging(logging =>
                 {
                     logging.AddEventSourceLogger();


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the Azure MCP server, when started with SSE transport, always binds to `localhost`, preventing access from outside the Docker container even when using `ASPNETCORE_URLS` or Docker port mappings.

The code previously used `ListenLocalhost`, which hardcoded the server to bind only to `localhost`. This PR replaces it with `ListenAnyIP` to allow the server to bind to `0.0.0.0`, making it accessible externally. This change has been tested inside a Docker container and works as expected.

## GitHub issue number?

Fixes #221 

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
