### PR TITLE
Fix types for input schema when calling `tools/list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## 0.1.1 (Unreleased)
 
 ### Features Added
-
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Fixed return value of `tools/list` to use JSON object names. https://github.com/Azure/azure-mcp/pull/275
 
 ### Other Changes
 

--- a/src/Commands/Server/ToolOperations.cs
+++ b/src/Commands/Server/ToolOperations.cs
@@ -146,7 +146,6 @@ public class ToolOperations
 
         var options = command.GetCommand().Options;
 
-
         var schema = new JsonObject
         {
             ["type"] = "object"
@@ -159,7 +158,7 @@ public class ToolOperations
             {
                 arguments.Add(option.Name, new JsonObject()
                 {
-                    ["type"] = option.ValueType.ToString().ToLower(),
+                    ["type"] = option.ValueType.ToJsonType(),
                     ["description"] = option.Description,
                 });
             }

--- a/src/Commands/Server/TypeToJsonTypeMapper.cs
+++ b/src/Commands/Server/TypeToJsonTypeMapper.cs
@@ -69,7 +69,7 @@ public static class TypeToJsonTypeMapper
 
         if (type.IsEnum)
         {
-            return "string"; // or integer
+            return "integer";
         }
 
         return "object";

--- a/src/Commands/Server/TypeToJsonTypeMapper.cs
+++ b/src/Commands/Server/TypeToJsonTypeMapper.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+
+namespace AzureMcp.Commands.Server;
+
+/// <summary>
+/// Gets the JSON object type based on its C# type.
+/// </summary>
+public static class TypeToJsonTypeMapper
+{
+    private static readonly Dictionary<Type, string> TypeToJsonMap = new()
+    {
+        // String types
+        { typeof(string), "string" },
+        { typeof(char), "string" },
+        { typeof(Guid), "string" },
+        { typeof(DateTime), "string" },
+        { typeof(DateTimeOffset), "string" },
+        { typeof(TimeSpan), "string" },
+        { typeof(Uri), "string" },
+        
+        // Number types
+        { typeof(int), "integer" },
+        { typeof(uint), "integer" },
+        { typeof(long), "integer" },
+        { typeof(ulong), "integer" },
+        { typeof(short), "integer" },
+        { typeof(ushort), "integer" },
+        { typeof(byte), "integer" },
+        { typeof(sbyte), "integer" },
+
+        { typeof(float), "number" },
+        { typeof(double), "number" },
+        { typeof(decimal), "number" },
+        
+        // Boolean
+        { typeof(bool), "boolean" },
+        
+        // Arrays and collections
+        { typeof(Array), "array" },
+        
+        // Object
+        { typeof(object), "object" }
+    };
+
+    /// <summary>
+    /// Gets the JSON type name based on the given type.  If <paramref name="type"/> is null, then "null" is returned.
+    /// </summary>
+    /// <param name="type">Type to get JSON type name from.</param>
+    /// <returns></returns>
+    public static string ToJsonType(this Type? type)
+    {
+        if (type == null)
+        {
+            return "null";
+        }
+
+        if (TypeToJsonMap.TryGetValue(type, out string? jsonType) && jsonType != null)
+        {
+            return jsonType;
+        }
+
+        if (typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string))
+        {
+            return typeof(IDictionary).IsAssignableFrom(type) ? "object" : "array";
+        }
+
+        if (type.IsEnum)
+        {
+            return "string"; // or integer
+        }
+
+        return "object";
+    }
+}

--- a/tests/Commands/Server/ToolOperationsTest.cs
+++ b/tests/Commands/Server/ToolOperationsTest.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
+using System.Xml.Linq;
 using AzureMcp.Commands;
 using AzureMcp.Commands.Server;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
@@ -13,6 +16,18 @@ using Xunit;
 namespace AzureMcp.Tests.Commands.Server;
 public class ToolOperationsTest
 {
+    // https://json-schema.org/understanding-json-schema/reference/type
+    private static readonly HashSet<string> JsonSchemaDataTypes = new()
+    {
+        "string",
+        "integer",
+        "number",
+        "boolean",
+        "array",
+        "null",
+        "object"
+    };
+
     private readonly CommandFactory _commandFactory;
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<ToolOperations> _logger;
@@ -48,6 +63,31 @@ public class ToolOperationsTest
             Assert.NotNull(tool);
             Assert.NotNull(tool.Name);
             Assert.NotNull(tool.Description!);
+
+            Assert.Equal(JsonValueKind.Object, tool.InputSchema.ValueKind);
+
+            foreach (var properties in tool.InputSchema.EnumerateObject())
+            {
+                if (properties.NameEquals("type"))
+                {
+                    Assert.Equal("object", properties.Value.GetString());
+                }
+
+                if (!properties.NameEquals("properties"))
+                {
+                    continue;
+                }
+
+                var commandArguments = properties.Value.EnumerateObject().ToArray();
+                foreach (var argument in commandArguments)
+                {
+                    var argumentType = argument.Value.GetProperty("type");
+                    var value = argumentType.GetString();
+
+                    Assert.NotNull(value);
+                    Assert.Contains(value, JsonSchemaDataTypes);
+                }
+            }
         }
     }
 }

--- a/tests/Commands/Server/ToolOperationsTest.cs
+++ b/tests/Commands/Server/ToolOperationsTest.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using System.Xml.Linq;
 using AzureMcp.Commands;
 using AzureMcp.Commands.Server;
-using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;

--- a/tests/Commands/Server/TypeToJsonTypeMapperTests.cs
+++ b/tests/Commands/Server/TypeToJsonTypeMapperTests.cs
@@ -1,0 +1,258 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections;
+using AzureMcp.Commands.Server;
+using Xunit;
+
+namespace AzureMcp.Tests.Commands.Server;
+
+public class TypeToJsonTypeMapperTests
+{
+    [Fact]
+    public void ToJsonType_WithNullType_ReturnsNull()
+    {
+        // Arrange
+        Type? nullType = null;
+
+        // Act
+        var result = nullType.ToJsonType();
+
+        // Assert
+        Assert.Equal("null", result);
+    }
+
+    [Theory]
+    [InlineData(typeof(string), "string")]
+    [InlineData(typeof(char), "string")]
+    [InlineData(typeof(Guid), "string")]
+    [InlineData(typeof(DateTime), "string")]
+    [InlineData(typeof(DateTimeOffset), "string")]
+    [InlineData(typeof(TimeSpan), "string")]
+    [InlineData(typeof(Uri), "string")]
+    public void ToJsonType_WithStringTypes_ReturnsString(Type type, string expected)
+    {
+        // Act
+        var result = type.ToJsonType();
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(typeof(int), "integer")]
+    [InlineData(typeof(uint), "integer")]
+    [InlineData(typeof(long), "integer")]
+    [InlineData(typeof(ulong), "integer")]
+    [InlineData(typeof(short), "integer")]
+    [InlineData(typeof(ushort), "integer")]
+    [InlineData(typeof(byte), "integer")]
+    [InlineData(typeof(sbyte), "integer")]
+    public void ToJsonType_WithIntegerTypes_ReturnsInteger(Type type, string expected)
+    {
+        // Act
+        var result = type.ToJsonType();
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(typeof(float), "number")]
+    [InlineData(typeof(double), "number")]
+    [InlineData(typeof(decimal), "number")]
+    public void ToJsonType_WithNumberTypes_ReturnsNumber(Type type, string expected)
+    {
+        // Act
+        var result = type.ToJsonType();
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToJsonType_WithBooleanType_ReturnsBoolean()
+    {
+        // Act
+        var result = typeof(bool).ToJsonType();
+
+        // Assert
+        Assert.Equal("boolean", result);
+    }
+
+    [Fact]
+    public void ToJsonType_WithArrayType_ReturnsArray()
+    {
+        // Act
+        var result = typeof(Array).ToJsonType();
+
+        // Assert
+        Assert.Equal("array", result);
+
+        var someArray = new[] { 1, 2, 3 }.GetType();
+
+        Assert.Equal("array", someArray.ToJsonType());
+    }
+
+    [Fact]
+    public void ToJsonType_WithArrayType_ReturnsArray2()
+    {
+        // Act
+        var someArray = new[] { 1, 2, 3 }.GetType();
+
+        // Assert
+        Assert.Equal("array", someArray.ToJsonType());
+    }
+
+
+    [Fact]
+    public void ToJsonType_WithObjectType_ReturnsObject()
+    {
+        // Act
+        var result = typeof(object).ToJsonType();
+
+        // Assert
+        Assert.Equal("object", result);
+    }
+
+    [Theory]
+    [InlineData(typeof(int[]))]
+    [InlineData(typeof(string[]))]
+    [InlineData(typeof(List<int>))]
+    [InlineData(typeof(IList<string>))]
+    [InlineData(typeof(ICollection<object>))]
+    [InlineData(typeof(IEnumerable<int>))]
+    [InlineData(typeof(ArrayList))]
+    public void ToJsonType_WithCollectionTypes_ReturnsArray(Type type)
+    {
+        // Act
+        var result = type.ToJsonType();
+
+        // Assert
+        Assert.Equal("array", result);
+    }
+
+    [Fact]
+    public void ToJsonType_WithStringType_ReturnsString_NotArray()
+    {
+        // Note: string implements IEnumerable<char> but should return "string", not "array"
+        // Act
+        var result = typeof(string).ToJsonType();
+
+        // Assert
+        Assert.Equal("string", result);
+    }
+
+    public enum TestEnum
+    {
+        Value1,
+        Value2
+    }
+
+    [Fact]
+    public void ToJsonType_WithEnumType_ReturnsString()
+    {
+        // Act
+        var result = typeof(TestEnum).ToJsonType();
+
+        // Assert
+        Assert.Equal("string", result);
+    }
+
+    [Theory]
+    [InlineData(typeof(ConsoleColor))]
+    [InlineData(typeof(DayOfWeek))]
+    [InlineData(typeof(FileAttributes))]
+    public void ToJsonType_WithBuiltInEnumTypes_ReturnsString(Type enumType)
+    {
+        // Act
+        var result = enumType.ToJsonType();
+
+        // Assert
+        Assert.Equal("string", result);
+    }
+
+    public class CustomClass
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public struct CustomStruct
+    {
+        public int Value { get; set; }
+    }
+
+    public interface ICustomInterface
+    {
+        void DoSomething();
+    }
+
+    [Theory]
+    [InlineData(typeof(CustomClass))]
+    [InlineData(typeof(CustomStruct))]
+    [InlineData(typeof(ICustomInterface))]
+    [InlineData(typeof(Exception))]
+    [InlineData(typeof(Stream))]
+    public void ToJsonType_WithCustomTypes_ReturnsObject(Type type)
+    {
+        // Act
+        var result = type.ToJsonType();
+
+        // Assert
+        Assert.Equal("object", result);
+    }
+
+    [Theory]
+    [InlineData(typeof(int?))]
+    [InlineData(typeof(bool?))]
+    [InlineData(typeof(DateTime?))]
+    [InlineData(typeof(TestEnum?))]
+    public void ToJsonType_WithNullableTypes_ReturnsObject(Type nullableType)
+    {
+        // Nullable types are not in the dictionary and don't fall into other categories
+        // Act
+        var result = nullableType.ToJsonType();
+
+        // Assert
+        Assert.Equal("object", result);
+    }
+
+    [Fact]
+    public void ToJsonType_WithGenericType_ReturnsObject()
+    {
+        // Act
+        var result = typeof(Dictionary<string, int>).ToJsonType();
+
+        // Assert
+        Assert.Equal("object", result);
+    }
+
+    [Fact]
+    public void ToJsonType_WithNestedGenericType_ReturnsObject()
+    {
+        // Act
+        var result = typeof(Dictionary<string, List<int>>).ToJsonType();
+
+        // Assert
+        Assert.Equal("object", result);
+    }
+
+    [Fact]
+    public void ToJsonType_WithMultidimensionalArray_ReturnsArray()
+    {
+        // Act
+        var result = typeof(int[,]).ToJsonType();
+
+        // Assert
+        Assert.Equal("array", result);
+    }
+
+    [Fact]
+    public void ToJsonType_WithJaggedArray_ReturnsArray()
+    {
+        // Act
+        var result = typeof(int[][]).ToJsonType();
+
+        // Assert
+        Assert.Equal("array", result);
+    }
+}

--- a/tests/Commands/Server/TypeToJsonTypeMapperTests.cs
+++ b/tests/Commands/Server/TypeToJsonTypeMapperTests.cs
@@ -155,7 +155,7 @@ public class TypeToJsonTypeMapperTests
         var result = typeof(TestEnum).ToJsonType();
 
         // Assert
-        Assert.Equal("string", result);
+        Assert.Equal("integer", result);
     }
 
     [Theory]
@@ -168,7 +168,7 @@ public class TypeToJsonTypeMapperTests
         var result = enumType.ToJsonType();
 
         // Assert
-        Assert.Equal("string", result);
+        Assert.Equal("integer", result);
     }
 
     public class CustomClass


### PR DESCRIPTION
## What does this PR do?

* Fixes the return type names for inputSchema when calling `tools/list`.
* It would call Type.ToString() returning the full type name (i.e. system.string, azure.mcp.server.model) rather than the JSON type.

## GitHub issue number?

Fixes #270 #267 

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If it's a core feature, I have added thorough tests.
- [x] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [x] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [x] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
