### PR TITLE
[Docker] Fix: mcp server can't start without pwsh #377

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,16 @@ COPY . .
 
 # Publish the application
 FROM build AS publish
+
+# Install PowerShell
+RUN apt-get update && \
+    apt-get install -y wget apt-transport-https software-properties-common && \
+    wget -q "https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb" && \
+    dpkg -i packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y powershell && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pwsh "eng/scripts/Build-Module.ps1" -OutputPath /app/publish -OperatingSystem Linux -Architecture x64
 
 # Build the runtime image


### PR DESCRIPTION
## What does this PR do?
Add pwsh to dockerfile so mcp servers running locally built docker images can start without the error message  
## GitHub issue number?
#377 
## Checklist before merging
- [x ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If it's a core feature, I have added thorough tests.
- [x] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [x ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
