### PR TITLE
Move Key Vault Secrets to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Support for Azure ISV Services https://github.com/Azure/azure-mcp/pull/199/
 - Support for Azure RBAC https://github.com/Azure/azure-mcp/pull/266
+- Support for Key Vault Secrets https://github.com/Azure/azure-mcp/pull/173
+
 
 ## 0.2.1 (2025-06-12)
 
@@ -29,7 +31,6 @@
 ### Features Added
 
 - Support for launching smaller service level MCP servers. https://github.com/Azure/azure-mcp/pull/324
-- Added support for Key Vault Secrets. https://github.com/Azure/azure-mcp/pull/173
 
 ### Bugs Fixed
 


### PR DESCRIPTION
## What does this PR do?
Move Key Vault Secrets to 0.2.2 in CHANGELOG. 

That PR was merged Tuesday, June 17th around 7am PDT, so it first shipped in the 0.2.2 release.

## GitHub issue number?

## Checklist before merging
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
