### PR TITLE
Fix token expiration issues in post-deployment script

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -172,6 +172,7 @@
         "Npgsql",
         "npmjs",
         "onboarded",
+        "oidc",
         "pscore",
         "RediSearch",
         "resourcegroup",

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -51,6 +51,7 @@ jobs:
       Location: ${{ parameters.CloudConfig.Location }}
       SubscriptionConfiguration: $(SubscriptionConfiguration)
       ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+      PersistOidcToken: true
       EnvVars:
         Pool: $(Pool)
         ${{insert}}: ${{ parameters.EnvVars }}

--- a/infra/test-resources-post.ps1
+++ b/infra/test-resources-post.ps1
@@ -1,6 +1,8 @@
 #Requires -Version 7
 
 param(
+    [string] $TenantId,
+    [string] $TestApplicationId,
     [string] $ResourceGroupName,
     [string] $BaseName
 )
@@ -9,6 +11,11 @@ $ErrorActionPreference = "Stop"
 
 . "$PSScriptRoot/../eng/common/scripts/common.ps1"
 $RepoRoot = $RepoRoot.Path.Replace('\', '/')
+
+Connect-AzAccount -ServicePrincipal `
+    -TenantId $TenantId `
+    -ApplicationId $TestApplicationId `
+    -FederatedToken $env:ARM_OIDC_TOKEN
 
 $context = Get-AzContext
 


### PR DESCRIPTION
## What does this PR do?
Storage's post deployment script is currently failing for auth issues.  This is likely related to deployment time increases due to other services onboarding.

Using the PersistOidcToken parameter will cause the post-deployment scripts to be run in a fresh AzCLI task with a fresh token.
