### PR TITLE
[Draft]: Add Application Insights commands for diagose

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Azure.Monitor.Ingestion" Version="1.1.2" />
     <PackageVersion Include="Azure.Monitor.Query" Version="1.6.0" />
     <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.4.0" />
+    <PackageVersion Include="Azure.ResourceManager.ApplicationInsights" Version="1.0.1" />
     <PackageVersion Include="Azure.ResourceManager.Kusto" Version="1.6.0" />
     <PackageVersion Include="Azure.ResourceManager.PostgreSql" Version="1.2.0" />
     <PackageVersion Include="Azure.ResourceManager.Redis" Version="1.5.0" />

--- a/src/AzureMcp.csproj
+++ b/src/AzureMcp.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" />
     <PackageReference Include="Azure.Monitor.Query" />
     <PackageReference Include="Azure.ResourceManager.AppConfiguration" />
+    <PackageReference Include="Azure.ResourceManager.ApplicationInsights" />
     <PackageReference Include="Azure.ResourceManager.Kusto" />
     <PackageReference Include="Azure.ResourceManager.PostgreSql" />
     <PackageReference Include="Azure.ResourceManager.Redis" />

--- a/src/Commands/CommandFactory.cs
+++ b/src/Commands/CommandFactory.cs
@@ -248,7 +248,12 @@ public class CommandFactory
         workspaces.AddCommand("list", new Monitor.Workspace.WorkspaceListCommand(GetLogger<Monitor.Workspace.WorkspaceListCommand>()));
         monitorTable.AddCommand("list", new Monitor.Table.TableListCommand(GetLogger<Monitor.Table.TableListCommand>()));
 
-        monitorTableType.AddCommand("list", new Monitor.TableType.TableTypeListCommand(GetLogger<Monitor.TableType.TableTypeListCommand>()));
+        monitorTableType.AddCommand("list", new Monitor.TableType.TableTypeListCommand(GetLogger<Monitor.TableType.TableTypeListCommand>()));        // Application Insights commands
+        var appInsights = new CommandGroup("app", "Application Insights operations - Commands for working with Application Insights resources.");
+        monitor.AddSubGroup(appInsights);
+        
+        appInsights.AddCommand("diagnose", new Monitor.ApplicationInsights.AppDiagnoseCommand(GetLogger<Monitor.ApplicationInsights.AppDiagnoseCommand>()));
+        appInsights.AddCommand("trace", new Monitor.ApplicationInsights.AppTraceCommand(GetLogger<Monitor.ApplicationInsights.AppTraceCommand>()));
 
         var health = new CommandGroup("healthmodels", "Azure Monitor Health Models operations - Commands for working with Azure Monitor Health Models.");
         monitor.AddSubGroup(health);
@@ -456,7 +461,7 @@ public class CommandFactory
         {
             _logger.LogTrace("Executing '{Command}'.", command.Name);
 
-            var cmdContext = new CommandContext(_serviceProvider);
+            var cmdContext = new CommandContext(_serviceProvider, null);
             var startTime = DateTime.UtcNow;
             try
             {

--- a/src/Commands/Monitor/ApplicationInsights/AppDiagnoseCommand.cs
+++ b/src/Commands/Monitor/ApplicationInsights/AppDiagnoseCommand.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using AzureMcp.Commands.Monitor.ApplicationInsights;
+using AzureMcp.Models;
+using AzureMcp.Models.Monitor;
+using AzureMcp.Models.Option;
+using AzureMcp.Options.Monitor.ApplicationInsights;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Commands.Monitor.ApplicationInsights;
+
+public sealed class AppDiagnoseCommand(ILogger<AppDiagnoseCommand> logger) 
+    : BaseApplicationInsightsCommand<AppDiagnoseOptions>
+{
+    private const string _commandTitle = "Diagnose App with Application Insights";
+    private readonly ILogger<AppDiagnoseCommand> _logger = logger;
+
+    private readonly Option<string> _startTimeOption = OptionDefinitions.Monitor.StartTime;
+    private readonly Option<string> _endTimeOption = OptionDefinitions.Monitor.EndTime;
+    private readonly Option<string> _symptomsOption = OptionDefinitions.Monitor.Symptoms;
+
+    public override string Name => "diagnose";
+
+    public override string Description =>
+        $"""
+        Diagnose an issue with an application using Application Insights. This tool can be used to diagnose issues such as slow performance, failing requests, or availability problems.
+        Returns a list of detected issues with trace and span IDs for drilling into distributed traces to uncover the root cause.
+        Required options:
+        - --{OptionDefinitions.Monitor.AppIdName}: {OptionDefinitions.Monitor.AppId.Description}
+        - --{OptionDefinitions.Monitor.SymptomsName}: {OptionDefinitions.Monitor.Symptoms.Description}
+        Optional parameters:
+        - --{OptionDefinitions.Monitor.StartTimeName}: {OptionDefinitions.Monitor.StartTime.Description}
+        - --{OptionDefinitions.Monitor.EndTimeName}: {OptionDefinitions.Monitor.EndTime.Description}
+        """;
+
+    public override string Title => _commandTitle;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_startTimeOption);
+        command.AddOption(_endTimeOption);
+        command.AddOption(_symptomsOption);
+    }    
+    
+    protected override AppDiagnoseOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.StartTime = parseResult.GetValueForOption(_startTimeOption);
+        options.EndTime = parseResult.GetValueForOption(_endTimeOption);
+        options.Symptoms = parseResult.GetValueForOption(_symptomsOption);
+        return options;
+    }
+
+    [McpServerTool(
+        Destructive = false,
+        ReadOnly = true,
+        Title = _commandTitle)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            // Required validation step
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            // Get the Application Insights service from DI
+            var service = context.GetService<IApplicationInsightsService>();
+            
+            // Execute the command and get the results
+            var diagnosticResults = await service.DiagnoseApplicationAsync(
+                context.Server,
+                options.Subscription!,
+                options.AppId!,
+                options.Symptoms!,
+                options.StartTime,
+                options.EndTime,
+                options.Tenant,
+                options.RetryPolicy);
+
+            // Set the response
+            context.Response.Results = diagnosticResults.Count > 0 ?
+                ResponseResult.Create(new AppDiagnoseCommandResult(diagnosticResults), MonitorJsonContext.Default.AppDiagnoseCommandResult) :
+                null;
+            return context.Response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error diagnosing Application Insights application: {AppId}", options.AppId);
+            HandleException(context.Response, ex);
+            return context.Response;
+        }
+    }
+
+    // Result model for the command
+    internal record AppDiagnoseCommandResult(List<JsonNode> Results);
+}

--- a/src/Commands/Monitor/ApplicationInsights/AppTraceCommand.cs
+++ b/src/Commands/Monitor/ApplicationInsights/AppTraceCommand.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Models.Monitor.ApplicationInsights;
+using AzureMcp.Models.Option;
+using AzureMcp.Options.Monitor.ApplicationInsights;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Commands.Monitor.ApplicationInsights;
+
+public sealed class AppTraceCommand(ILogger<AppTraceCommand> logger)
+    : BaseApplicationInsightsCommand<AppTraceOptions>
+{
+    private const string _commandTitle = "Get Distributed Trace from Application Insights";
+    private readonly ILogger<AppTraceCommand> _logger = logger;
+
+    // Define options from OptionDefinitions
+    private readonly Option<string> _traceIdOption = OptionDefinitions.Monitor.TraceId;
+    private readonly Option<string> _spanIdOption = OptionDefinitions.Monitor.SpanId;
+    private readonly Option<string> _startTimeOption = OptionDefinitions.Monitor.StartTime;
+    private readonly Option<string> _endTimeOption = OptionDefinitions.Monitor.EndTime;
+
+    public override string Name => "trace";
+
+    public override string Description =>
+        $"""
+        Get a distributed trace from Application Insights by trace ID and span ID. This command retrieves detailed span information including timing, dependencies, and properties.
+        Returns the hierarchical trace structure with all spans and their relationships.
+        Required options:
+        - {OptionDefinitions.Monitor.AppIdName}: {OptionDefinitions.Monitor.AppId.Description}
+        - {OptionDefinitions.Monitor.TraceIdName}: {OptionDefinitions.Monitor.TraceId.Description}
+        - {OptionDefinitions.Monitor.SpanIdName}: {OptionDefinitions.Monitor.SpanId.Description}
+        Optional parameters:
+        - {OptionDefinitions.Monitor.StartTimeName}: {OptionDefinitions.Monitor.StartTime.Description}
+        - {OptionDefinitions.Monitor.EndTimeName}: {OptionDefinitions.Monitor.EndTime.Description}
+        """;
+
+    public override string Title => _commandTitle;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_traceIdOption);
+        command.AddOption(_spanIdOption);
+        command.AddOption(_startTimeOption);
+        command.AddOption(_endTimeOption);
+    }
+
+    protected override AppTraceOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.TraceId = parseResult.GetValueForOption(_traceIdOption);
+        options.SpanId = parseResult.GetValueForOption(_spanIdOption);
+        options.StartTime = parseResult.GetValueForOption(_startTimeOption);
+        options.EndTime = parseResult.GetValueForOption(_endTimeOption);
+        return options;
+    }
+
+    [McpServerTool(
+        Destructive = false,
+        ReadOnly = true,
+        Title = _commandTitle)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            // Required validation step
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            // Get the Application Insights service from DI
+            var service = context.GetService<IApplicationInsightsService>();
+
+            // Execute the command and get the results
+            var traceResult = await service.GetDistributedTraceAsync(
+                options.Subscription!,
+                options.AppId!,
+                options.TraceId!,
+                options.SpanId!,
+                options.StartTime,
+                options.EndTime,
+                options.Tenant,
+                options.RetryPolicy);
+
+            // Set the response
+            context.Response.Results = ResponseResult.Create(
+                new AppTraceCommandResult(traceResult),
+                MonitorJsonContext.Default.AppTraceCommandResult);
+            return context.Response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving distributed trace: TraceId={TraceId}, SpanId={SpanId}, AppId={AppId}",
+                options.TraceId, options.SpanId, options.AppId);
+            HandleException(context.Response, ex);
+            return context.Response;
+        }
+    }
+
+    // Define specialized error handling if needed
+    protected override string GetErrorMessage(Exception ex) => ex switch
+    {
+        InvalidOperationException invEx when invEx.Message.Contains("Could not find Application Insights") => 
+            $"The specified Application Insights resource was not found. Please check the AppId and your permissions.",
+        _ => base.GetErrorMessage(ex)
+    };
+
+    // Result model for the command
+    internal record AppTraceCommandResult(DistributedTraceResult Result);
+}

--- a/src/Commands/Monitor/ApplicationInsights/BaseApplicationInsightsCommand.cs
+++ b/src/Commands/Monitor/ApplicationInsights/BaseApplicationInsightsCommand.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using AzureMcp.Commands.Subscription;
+using AzureMcp.Models.Option;
+using AzureMcp.Options;
+using AzureMcp.Options.Monitor.ApplicationInsights;
+
+namespace AzureMcp.Commands.Monitor.ApplicationInsights;
+
+public abstract class BaseApplicationInsightsCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions>
+    : SubscriptionCommand<TOptions>
+    where TOptions : SubscriptionOptions, IApplicationInsightsOptions, new()
+{
+    protected readonly Option<string> _appIdOption = OptionDefinitions.Monitor.AppId;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_appIdOption);
+    }
+
+    protected override TOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        
+        // Cast to the right interface that has the AppId property
+        if (options is AppTraceOptions traceOptions)
+        {
+            traceOptions.AppId = parseResult.GetValueForOption(_appIdOption);
+        }
+        else if (options is AppDiagnoseOptions diagnoseOptions)
+        {
+            diagnoseOptions.AppId = parseResult.GetValueForOption(_appIdOption);
+        }
+        
+        return options;
+    }
+}

--- a/src/Commands/Monitor/MonitorJsonContext.cs
+++ b/src/Commands/Monitor/MonitorJsonContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using AzureMcp.Commands.Monitor.ApplicationInsights;
 using AzureMcp.Commands.Monitor.TableType;
 using AzureMcp.Commands.Monitor.Workspace;
 
@@ -10,6 +11,8 @@ namespace AzureMcp.Commands.Monitor;
 [JsonSerializable(typeof(WorkspaceListCommand.WorkspaceListCommandResult))]
 [JsonSerializable(typeof(Table.TableListCommand.TableListCommandResult))]
 [JsonSerializable(typeof(TableTypeListCommand.TableTypeListCommandResult))]
+[JsonSerializable(typeof(AppDiagnoseCommand.AppDiagnoseCommandResult))]
+[JsonSerializable(typeof(AppTraceCommand.AppTraceCommandResult))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class MonitorJsonContext : JsonSerializerContext
 {

--- a/src/Commands/Server/ToolOperations.cs
+++ b/src/Commands/Server/ToolOperations.cs
@@ -100,7 +100,7 @@ public class ToolOperations
             };
         }
 
-        var commandContext = new CommandContext(_serviceProvider);
+        var commandContext = new CommandContext(_serviceProvider, parameters.Server);
 
         var args = parameters.Params.Arguments != null
             ? string.Join(" ", parameters.Params.Arguments.Select(kvp => $"--{kvp.Key} \"{(kvp.Value).ToString().Replace("\"", "'")}\""))

--- a/src/Models/Command/CommandContext.cs
+++ b/src/Models/Command/CommandContext.cs
@@ -21,12 +21,18 @@ public class CommandContext
     public CommandResponse Response { get; }
 
     /// <summary>
+    /// The server instance that is executing the command. May be null.
+    /// </summary>
+    public IMcpServer? Server { get; }
+
+    /// <summary>
     /// Creates a new command context
     /// </summary>
     /// <param name="serviceProvider">The service provider for dependency injection</param>
-    public CommandContext(IServiceProvider serviceProvider)
+    public CommandContext(IServiceProvider serviceProvider, IMcpServer? server = null)
     {
         _serviceProvider = serviceProvider;
+        Server = server;
         Response = new CommandResponse
         {
             Status = 200,

--- a/src/Models/Monitor/ApplicationDiagnosticResult.cs
+++ b/src/Models/Monitor/ApplicationDiagnosticResult.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace AzureMcp.Models.Monitor;
+
+public class ApplicationDiagnosticResult
+{
+    [JsonPropertyName("operationName")]
+    public string OperationName { get; set; } = string.Empty;
+    
+    [JsonPropertyName("resultCode")]
+    public string ResultCode { get; set; } = string.Empty;
+    
+    [JsonPropertyName("itemType")]
+    public string ItemType { get; set; } = string.Empty;
+    
+    [JsonPropertyName("failedRequestCount")]
+    public int FailedRequestCount { get; set; }
+    
+    [JsonPropertyName("traces")]
+    public List<TraceInfo> Traces { get; set; } = new List<TraceInfo>();
+}
+
+public class TraceInfo
+{
+    [JsonPropertyName("traceId")]
+    public string TraceId { get; set; } = string.Empty;
+    
+    [JsonPropertyName("spanId")]
+    public string SpanId { get; set; } = string.Empty;
+}

--- a/src/Models/Monitor/ApplicationInsights/ApplicationInsightsResourceInfo.cs
+++ b/src/Models/Monitor/ApplicationInsights/ApplicationInsightsResourceInfo.cs
@@ -1,0 +1,12 @@
+﻿using Azure.Core;
+
+namespace AzureMcp.Models.Monitor.ApplicationInsights
+{
+    public class ApplicationInsightsResourceInfo
+    {
+        public required string Name { get; set; }
+        public required ResourceIdentifier ResourceId { get; set; }
+        public required string AppId { get; set; }
+        public required string InstrumentationKey { get; set; }
+    }
+}

--- a/src/Models/Monitor/ApplicationInsights/DistributedTraceResult.cs
+++ b/src/Models/Monitor/ApplicationInsights/DistributedTraceResult.cs
@@ -1,0 +1,49 @@
+﻿using System.Text.Json.Serialization;
+
+namespace AzureMcp.Models.Monitor.ApplicationInsights
+{
+    public class DistributedTraceResult
+    {
+        [JsonPropertyName("traceId")]
+        public string TraceId { get; set; } = string.Empty;
+
+        [JsonPropertyName("spans")]
+        public List<SpanDetails> Spans { get; set; } = new List<SpanDetails>();
+    }
+
+    public class SpanDetails
+    {
+        [JsonPropertyName("spanId")]
+        public string SpanId { get; set; } = string.Empty;
+
+        [JsonPropertyName("parentId")]
+        public string ParentId { get; set; } = string.Empty;
+
+        [JsonPropertyName("operationName")]
+        public string OperationName { get; set; } = string.Empty;
+
+        [JsonPropertyName("responseCode")]
+        public string ResponseCode { get; set; } = string.Empty;
+
+        [JsonPropertyName("itemType")]
+        public string ItemType { get; set; } = string.Empty;
+
+        [JsonPropertyName("isSuccessful")]
+        public bool IsSuccessful { get; set; }
+
+        [JsonPropertyName("startTime")]
+        public DateTime StartTime { get; set; }
+
+        [JsonPropertyName("endTime")]
+        public DateTime EndTime { get; set; }
+
+        [JsonPropertyName("duration")]
+        public TimeSpan Duration { get; set; }
+
+        [JsonPropertyName("properties")]
+        public List<KeyValuePair<string, string>> Properties { get; set; } = new List<KeyValuePair<string, string>>();
+
+        [JsonPropertyName("childSpans")]
+        public List<SpanDetails> ChildSpans { get; set; } = new List<SpanDetails>();
+    }
+}

--- a/src/Models/Monitor/LogsQueryTable.cs
+++ b/src/Models/Monitor/LogsQueryTable.cs
@@ -1,0 +1,8 @@
+﻿
+namespace AzureMcp.Models.Monitor
+{
+    public class LogsQueryTable
+    {
+        public List<Dictionary<string, object>> Rows { get; set; } = new List<Dictionary<string, object>>();
+    }
+}

--- a/src/Models/Option/OptionDefinitions.cs
+++ b/src/Models/Option/OptionDefinitions.cs
@@ -286,7 +286,13 @@ public static class OptionDefinitions
         public const string TableTypeName = "table-type";
         public const string QueryTextName = "query";
         public const string HoursName = "hours";
-        public const string LimitName = "limit";
+        public const string LimitName = "limit";        
+        public const string AppIdName = "app-id";
+        public const string StartTimeName = "start-time";
+        public const string EndTimeName = "end-time";
+        public const string SymptomsName = "symptoms";
+        public const string TraceIdName = "trace-id";
+        public const string SpanIdName = "span-id";
 
         public const string EntityName = "entity";
         public const string HealthModelName = "model-name";
@@ -340,6 +346,56 @@ public static class OptionDefinitions
             $"--{LimitName}",
             () => 20,
             "The maximum number of results to return."
+        )
+        {
+            IsRequired = true
+        };
+
+        public static readonly Option<string> AppId = new(
+            $"--{AppIdName}",
+            "The Application Insights Instrumentation Key, App ID or name. This can be either the Application Insights instrumentation key, the unique identifier (GUID) or the display name of your Application Insights resource."
+        )
+        {
+            IsRequired = true
+        };
+
+        public static readonly Option<string> StartTime = new(
+            $"--{StartTimeName}",
+            () => DateTime.UtcNow.AddHours(-24).ToString("o"),
+            "The start time of the investigation in ISO format (e.g., 2023-01-01T00:00:00Z)"
+        )
+        {
+            IsRequired = false
+        };
+
+        public static readonly Option<string> EndTime = new(
+            $"--{EndTimeName}",
+            () => DateTime.UtcNow.ToString("o"),
+            "The end time of the investigation in ISO format (e.g., 2023-01-01T00:00:00Z)"
+        )
+        {
+            IsRequired = false
+        };
+
+        public static readonly Option<string> Symptoms = new(
+            $"--{SymptomsName}",
+            "Description of the symptoms the application is experiencing. This should be a concise description of the issue with details of the symptoms. (e.g. 'requests are failing with 500 errors')"
+        )
+        {
+            IsRequired = true
+        };
+
+        public static readonly Option<string> TraceId = new(
+            $"--{TraceIdName}",
+            "The trace ID of the distributed trace to retrieve from Application Insights."
+        )
+        {
+            IsRequired = true
+        };
+
+        public static readonly Option<string> SpanId = new(
+            $"--{SpanIdName}",
+            "The span ID of the distributed trace to retrieve from Application Insights."
         )
         {
             IsRequired = true

--- a/src/Options/Monitor/ApplicationInsights/AppDiagnoseOptions.cs
+++ b/src/Options/Monitor/ApplicationInsights/AppDiagnoseOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using AzureMcp.Models.Option;
+
+namespace AzureMcp.Options.Monitor.ApplicationInsights;
+
+public class AppDiagnoseOptions : BaseMonitorOptions, IApplicationInsightsOptions
+{
+    [JsonPropertyName(OptionDefinitions.Monitor.AppIdName)]
+    public string? AppId { get; set; }
+    
+    [JsonPropertyName(OptionDefinitions.Monitor.StartTimeName)]
+    public string? StartTime { get; set; }
+    
+    [JsonPropertyName(OptionDefinitions.Monitor.EndTimeName)]
+    public string? EndTime { get; set; }
+
+    [JsonPropertyName(OptionDefinitions.Monitor.SymptomsName)]
+    public string? Symptoms { get; set; }
+}

--- a/src/Options/Monitor/ApplicationInsights/AppTraceOptions.cs
+++ b/src/Options/Monitor/ApplicationInsights/AppTraceOptions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using AzureMcp.Models.Option;
+
+namespace AzureMcp.Options.Monitor.ApplicationInsights;
+
+public class AppTraceOptions : BaseMonitorOptions, IApplicationInsightsOptions
+{
+    [JsonPropertyName(OptionDefinitions.Monitor.AppIdName)]
+    public string? AppId { get; set; }
+    
+    [JsonPropertyName("traceId")]
+    public string? TraceId { get; set; }
+    
+    [JsonPropertyName("spanId")]
+    public string? SpanId { get; set; }
+    
+    [JsonPropertyName(OptionDefinitions.Monitor.StartTimeName)]
+    public string? StartTime { get; set; }
+    
+    [JsonPropertyName(OptionDefinitions.Monitor.EndTimeName)]
+    public string? EndTime { get; set; }
+}

--- a/src/Options/Monitor/ApplicationInsights/IApplicationInsightsOptions.cs
+++ b/src/Options/Monitor/ApplicationInsights/IApplicationInsightsOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace AzureMcp.Options.Monitor.ApplicationInsights
+{
+    public interface IApplicationInsightsOptions
+    {
+        string? AppId { get; set; }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -62,7 +62,7 @@ internal class Program
 
         builder.AddMiddleware(async (context, next) =>
         {
-            var commandContext = new CommandContext(serviceProvider);
+            var commandContext = new CommandContext(serviceProvider, null);
             var command = context.ParseResult.CommandResult.Command;
             if (command.Handler is IBaseCommand baseCommand)
             {
@@ -99,6 +99,8 @@ internal class Program
         services.AddSingleton<IStorageService, StorageService>();
         services.AddSingleton<IMonitorService, MonitorService>();
         services.AddSingleton<IMonitorHealthModelService, MonitorHealthModelService>();
+        services.AddSingleton<IApplicationInsightsService, ApplicationInsightsService>();
+        services.AddSingleton<ILogsQueryService, LogsQueryService>();
         services.AddSingleton<IResourceGroupService, ResourceGroupService>();
         services.AddSingleton<IAppConfigService, AppConfigService>();
         services.AddSingleton<ISearchService, SearchService>();

--- a/src/Services/Azure/Monitor/ApplicationInsightsService.cs
+++ b/src/Services/Azure/Monitor/ApplicationInsightsService.cs
@@ -1,0 +1,523 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+using System.Threading;
+using Azure.Core;
+using Azure.Monitor.Query;
+using Azure.ResourceManager.ApplicationInsights;
+using AzureMcp.Commands.Server.Tools;
+using AzureMcp.Models.Monitor.ApplicationInsights;
+using AzureMcp.Options;
+using AzureMcp.Services.Interfaces;
+using ModelContextProtocol.Protocol;
+
+namespace AzureMcp.Services.Azure.Monitor;
+
+public class ApplicationInsightsService(ISubscriptionService subscriptionService, ITenantService tenantService, ILogsQueryService logsQueryService) : BaseAzureService(tenantService), IApplicationInsightsService
+{
+    private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
+    private readonly ILogsQueryService _logsQueryService = logsQueryService ?? throw new ArgumentNullException(nameof(logsQueryService));
+
+    private static readonly StandardFields _standardFields = new StandardFields();
+    // TODO: Add call to DT Indexer to get the full list of resource IDs.
+    private const string DistributedTraceQueryTemplate = @"union requests, dependencies, exceptions, (availabilityResults | extend success=iff(success=='1', true, false))
+| where timestamp > datetime(""{{startTime}}"") and timestamp < datetime(""{{endTime}}"")
+| where operation_Id == ""{{traceId}}""
+| project-away customMeasurements, _ResourceId, itemCount, client_Type, client_Model, client_OS, client_IP, client_City, client_StateOrProvince, client_CountryOrRegion, client_Browser, appId, appName, iKey, sdkVersion";
+
+    private class StandardFields
+    {
+        public IEnumerable<string> Values => StandardFieldValues;
+
+        public static List<string> StandardFieldValues = new List<string>();
+
+        public string Id = AddValue("id");
+        public string OperationParentId = AddValue("operation_ParentId");
+        public string OperationName = AddValue("operation_Name");
+        public string ResultCode = AddValue("resultCode");
+        public string ItemType = AddValue("itemType");
+        public string Success = AddValue("success");
+        public string Timestamp = AddValue("timestamp");
+        public string Duration = AddValue("duration");
+        public string OperationId = AddValue("operation_Id");
+
+        public StandardFields()
+        {
+
+        }
+
+        private static string AddValue(string name)
+        {
+            StandardFieldValues.Add(name);
+            return name;
+        }
+    }
+
+    private enum InputType
+    {
+        Requests,
+        Dependencies,
+        AvailabilityResults
+    }
+
+    private enum IssueType
+    {
+        Errors,
+        Latency
+    }
+
+    public async Task<List<JsonNode>> DiagnoseApplicationAsync(
+        IMcpServer? mcpServer,
+        string subscription,
+        string appId,
+        string symptoms,
+        string? startTime = null,
+        string? endTime = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscription, appId, symptoms);
+
+        // Calculate default times if not provided
+        var end = string.IsNullOrEmpty(endTime)
+            ? DateTimeOffset.UtcNow
+            : DateTimeOffset.Parse(endTime);
+
+        var start = string.IsNullOrEmpty(startTime)
+            ? end.AddHours(-24)
+            : DateTimeOffset.Parse(startTime);
+
+        try
+        {
+            var (resourceId, _) = await GetApplicationInsightsInfo(appId, subscription, tenant, retryPolicy);
+
+            (InputType inputType, IssueType issueType) = await GetSourceAndIssueAsync(mcpServer, symptoms, CancellationToken.None);
+
+            // TODO: Implement the actual query logic to diagnose the application
+            return new List<JsonNode>
+            {
+                new JsonObject
+                {
+                    ["inputType"] = inputType.ToString(),
+                    ["issueType"] = issueType.ToString(),
+                    ["resourceId"] = resourceId.ToString(),
+                    ["startTime"] = start.UtcDateTime.ToString("O"),
+                    ["endTime"] = end.UtcDateTime.ToString("O"),
+                    ["symptoms"] = symptoms
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Error diagnosing application: {ex.Message}", ex);
+        }
+        
+    }
+
+    public async Task<DistributedTraceResult> GetDistributedTraceAsync(
+        string subscription,
+        string appId,
+        string traceId,
+        string spanId,
+        string? startTime = null,
+        string? endTime = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscription, appId, traceId, spanId);
+
+        // Calculate default times if not provided
+        var end = string.IsNullOrEmpty(endTime)
+            ? DateTimeOffset.UtcNow
+            : DateTimeOffset.Parse(endTime);
+
+        var start = string.IsNullOrEmpty(startTime)
+            ? end.AddHours(-24)
+            : DateTimeOffset.Parse(startTime);
+
+        try
+        {
+            var (resourceId, _) = await GetApplicationInsightsInfo(appId, subscription, tenant, retryPolicy);
+            var kql = DistributedTraceQueryTemplate
+                .Replace("{{startTime}}", start.UtcDateTime.ToString("O"))
+                .Replace("{{endTime}}", end.UtcDateTime.ToString("O"))
+                .Replace("{{traceId}}", traceId);
+
+            var response = await _logsQueryService.QueryResourceAsync(resourceId, kql, start, end, tenant, retryPolicy);
+            
+            // Create a result object to hold our trace data
+            var result = new DistributedTraceResult
+            {
+                TraceId = traceId,
+                Spans = new List<SpanDetails>()
+            };
+
+            List<SpanDetails> spans = new List<SpanDetails>();
+
+            if (response != null)
+            {
+                // Dictionary to keep track of spans by ID and parent-child relationships
+                var spanMap = new Dictionary<string, SpanDetails>();
+                var parentChildRelationships = new Dictionary<string, List<string>>();
+
+                // Process each row in the query results
+                foreach (var row in response.Rows)
+                {
+                    var currentSpanId = GetStringValue(row, _standardFields.Id, string.Empty);
+                    var parentSpanId = GetStringValue(row, _standardFields.OperationParentId, string.Empty);
+
+                    var spanDetails = new SpanDetails
+                    {
+                        SpanId = currentSpanId,
+                        ParentId = parentSpanId,
+                        OperationName = GetStringValue(row, _standardFields.OperationName, string.Empty),
+                        ResponseCode = GetStringValue(row, _standardFields.ResultCode, string.Empty),
+                        ItemType = GetStringValue(row, _standardFields.ItemType, string.Empty),
+                        IsSuccessful = GetStringValue(row, _standardFields.Success, "true").Equals("true", StringComparison.OrdinalIgnoreCase),
+                        Properties = new List<KeyValuePair<string, string>>(),
+                        ChildSpans = new List<SpanDetails>()
+                    };
+
+                    // Parse datetime fields when present
+                    if (TryGetDateTime(row, _standardFields.Timestamp, out DateTime timestamp))
+                    {
+                        spanDetails.StartTime = timestamp;
+                    }
+
+                    // Try to get duration in milliseconds
+                    if (TryGetDouble(row, _standardFields.Duration, out double durationMs))
+                    {
+                        spanDetails.Duration = TimeSpan.FromMilliseconds(durationMs);
+                        spanDetails.EndTime = spanDetails.StartTime.Add(spanDetails.Duration);
+                    }
+                    else
+                    {
+                        // Default end time if duration isn't available
+                        spanDetails.EndTime = spanDetails.StartTime;
+                    }
+
+                    // Add all other properties as key-value pairs
+                    foreach (var column in row)
+                    {
+                        string columnName = column.Key;
+
+                        if (!IsStandardField(columnName) && column.Value != null)
+                        {
+                            spanDetails.Properties.Add(new KeyValuePair<string, string>(
+                                columnName,
+                                column.Value?.ToString() ?? string.Empty
+                            ));
+                        }
+                    }
+                    // Add the span to our tracking map
+                    spanMap[currentSpanId] = spanDetails;
+                }
+                  // Now we have all spans, we can build the hierarchy
+                BuildSpanHierarchy(spanMap);
+                
+                // Filter to only include the specified span, its ancestors, and direct descendants
+                if (spanMap.TryGetValue(spanId, out var targetSpan))
+                {
+                    // Find all ancestor spans (parents up to the root)
+                    var ancestorSpans = FindAncestorSpans(spanMap, targetSpan);
+                    
+                    // The direct descendants are already in the ChildSpans property after building the hierarchy
+                    var directDescendants = targetSpan.ChildSpans;
+                    
+                    // The result should include the target span, its ancestors, and direct descendants
+                    var filteredSpans = new List<SpanDetails> { targetSpan };
+                    filteredSpans.AddRange(ancestorSpans);
+                    filteredSpans.AddRange(directDescendants);
+                    
+                    // Set the filtered spans to the result
+                    result.Spans = filteredSpans;
+                }
+                else
+                {
+                    // If the specified span wasn't found, return an empty result
+                    result.Spans = new List<SpanDetails>();
+                }
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Error retrieving distributed trace: {ex.Message}", ex);
+        }
+    }
+
+    private static bool SupportsSampling(IMcpServer? server)
+    {
+        return server?.ClientCapabilities?.Sampling != null;
+    }
+
+    private static async Task<(InputType, IssueType)> GetSourceAndIssueAsync(IMcpServer? server, string symptoms, CancellationToken cancellationToken)
+    {
+        if (server == null || !SupportsSampling(server))
+        {
+            // Default to investigating request failures if we don't have ability to sample
+            return (InputType.Requests, IssueType.Errors);
+        }
+
+        // TODO: Progress notification?
+
+        var samplingRequest = new CreateMessageRequestParams
+        {
+            Messages = [
+                new SamplingMessage
+                {
+                    Role = Role.Assistant,
+                    Content = new Content {
+                        Type = "text",
+                        Text = $$"""
+                        Based on the symptoms below, determine the InputType and IssueType.
+
+                        Symptoms
+                        {{symptoms}}
+
+                        InputType options (choose one that best matches the symptoms):
+                        - Inbound - Inbound describes issues with requests being made to the application. For example, a user making a call to the application and getting an error.
+                        - Outbound - Outbound describes issues with requests the application is making to external dependencies. For example, the application calls a SQL database.
+                        - Availability - Availability describes issues with synthetic tests running against the application reporting failures. For example, the availability test for the health endpoint is failing.
+
+                        IssueType options (choose one that best matches the symptoms):
+                        - Slow - Slow describes issues where there is increased response time for an application or the application is behaving slower than expected.
+                        - Failing - Failing describes issues where the application is experiencing errors.
+
+                        Return the output in JSON with the following format:
+                        ```json
+                        {
+                            "inputType": "Inbound|Outbound|Availability",
+                            "issueType": "Slow|Failing"
+                        }
+                        ```
+                        """
+                    }
+                }
+            ]
+        };
+
+        try
+        {
+            var samplingResponse = await server.RequestSamplingAsync(samplingRequest, cancellationToken);
+            var responseJson = samplingResponse.Content.Text?.Trim()?.Replace("```json", "").Replace("```", "");
+            IssueType? issueType = null;
+            InputType? inputType = null;
+            Dictionary<string, object?> parameters = [];
+            if (!string.IsNullOrEmpty(responseJson))
+            {
+                using var doc = JsonDocument.Parse(responseJson);
+                var root = doc.RootElement;
+                foreach (var property in root.EnumerateObject())
+                {
+                    if (property.NameEquals("inputType") && property.Value.ValueKind == JsonValueKind.String)
+                    {
+                        switch (property.Value.ToString())
+                        {
+                            case "Inbound":
+                                inputType = InputType.Requests;
+                                break;
+                            case "Outbound":
+                                inputType = InputType.Dependencies;
+                                break;
+                            case "Availability":
+                                inputType = InputType.AvailabilityResults;
+                                break;
+                        }
+                    }
+                    if (property.NameEquals("issueType") && property.Value.ValueKind == JsonValueKind.String)
+                    {
+                        switch (property.Value.ToString())
+                        {
+                            case "Slow":
+                                issueType = IssueType.Latency;
+                                break;
+                            case "Failing":
+                                issueType = IssueType.Errors;
+                                break;
+                        }
+                    }
+                }
+                
+            }
+            if (inputType == null || issueType == null)
+            {
+                throw new Exception($"Failed to understand the diagnostic flow based on the reported symptoms {symptoms}. {responseJson}.");
+            }
+            return (inputType.Value, issueType.Value);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Failed to understand the symptoms: {ex}", ex);
+        }
+    }
+
+    // Helper method to find all ancestor spans (parents, grandparents, etc.)
+    private static List<SpanDetails> FindAncestorSpans(Dictionary<string, SpanDetails> spanMap, SpanDetails span)
+    {
+        var ancestors = new List<SpanDetails>();
+        string currentParentId = span.ParentId;
+        
+        // Traverse up the chain until we reach a span with no parent or one that isn't in our map
+        while (!string.IsNullOrEmpty(currentParentId) && spanMap.TryGetValue(currentParentId, out var parentSpan))
+        {
+            ancestors.Add(parentSpan);
+            currentParentId = parentSpan.ParentId;
+        }
+        
+        return ancestors;
+    }
+
+    // Helper method to build the span hierarchy based on parent-child relationships
+    private static void BuildSpanHierarchy(Dictionary<string, SpanDetails> spanMap)
+    {
+        // Create a dictionary to track parent-child relationships
+        var parentChildRelationships = new Dictionary<string, List<string>>();
+        
+        // Identify parent-child relationships from the span data
+        foreach (var span in spanMap.Values)
+        {
+            // Find the parent span ID if available in properties
+            string parentSpanId = span.ParentId;
+            
+            // If we found a parent ID, add this relationship
+            if (!string.IsNullOrEmpty(parentSpanId) && spanMap.ContainsKey(parentSpanId))
+            {
+                if (!parentChildRelationships.TryGetValue(parentSpanId, out var children))
+                {
+                    children = new List<string>();
+                    parentChildRelationships[parentSpanId] = children;
+                }
+                children.Add(span.SpanId);
+            }
+        }
+        
+        // Build the hierarchy based on identified relationships
+        foreach (var parentId in parentChildRelationships.Keys)
+        {
+            if (spanMap.TryGetValue(parentId, out var parentSpan))
+            {
+                foreach (var childId in parentChildRelationships[parentId])
+                {
+                    if (spanMap.TryGetValue(childId, out var childSpan))
+                    {
+                        parentSpan.ChildSpans.Add(childSpan);
+                    }
+                }
+            }
+        }
+    }
+
+    // Helper method to get column indexes for faster lookup
+
+    private static bool IsAppIdOrIkey(string app)
+    {
+        // Workspace IDs are GUIDs
+        return Guid.TryParse(app, out _);
+    }
+
+    private async Task<(ResourceIdentifier id, string name)> GetApplicationInsightsInfo(
+        string appId,
+        string subscription,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        // If we're given an ID and need an ID, or given a name and need a name, return as is
+        bool isId = IsAppIdOrIkey(appId);
+        var resources = await ListApplicationInsightsResources(subscription, tenant, retryPolicy);
+
+        // Find the workspace
+        var matchingResource = resources.FirstOrDefault(w =>
+            isId ? (w.AppId.Equals(appId, StringComparison.OrdinalIgnoreCase) || w.InstrumentationKey.Equals(appId, StringComparison.OrdinalIgnoreCase)) 
+                 : w.Name.Equals(appId, StringComparison.OrdinalIgnoreCase));
+
+        if (matchingResource == null)
+        {
+            throw new Exception($"Could not find Application Insights resource with {(isId ? "ID" : "name")} {appId}");
+        }
+
+        return (matchingResource.ResourceId, matchingResource.Name);
+    }
+
+    public async Task<List<ApplicationInsightsResourceInfo>> ListApplicationInsightsResources(
+        string subscription,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscription);
+
+        try
+        {
+            var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+
+            var appInsightsResources = await subscriptionResource
+                .GetApplicationInsightsComponentsAsync()
+                .Select(resource => new ApplicationInsightsResourceInfo
+                {
+                    Name = resource.Data.Name,
+                    ResourceId = resource.Id,
+                    AppId = resource.Data.AppId,
+                    InstrumentationKey = resource.Data.InstrumentationKey,
+                })
+                .ToListAsync()
+                .ConfigureAwait(false);
+
+            return appInsightsResources;
+        }
+        catch (Exception ex) when (ex is not ArgumentNullException)
+        {
+            throw new Exception($"Error retrieving Application Insights resources: {ex.Message}", ex);
+        }
+    }    // Helper methods for parsing query results
+    private static string GetStringValue(Dictionary<string, object> row, string columnName, string defaultValue)
+    {
+        if (row.TryGetValue(columnName, out object? value) && value != null)
+        {
+            return value.ToString() ?? defaultValue;
+        }
+        return defaultValue;
+    }
+
+    private static bool TryGetDateTime(Dictionary<string, object> row, string columnName, out DateTime result)
+    {
+        result = DateTime.MinValue;
+        
+        if (!row.TryGetValue(columnName, out object? value) || value == null)
+        {
+            return false;
+        }
+
+        if (value is DateTime dateTime)
+        {
+            result = dateTime;
+            return true;
+        }
+
+        return DateTime.TryParse(value.ToString(), out result);
+    }
+
+    private static bool TryGetDouble(Dictionary<string, object> row, string columnName, out double result)
+    {
+        result = 0;
+
+        if (!row.TryGetValue(columnName, out object? value) || value == null)
+        {
+            return false;
+        }
+
+        if (value is double doubleVal)
+        {
+            result = doubleVal;
+            return true;
+        }
+
+        return double.TryParse(value.ToString(), out result);
+    }
+
+    private static bool IsStandardField(string columnName)
+    {
+        return _standardFields.Values.Contains(columnName, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Services/Azure/Monitor/LogsQueryService.cs
+++ b/src/Services/Azure/Monitor/LogsQueryService.cs
@@ -1,0 +1,69 @@
+﻿using Azure;
+using Azure.Core;
+using Azure.Monitor.Query;
+using Azure.Monitor.Query.Models;
+using AzureMcp.Models.Monitor;
+using AzureMcp.Options;
+using AzureMcp.Services.Interfaces;
+
+namespace AzureMcp.Services.Azure.Monitor
+{
+    internal class LogsQueryService : BaseAzureService, ILogsQueryService
+    {
+        public async Task<LogsQueryTable?> QueryResourceAsync(ResourceIdentifier resource, string kql, DateTimeOffset startTime, DateTimeOffset endTime, string? tenant = null, RetryPolicyOptions? retryPolicy = null)
+        {
+            ValidateRequiredParameters(resource, kql);
+
+            var options = AddDefaultPolicies(new LogsQueryClientOptions());
+
+            if (retryPolicy != null)
+            {
+                options.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds);
+                options.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds);
+                options.Retry.MaxRetries = retryPolicy.MaxRetries;
+                options.Retry.Mode = retryPolicy.Mode;
+                options.Retry.NetworkTimeout = TimeSpan.FromSeconds(retryPolicy.NetworkTimeoutSeconds);
+            }
+
+            var credential = await GetCredential(tenant);
+
+            var queryTimeRange = new QueryTimeRange(startTime, endTime);
+            LogsQueryClient logsQueryClient = new LogsQueryClient(credential, options);
+
+            var response = await logsQueryClient.QueryResourceAsync(resource, kql, queryTimeRange);
+
+            List<Dictionary<string, object>> rows = new List<Dictionary<string, object>>();
+
+            if (response.Value != null)
+            {
+                // Get column indexes for easier access
+                var columnIndexes = new Dictionary<int, string>();
+                for (int i = 0; i < response.Value.Table.Columns.Count; i++)
+                {
+                    columnIndexes[i] = response.Value.Table.Columns[i].Name;
+                }
+
+                // Process each row in the query results
+                foreach (var row in response.Value.Table.Rows)
+                {
+                    var columnValues = new Dictionary<string, object>();
+                    for (int i = 0; i < row.Count; i++)
+                    {
+                        // Use column indexes to map values to column names
+                        columnValues[columnIndexes[i]] = row[i];
+                    }
+                    rows.Add(columnValues);
+                }
+
+                return new LogsQueryTable
+                {
+                    Rows = rows
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Services/Interfaces/IApplicationInsightsService.cs
+++ b/src/Services/Interfaces/IApplicationInsightsService.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+using AzureMcp.Models.Monitor.ApplicationInsights;
+using AzureMcp.Options;
+
+namespace AzureMcp.Services.Interfaces;
+
+public interface IApplicationInsightsService
+{
+    /// <summary>
+    /// Diagnoses application issues by analyzing telemetry data
+    /// </summary>
+    /// <param name="mcpServer">MCP server instance (if present), used for sampling</param>
+    /// <param name="subscription">The current subscription</param>
+    /// <param name="appId">The Application Insights identifier (instrumentation key, app ID, or resource name)</param>
+    /// <param name="startTime">The optional start time in ISO format</param>
+    /// <param name="endTime">The optional end time in ISO format</param>
+    /// <param name="symptoms">Description of the symptoms to diagnose</param>
+    /// <param name="retryPolicy">Optional retry policy parameters for the request</param>
+    /// <param name="tenant">Optional tenant ID for multi-tenant scenarios</param>
+    /// <returns>A list of diagnostic results with trace and span information</returns>
+    Task<List<JsonNode>> DiagnoseApplicationAsync(
+        IMcpServer? mcpServer,
+        string subscription,
+        string appId,
+        string symptoms,
+        string? startTime = null,
+        string? endTime = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
+
+    /// <summary>
+    /// Gets a distributed trace by trace ID and span ID
+    /// </summary>
+    /// <param name="tenant">Optional tenant ID for multi-tenant scenarios</param>
+    /// <param name="retryPolicy">Optional retry policy parameters for the request</param>
+    /// <param name="subscription"> The current subscription</param>
+    /// <param name="appId">The Application Insights resource ID</param>
+    /// <param name="traceId">The trace ID to retrieve</param>
+    /// <param name="spanId">The span ID to retrieve</param>
+    /// <param name="startTime">The optional start time in ISO format</param>
+    /// <param name="endTime">The optional end time in ISO format</param>
+    /// <returns>The trace details object</returns>
+    Task<DistributedTraceResult> GetDistributedTraceAsync(
+        string subscription,
+        string appId,
+        string traceId,
+        string spanId,
+        string? startTime = null,
+        string? endTime = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
+}

--- a/src/Services/Interfaces/ILogsQueryService.cs
+++ b/src/Services/Interfaces/ILogsQueryService.cs
@@ -1,0 +1,12 @@
+﻿using Azure;
+using Azure.Core;
+using AzureMcp.Models.Monitor;
+using AzureMcp.Options;
+
+namespace AzureMcp.Services.Interfaces
+{
+    public interface ILogsQueryService
+    {
+        Task<LogsQueryTable?> QueryResourceAsync(ResourceIdentifier resource, string kql, DateTimeOffset startTime, DateTimeOffset endTime, string? tenant = null, RetryPolicyOptions? retryPolicy = null);
+    }
+}

--- a/tests/Client/ApplicationInsightsCommandTests.cs
+++ b/tests/Client/ApplicationInsightsCommandTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using AzureMcp.Tests.Client.Helpers;
+using Xunit;
+
+namespace AzureMcp.Tests.Client;
+
+public class ApplicationInsightsCommandTests(LiveTestFixture liveTestFixture, ITestOutputHelper output) 
+    : CommandTestsBase(liveTestFixture, output),
+      IClassFixture<LiveTestFixture>
+{    [Fact]
+    [Trait("Category", "Live")]
+    [Trait("Category", "Skip")] // Skip this test as it requires actual Azure resources
+    public async Task DiagnoseApplication_ReturnsResults()
+    {
+        // Arrange
+        var appId = $"/subscriptions/{Settings.SubscriptionId}/resourceGroups/test-rg/providers/microsoft.insights/components/test-app";
+        
+        // Act
+        var result = await CallToolAsync(
+            "azmcp-monitor-app-diagnose",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "app-id", appId },
+                { "symptoms", "Application is experiencing slow response times" }
+            });
+        
+        // Assert
+        var diagnosticResults = result.AssertProperty("results");
+        Assert.Equal(JsonValueKind.Array, diagnosticResults.ValueKind);
+    }
+}

--- a/tests/Commands/Monitor/ApplicationInsights/AppDiagnoseCommandTests.cs
+++ b/tests/Commands/Monitor/ApplicationInsights/AppDiagnoseCommandTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using AzureMcp.Commands.Monitor.ApplicationInsights;
+using AzureMcp.Models.Command;
+using AzureMcp.Services.Azure.Monitor;
+using AzureMcp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Commands.Monitor.ApplicationInsights;
+
+public class AppDiagnoseCommandTests
+{    private readonly IServiceProvider _serviceProvider;
+    private readonly IMcpServer _mcpServer;
+    private readonly ILogger<AppDiagnoseCommand> _logger;
+    private readonly ISubscriptionService _subscriptionService;
+    private readonly ITenantService _tenantService;
+    private readonly IResourceGroupService _resourceGroupService;
+    private readonly ILogsQueryService _logsQueryService;
+    private readonly AppDiagnoseCommand _command;
+    private readonly IApplicationInsightsService _applicationInsightsService;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public AppDiagnoseCommandTests()
+    {
+        _logger = Substitute.For<ILogger<AppDiagnoseCommand>>();
+        _mcpServer = Substitute.For<IMcpServer>();
+        _subscriptionService = Substitute.For<ISubscriptionService>();
+        _tenantService = Substitute.For<ITenantService>();
+        _resourceGroupService = Substitute.For<IResourceGroupService>();
+        _logsQueryService = Substitute.For<ILogsQueryService>();
+        
+        // Use the real ApplicationInsightsService implementation with mocked dependencies
+        _applicationInsightsService = new ApplicationInsightsService(_subscriptionService, _tenantService, _logsQueryService);
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton(_logger);
+        serviceCollection.AddSingleton(_mcpServer);
+        serviceCollection.AddSingleton(_subscriptionService);
+        serviceCollection.AddSingleton(_resourceGroupService);
+        serviceCollection.AddSingleton(_tenantService);
+        serviceCollection.AddSingleton<ILogsQueryService>(_logsQueryService);
+        serviceCollection.AddSingleton<IApplicationInsightsService>(_applicationInsightsService);
+        
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+        _context = new CommandContext(_serviceProvider);
+        _command = new AppDiagnoseCommand(_logger);
+        _parser = new Parser(_command.GetCommand());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidOptions_ReturnsResult()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "/subscriptions/123/resourceGroups/test/providers/microsoft.insights/components/testapp";
+        var startTime = "2025-01-01T00:00:00Z";
+        var endTime = "2025-01-02T00:00:00Z";
+        var symptoms = "Requests are failing with 500 errors";
+        
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --start-time {startTime} --end-time {endTime} --symptoms \"{symptoms}\"");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.Null(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMissingRequiredOptions_ReturnsValidationError()
+    {
+        // Arrange
+        var parseResult = _parser.Parse("--subscription test-sub");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("Required option", response.Message);
+    }
+}

--- a/tests/Commands/Monitor/ApplicationInsights/AppTraceCommandTests.cs
+++ b/tests/Commands/Monitor/ApplicationInsights/AppTraceCommandTests.cs
@@ -1,0 +1,615 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure;
+using Azure.Core;
+using Azure.Data.Tables;
+using Azure.Monitor.Query.Models;
+using Azure.ResourceManager;
+using Azure.ResourceManager.ApplicationInsights;
+using Azure.ResourceManager.ApplicationInsights.Mocking;
+using Azure.ResourceManager.Resources;
+using AzureMcp.Commands.Monitor.ApplicationInsights;
+using AzureMcp.Models;
+using AzureMcp.Models.Command;
+using AzureMcp.Models.Monitor;
+using AzureMcp.Models.Monitor.ApplicationInsights;
+using AzureMcp.Options;
+using AzureMcp.Services.Azure.Monitor;
+using AzureMcp.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Commands.Monitor.ApplicationInsights;
+
+public class AppTraceCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IMcpServer _mcpServer;
+    private readonly ILogger<AppTraceCommand> _logger;
+    private readonly ISubscriptionService _subscriptionService;
+    private readonly ITenantService _tenantService;
+    private readonly ILogsQueryService _logsQueryService;
+    private readonly AppTraceCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    private readonly MockableApplicationInsightsSubscriptionResource _listAppInsightsResourcesMock;
+
+    public AppTraceCommandTests()
+    {
+        _logger = Substitute.For<ILogger<AppTraceCommand>>();
+        _mcpServer = Substitute.For<IMcpServer>();
+        _subscriptionService = Substitute.For<ISubscriptionService>();
+        _tenantService = Substitute.For<ITenantService>();
+        _logsQueryService = Substitute.For<ILogsQueryService>();
+
+        _listAppInsightsResourcesMock = Substitute.For<MockableApplicationInsightsSubscriptionResource>();
+
+        SubscriptionResource subscriptionResource = Substitute.For<SubscriptionResource>();
+
+        subscriptionResource.GetCachedClient(Arg.Any<Func<ArmClient, MockableApplicationInsightsSubscriptionResource>>())
+            .Returns(_listAppInsightsResourcesMock);
+
+        _subscriptionService.GetSubscription(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromResult(subscriptionResource));
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton(_logger);
+        serviceCollection.AddSingleton(_mcpServer);
+        serviceCollection.AddSingleton(_subscriptionService);
+        serviceCollection.AddSingleton(_tenantService);
+        serviceCollection.AddSingleton(_logsQueryService);
+        serviceCollection.AddSingleton<IApplicationInsightsService, ApplicationInsightsService>();
+
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+        _context = new CommandContext(_serviceProvider);
+        _command = new AppTraceCommand(_logger);
+        _parser = new Parser(_command.GetCommand());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMissingRequiredOptions_ReturnsValidationError()
+    {
+        // Arrange - missing trace-id and span-id
+        var parseResult = _parser.Parse("--subscription test-sub --app-id testapp");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("Required option", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyLogsQueryResult_ReturnsEmptyTrace()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "matchingapp";
+        var traceId = "trace123";
+        var spanId = "span456";
+
+        var resourceList = GetAppInsightsResourcesAsPageable(new List<ApplicationInsightsResourceInfo>()
+        {
+            new() {
+                ResourceId = new ResourceIdentifier("/subscriptions/test-sub/resourceGroups/test/providers/microsoft.insights/components/testapp"),
+                AppId = Guid.NewGuid().ToString(),
+                Name = appId,
+                InstrumentationKey = Guid.NewGuid().ToString()
+            }
+        });
+
+        _listAppInsightsResourcesMock.GetApplicationInsightsComponentsAsync(Arg.Any<CancellationToken>()).Returns(resourceList);
+
+        _logsQueryService.QueryResourceAsync(Arg.Any<ResourceIdentifier>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromResult<LogsQueryTable?>(new LogsQueryTable()));
+
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --trace-id {traceId} --span-id {spanId}");
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+        // Assert
+        Assert.Equal(200, response.Status);
+
+        DistributedTraceResult? actual = GetResult(response.Results);
+
+        Assert.Equal(traceId, actual?.TraceId);
+        Assert.Equal(0, actual?.Spans.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ServiceThrowsException_ReturnsValidationError()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "matchingapp";
+        var traceId = "trace123";
+        var spanId = "span456";
+
+        var resourceList = GetAppInsightsResourcesAsPageable(new List<ApplicationInsightsResourceInfo>()
+        {
+            new() {
+                ResourceId = new ResourceIdentifier("/subscriptions/test-sub/resourceGroups/test/providers/microsoft.insights/components/testapp"),
+                AppId = Guid.NewGuid().ToString(),
+                Name = appId,
+                InstrumentationKey = Guid.NewGuid().ToString()
+            }
+        });
+
+        _listAppInsightsResourcesMock.GetApplicationInsightsComponentsAsync(Arg.Any<CancellationToken>()).Returns(resourceList);
+
+        _logsQueryService.When(s => s.QueryResourceAsync(Arg.Any<ResourceIdentifier>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>()))
+            .Throw(new Exception("Test exception"));
+
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --trace-id {traceId} --span-id {spanId}");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        // The test is failing because validation is returning 400 before we get to the service call
+        // In a real implementation with valid parameters, this would be 500
+        Assert.Contains("Test exception", response.Message);
+        Assert.Equal(500, response.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptySubscription_ReturnsValidationError()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "nonexistentapp";
+        var traceId = "trace123";
+        var spanId = "span456";
+
+        _listAppInsightsResourcesMock.GetApplicationInsightsComponentsAsync(Arg.Any<CancellationToken>()).Returns(GetAppInsightsResourcesAsPageable(new List<ApplicationInsightsResourceInfo>()));
+
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --trace-id {traceId} --span-id {spanId}");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Error retrieving distributed trace: Could not find Application Insights resource with name nonexistentapp.", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNonMatchingResource_ReturnsValidationError()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "nonexistentapp";
+        var traceId = "trace123";
+        var spanId = "span456";
+
+        var result = GetAppInsightsResourcesAsPageable(new List<ApplicationInsightsResourceInfo>()
+        {
+            new() {
+                ResourceId = new ResourceIdentifier("/subscriptions/test-sub/resourceGroups/test/providers/microsoft.insights/components/otherapp"),
+                AppId = "otherapp",
+                Name = "Other App",
+                InstrumentationKey = "other-instrumentation-key"
+            }
+        });
+
+        _listAppInsightsResourcesMock.GetApplicationInsightsComponentsAsync(Arg.Any<CancellationToken>()).Returns(result);
+
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --trace-id {traceId} --span-id {spanId}");
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Error retrieving distributed trace: Could not find Application Insights resource with name nonexistentapp.", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithLogsQueryResult_BuildsSpanHierarchyCorrectly()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "testapp";
+        var traceId = "trace123";
+        var spanId = "span1"; // Root span
+
+        var resourceList = GetAppInsightsResourcesAsPageable(new List<ApplicationInsightsResourceInfo>()
+        {
+            new() {
+                ResourceId = new ResourceIdentifier("/subscriptions/test-sub/resourceGroups/test/providers/microsoft.insights/components/testapp"),
+                AppId = Guid.NewGuid().ToString(),
+                Name = appId,
+                InstrumentationKey = Guid.NewGuid().ToString()
+            }
+        });
+
+        _listAppInsightsResourcesMock.GetApplicationInsightsComponentsAsync(Arg.Any<CancellationToken>()).Returns(resourceList);
+
+        // Create a mock query result with multiple spans in a hierarchy
+        var mockTable = new LogsQueryTable();
+        
+        // Root span
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span1" },
+            { "operation_ParentId", "" },
+            { "operation_Name", "Root Operation" },
+            { "resultCode", "200" },
+            { "itemType", "request" },
+            { "success", "true" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 1000.0 },
+            { "operation_Id", traceId },
+            { "custom_property", "custom value" }
+        });
+
+        // Child span 1
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span2" },
+            { "operation_ParentId", "span1" },
+            { "operation_Name", "Child Operation 1" },
+            { "resultCode", "200" },
+            { "itemType", "dependency" },
+            { "success", "true" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 500.0 },
+            { "operation_Id", traceId }
+        });
+
+        // Child span 2
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span3" },
+            { "operation_ParentId", "span1" },
+            { "operation_Name", "Child Operation 2" },
+            { "resultCode", "500" },
+            { "itemType", "dependency" },
+            { "success", "false" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 250.0 },
+            { "operation_Id", traceId }
+        });
+
+        _logsQueryService.QueryResourceAsync(Arg.Any<ResourceIdentifier>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromResult<LogsQueryTable?>(mockTable));
+
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --trace-id {traceId} --span-id {spanId}");
+        
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+        
+        // Assert
+        Assert.Equal(200, response.Status);
+        
+        DistributedTraceResult? actual = GetResult(response.Results);
+        
+        Assert.Equal(traceId, actual?.TraceId);
+        Assert.Equal(3, actual?.Spans.Count);
+        
+        // Find span1 in the result spans
+        var rootSpan = actual?.Spans.FirstOrDefault(s => s.SpanId == "span1");
+        Assert.NotNull(rootSpan);
+        Assert.Equal("Root Operation", rootSpan?.OperationName);
+        Assert.Equal(2, rootSpan?.ChildSpans.Count);
+        
+        // Check that the children are correctly associated
+        var childSpanIds = rootSpan?.ChildSpans.Select(c => c.SpanId).ToList();        Assert.NotNull(childSpanIds);
+        Assert.Contains("span2", childSpanIds!);
+        Assert.Contains("span3", childSpanIds!);
+        
+        // Check custom property was added
+        var customProp = rootSpan?.Properties.FirstOrDefault(p => p.Key == "custom_property");
+        Assert.NotNull(customProp);
+        Assert.Equal("custom value", customProp?.Value);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNonRootSpanId_FiltersBySpecifiedSpan()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "testapp";
+        var traceId = "trace123";
+        var spanId = "span2"; // Middle span in the hierarchy
+
+        var resourceList = GetAppInsightsResourcesAsPageable(new List<ApplicationInsightsResourceInfo>()
+        {
+            new() {
+                ResourceId = new ResourceIdentifier("/subscriptions/test-sub/resourceGroups/test/providers/microsoft.insights/components/testapp"),
+                AppId = Guid.NewGuid().ToString(),
+                Name = appId,
+                InstrumentationKey = Guid.NewGuid().ToString()
+            }
+        });
+
+        _listAppInsightsResourcesMock.GetApplicationInsightsComponentsAsync(Arg.Any<CancellationToken>()).Returns(resourceList);
+
+        // Create a deeper hierarchy: root -> middle -> leaf
+        var mockTable = new LogsQueryTable();
+        
+        // Root span
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span1" },
+            { "operation_ParentId", "" },
+            { "operation_Name", "Root Operation" },
+            { "resultCode", "200" },
+            { "itemType", "request" },
+            { "success", "true" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 1000.0 },
+            { "operation_Id", traceId }
+        });
+
+        // Middle span (our target span)
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span2" },
+            { "operation_ParentId", "span1" },
+            { "operation_Name", "Middle Operation" },
+            { "resultCode", "200" },
+            { "itemType", "dependency" },
+            { "success", "true" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 500.0 },
+            { "operation_Id", traceId }
+        });
+
+        // Leaf span 1 (child of span2)
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span3" },
+            { "operation_ParentId", "span2" },
+            { "operation_Name", "Leaf Operation 1" },
+            { "resultCode", "200" },
+            { "itemType", "dependency" },
+            { "success", "true" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 250.0 },
+            { "operation_Id", traceId }
+        });
+
+        // Leaf span 2 (child of span2)
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span4" },
+            { "operation_ParentId", "span2" },
+            { "operation_Name", "Leaf Operation 2" },
+            { "resultCode", "200" },
+            { "itemType", "dependency" },
+            { "success", "true" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 300.0 },
+            { "operation_Id", traceId }
+        });
+
+        // Unrelated span (different parent)
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span5" },
+            { "operation_ParentId", "span1" },
+            { "operation_Name", "Unrelated Operation" },
+            { "resultCode", "200" },
+            { "itemType", "dependency" },
+            { "success", "true" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 150.0 },
+            { "operation_Id", traceId }
+        });
+
+        _logsQueryService.QueryResourceAsync(Arg.Any<ResourceIdentifier>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromResult<LogsQueryTable?>(mockTable));
+
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --trace-id {traceId} --span-id {spanId}");
+        
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+        
+        // Assert
+        Assert.Equal(200, response.Status);
+        
+        DistributedTraceResult? actual = GetResult(response.Results);
+        
+        Assert.Equal(traceId, actual?.TraceId);
+        
+        // Should include span2, its parent (span1), and its direct children (span3, span4)
+        // But not span5 (which is not related to span2)
+        Assert.Equal(4, actual?.Spans.Count);
+        
+        // Verify spans are included
+        var spanIds = actual?.Spans.Select(s => s.SpanId).ToList();        Assert.NotNull(spanIds);
+        Assert.Contains("span1", spanIds!); // Parent
+        Assert.Contains("span2", spanIds!); // Target
+        Assert.Contains("span3", spanIds!); // Child 1
+        Assert.Contains("span4", spanIds!); // Child 2
+        Assert.DoesNotContain("span5", spanIds!); // Unrelated span
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithSpanNotInResults_ReturnsEmptySpansList()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "testapp";
+        var traceId = "trace123";
+        var spanId = "nonexistent-span"; // Span ID that doesn't exist in the results
+
+        var resourceList = GetAppInsightsResourcesAsPageable(new List<ApplicationInsightsResourceInfo>()
+        {
+            new() {
+                ResourceId = new ResourceIdentifier("/subscriptions/test-sub/resourceGroups/test/providers/microsoft.insights/components/testapp"),
+                AppId = Guid.NewGuid().ToString(),
+                Name = appId,
+                InstrumentationKey = Guid.NewGuid().ToString()
+            }
+        });
+
+        _listAppInsightsResourcesMock.GetApplicationInsightsComponentsAsync(Arg.Any<CancellationToken>()).Returns(resourceList);
+
+        // Create a mock query result with some spans
+        var mockTable = new LogsQueryTable();
+        
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span1" },
+            { "operation_ParentId", "" },
+            { "operation_Name", "Root Operation" },
+            { "resultCode", "200" },
+            { "itemType", "request" },
+            { "success", "true" },
+            { "timestamp", DateTime.UtcNow },
+            { "duration", 1000.0 },
+            { "operation_Id", traceId }
+        });
+
+        _logsQueryService.QueryResourceAsync(Arg.Any<ResourceIdentifier>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromResult<LogsQueryTable?>(mockTable));
+
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --trace-id {traceId} --span-id {spanId}");
+        
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+        
+        // Assert
+        Assert.Equal(200, response.Status);
+        
+        DistributedTraceResult? actual = GetResult(response.Results);
+        
+        Assert.Equal(traceId, actual?.TraceId);
+        Assert.NotNull(actual);
+        Assert.Empty(actual!.Spans);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithDifferentDataTypes_ParsesPropertiesCorrectly()
+    {
+        // Arrange
+        var subscription = "test-sub";
+        var appId = "testapp";
+        var traceId = "trace123";
+        var spanId = "span1";
+        var testTimestamp = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var resourceList = GetAppInsightsResourcesAsPageable(new List<ApplicationInsightsResourceInfo>()
+        {
+            new() {
+                ResourceId = new ResourceIdentifier("/subscriptions/test-sub/resourceGroups/test/providers/microsoft.insights/components/testapp"),
+                AppId = Guid.NewGuid().ToString(),
+                Name = appId,
+                InstrumentationKey = Guid.NewGuid().ToString()
+            }
+        });
+
+        _listAppInsightsResourcesMock.GetApplicationInsightsComponentsAsync(Arg.Any<CancellationToken>()).Returns(resourceList);
+
+        // Create a mock query result with different data types
+        var mockTable = new LogsQueryTable();
+        
+        mockTable.Rows.Add(new Dictionary<string, object>
+        {
+            { "id", "span1" },
+            { "operation_ParentId", "" },
+            { "operation_Name", "Test Operation" },
+            { "resultCode", 404 }, // Integer instead of string
+            { "itemType", "request" },
+            { "success", false }, // Boolean instead of string
+            { "timestamp", testTimestamp }, // DateTime object
+            { "duration", 1000.0 }, // Double for duration
+            { "operation_Id", traceId },
+            { "int_property", 42 },
+            { "bool_property", true },
+            { "null_property", DBNull.Value }
+        });
+
+        _logsQueryService.QueryResourceAsync(Arg.Any<ResourceIdentifier>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromResult<LogsQueryTable?>(mockTable));
+
+        var parseResult = _parser.Parse($"--subscription {subscription} --app-id {appId} --trace-id {traceId} --span-id {spanId}");
+        
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+        
+        // Assert
+        Assert.Equal(200, response.Status);
+        
+        DistributedTraceResult? actual = GetResult(response.Results);
+        
+        Assert.Equal(traceId, actual?.TraceId);        Assert.NotNull(actual);
+        Assert.Single(actual!.Spans);
+        
+        var span = actual!.Spans.First();        Assert.NotNull(span);
+        Assert.Equal("span1", span.SpanId);
+        Assert.Equal("Test Operation", span.OperationName);
+        Assert.Equal("404", span.ResponseCode); // String conversion
+        Assert.False(span.IsSuccessful); // Parsed correctly
+        Assert.Equal(testTimestamp, span.StartTime);
+        Assert.Equal(TimeSpan.FromMilliseconds(1000), span.Duration);
+        
+        // Check custom properties
+        Assert.NotNull(span.Properties);
+        Assert.Contains(span.Properties, p => p.Key == "int_property" && p.Value == "42");
+        Assert.Contains(span.Properties, p => p.Key == "bool_property" && p.Value == "True");
+        Assert.DoesNotContain(span.Properties, p => p.Key == "null_property");
+    }
+
+    private AsyncPageable<ApplicationInsightsComponentResource> GetAppInsightsResourcesAsPageable(List<ApplicationInsightsResourceInfo> resources)
+    {
+        List<ApplicationInsightsComponentResource> components = resources.Select(t =>
+        {
+            var result = Substitute.For<ApplicationInsightsComponentResource>();
+
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes($@"{{
+                ""kind"": ""web"",
+                ""location"": ""eastus"",
+                ""name"": ""{t.Name}"",
+                ""properties"": {{
+                    ""AppId"": ""{t.AppId}"",
+                    ""InstrumentationKey"": ""{t.InstrumentationKey}""
+                }}
+            }}"));
+
+            IJsonModel<ApplicationInsightsComponentData> data = new ApplicationInsightsComponentData(AzureLocation.AustraliaCentral, "web");
+            var d = data.Create(ref reader, new ModelReaderWriterOptions("W"));
+
+            result.Data.Returns(d);
+            result.Id.Returns(t.ResourceId);
+            return result;
+        }).ToList();
+        var page = Page<ApplicationInsightsComponentResource>.FromValues(components, continuationToken: null, Substitute.For<Response>());
+        return AsyncPageable<ApplicationInsightsComponentResource>.FromPages(new[] { page });
+    }
+
+    private DistributedTraceResult GetResult(ResponseResult? response)
+    {
+        string serialized = JsonSerializer.Serialize(response, new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = true
+        });
+
+        JsonDocument document = JsonDocument.Parse(serialized);
+        JsonElement root = document.RootElement;
+        var actualResult = root.GetProperty("result");
+
+        return JsonSerializer.Deserialize<DistributedTraceResult>(actualResult.GetRawText(), new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNameCaseInsensitive = true
+        }) ?? throw new InvalidOperationException("Deserialized result is null");
+    }
+}


### PR DESCRIPTION
This pull request introduces Application Insights support to the Azure Monitor Command Platform, enabling new diagnostic and tracing functionalities. Key changes include the addition of Application Insights commands, updates to the command registration system, and new models for handling diagnostic and trace results.

### Application Insights Integration

* `Directory.Packages.props`, `src/AzureMcp.csproj`: Added `Azure.ResourceManager.ApplicationInsights` package references to enable Application Insights resource management. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R15) [[2]](diffhunk://#diff-d0a43b1faa35e36d0e8394c8416afebb1a9e43dd01584b540a3a752aef05f7afR52)
* [`src/Commands/CommandFactory.cs`](diffhunk://#diff-1c09cb6d702765452b8d0f39acbe2b55f72b2751d9003e49895b49a285cc2069L251-R256): Registered new Application Insights commands (`diagnose` and `trace`) under a dedicated `app` subgroup for Application Insights operations.

### New Commands for Application Insights

* [`src/Commands/Monitor/ApplicationInsights/AppDiagnoseCommand.cs`](diffhunk://#diff-a562699d2c31a4b29eb7801d57f0fbb49f9501908a13a51fdbc6fbf9d34b0b53R1-R107): Introduced a command for diagnosing application issues using Application Insights, including options for specifying time ranges and symptoms.
* [`src/Commands/Monitor/ApplicationInsights/AppTraceCommand.cs`](diffhunk://#diff-fb052657fd271d336776f148cb48e043804a940cc15927e24e0e477d7e6f00bdR1-R115): Added a command to retrieve distributed traces from Application Insights, providing detailed span information and hierarchical trace structures.

### Base Command Enhancements

* [`src/Commands/Monitor/ApplicationInsights/BaseApplicationInsightsCommand.cs`](diffhunk://#diff-cc27729f89ad653cc3ab6fc0f60449362c1766052bae0568d05297d79dd0e996R1-R41): Created an abstract base class for Application Insights commands, encapsulating common functionality such as `AppId` option registration and binding.

### Supporting Models

* [`src/Models/Monitor/ApplicationDiagnosticResult.cs`](diffhunk://#diff-4cd2c029e751fcd7e39c5d624033d26628e5cecc91776c863c0e2b3593504a49R1-R33): Added a model to represent diagnostic results, including failed request counts and trace details.
* [`src/Models/Monitor/ApplicationInsights/DistributedTraceResult.cs`](diffhunk://#diff-55e5d6c6345224efd7f71225e3aed4945b4a2d5baa0fd06c215148a2d4c84c98R1-R49): Defined a model for distributed trace results, including span details, hierarchical relationships, and timing information.
* [`src/Models/Monitor/ApplicationInsights/ApplicationInsightsResourceInfo.cs`](diffhunk://#diff-50280d8d05f5f641a2a54bc6a165fbe70431c1355b4e6adddcbe4209088e32a0R1-R12): Introduced a model for Application Insights resource information, such as `AppId` and `InstrumentationKey`.

### Command Context Updates

* `src/Models/Command/CommandContext.cs`, `src/Commands/Server/ToolOperations.cs`: Enhanced `CommandContext` to include an optional `Server` property, facilitating server-specific command execution. [[1]](diffhunk://#diff-e7a8f7ffade375f589d496682ebc07979ae342faf2f1d8e738517fac30c59472R23-R35) [[2]](diffhunk://#diff-95eb70408cb516849cda02f5183ad7b1b4b0d425fee9961a18ea1e5398377c78L103-R103)## What does this PR do?

## GitHub issue number?

## Checklist before merging
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
