### PR TITLE
Use absolute path in UploadSummary statement

### DIFF
--- a/eng/pipelines/templates/steps/publish-to-dev-feed.yml
+++ b/eng/pipelines/templates/steps/publish-to-dev-feed.yml
@@ -93,7 +93,7 @@ steps:
       $path = './.work/Usage.md'
 
       $markdown | Out-File -FilePath $path -Encoding utf8
-      Write-Host "##vso[task.uploadsummary]$path"
+      Write-Host "##vso[task.uploadsummary]$(Resolve-Path $path)"
     displayName: "Document dev version usage"
     env:
       REGISTRY_URL: ${{parameters.Registry}}

--- a/eng/pipelines/templates/steps/publish-to-dev-feed.yml
+++ b/eng/pipelines/templates/steps/publish-to-dev-feed.yml
@@ -93,6 +93,7 @@ steps:
       $path = './.work/Usage.md'
 
       $markdown | Out-File -FilePath $path -Encoding utf8
+      Start-Sleep -Seconds 2
       Write-Host "##vso[task.uploadsummary]$(Resolve-Path $path)"
     displayName: "Document dev version usage"
     env:

--- a/eng/pipelines/templates/steps/publish-to-dev-feed.yml
+++ b/eng/pipelines/templates/steps/publish-to-dev-feed.yml
@@ -92,9 +92,10 @@ steps:
       New-Item './.work' -ItemType Directory -Force | Out-Null
       $path = './.work/Usage.md'
 
-      $markdown | Out-File -FilePath $path -Encoding utf8
-      Start-Sleep -Seconds 2
-      Write-Host "##vso[task.uploadsummary]$(Resolve-Path $path)"
+      Set-Content -Path $path -Value $markdown -Encoding utf8
+      $file = Get-Item $path
+      Write-Host "Wrote summary to $($file.FullName). Uploading..."
+      Write-Host "##vso[task.uploadsummary]$($file.FullName)"
     displayName: "Document dev version usage"
     env:
       REGISTRY_URL: ${{parameters.Registry}}


### PR DESCRIPTION
## What does this PR do?
Fix a release issue where uploading the dev feed summary fails after writing the file.

Wait 2 seconds between writing the file and uploading it.
Use the full file path in the upload statement.