### PR TITLE
Look for the McpServerToolAttribute in the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- MCP tools now expose annotations to clients https://github.com/Azure/azure-mcp/pull/388
+
 ### Other Changes
 
 ## 0.2.2 (2025-06-17)

--- a/src/Commands/Server/ToolOperations.cs
+++ b/src/Commands/Server/ToolOperations.cs
@@ -144,9 +144,9 @@ public class ToolOperations
             Description = underlyingCommand.Description,
         };
 
-        // Get the GetCommand method info to check for McpServerToolAttribute
-        var getCommandMethod = command.GetType().GetMethod(nameof(IBaseCommand.GetCommand));
-        if (getCommandMethod?.GetCustomAttribute<McpServerToolAttribute>() is { } mcpServerToolAttr)
+        // Get the ExecuteAsync method info to check for McpServerToolAttribute
+        var executeAsyncMethod = command.GetType().GetMethod(nameof(IBaseCommand.ExecuteAsync));
+        if (executeAsyncMethod?.GetCustomAttribute<McpServerToolAttribute>() is { } mcpServerToolAttr)
         {
             tool.Annotations = new ToolAnnotations()
             {

--- a/tests/Commands/Server/ToolOperationsTest.cs
+++ b/tests/Commands/Server/ToolOperationsTest.cs
@@ -70,6 +70,7 @@ public class ToolOperationsTest
             Assert.NotNull(tool);
             Assert.NotNull(tool.Name);
             Assert.NotNull(tool.Description!);
+            Assert.NotNull(tool.Annotations);
 
             Assert.Equal(JsonValueKind.Object, tool.InputSchema.ValueKind);
 


### PR DESCRIPTION
## What does this PR do?

**Problem:**

The `ToolOperations` type is responsible for finding all the relevant commands and exposing them as MCP tools. As part of this process it looks for the `McpServerToolAttribute` on implementations of `IBaseCommand.GetCommand` method and uses the metadata to fill out the `Tool.Annotations` data structure. The problem is that this isn't where the `McpServerToolAttribute` is used; all commands place it on their implementation of the `IBaseCommand.ExecuteAsync` method.

Since the code is looking in the wrong place the annotations are never discovered and can't be passed along to MCP clients.

**Solution:**

Update the code to look for the attribute on the `ExecuteAsync` method instead of `GetCommand`.

The `ToolOperations.GetAllTools` test has been updated to validate that we now set `Tool.Annotations` for every tool. It is safe to make this assertion since every tool is expected to have at least a title.

I also ran the MCP server and connected to it with a client to verify that the annotations were coming through as expected.

## GitHub issue number?

_No existing issue_

## Checklist before merging
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If it's a core feature, I have added thorough tests.
- [x] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
