### PR TITLE
Add Postgres team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -99,6 +99,15 @@
 # ServiceOwners:                       @smritiy @srnagar @jongio
 
 
+# PRLabel: %area-Postgres
+/src/Options/Postgres/                  @kk-src @shreyaaithal @maxluk @xiangyan99 @Azure/azure-mcp
+/src/Commands/Postgres/                 @kk-src @shreyaaithal @maxluk @xiangyan99 @Azure/azure-mcp
+/src/Services/Azure/Postgres/           @kk-src @shreyaaithal @maxluk @xiangyan99 @Azure/azure-mcp
+ 
+# ServiceLabel: %area-Postgres
+# ServiceOwners:                       @kk-src @shreyaaithal @maxluk
+
+
 # PRLabel: %area-Search
 /src/Options/Search/                  @pablocastro @jongio @Azure/azure-mcp
 /src/Commands/Search/                 @pablocastro @jongio @Azure/azure-mcp


### PR DESCRIPTION
## What does this PR do?

Add Postgres team to CODEOWNERS as they're currently missing.  Without this entry the github auto-assign issue/PR bot won't work for their area label.

Related onboard issue with contacts https://github.com/Azure/azure-mcp-pr/issues/242

## GitHub issue number?

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
