### PR TITLE
Temporarily skip monitor logs query test

### DIFF
--- a/tests/Client/MonitorCommandTests.cs
+++ b/tests/Client/MonitorCommandTests.cs
@@ -76,7 +76,7 @@ public class MonitorCommandTests(LiveTestFixture fixture, ITestOutputHelper outp
         Assert.NotEmpty(array);
     }
 
-    [Fact()]
+    [Fact(Skip = "Temporary skip to fix the test")]
     [Trait("Category", "Live")]
     public async Task Should_query_monitor_logs()
     {


### PR DESCRIPTION
Skip the monitor logs query test to address existing issues.