### PR TITLE
AppConfig unit tests

### DIFF
--- a/src/Areas/AppConfig/Models/AppConfigurationAccount.cs
+++ b/src/Areas/AppConfig/Models/AppConfigurationAccount.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
 using AzureMcp.Models.Identity;
 
 namespace AzureMcp.Areas.AppConfig.Models;
@@ -23,4 +24,6 @@ public class AppConfigurationAccount
 
     // Full encryption properties
     public EncryptionProperties? Encryption { get; set; }
+
+    internal record AppConfigurationAccountList(IReadOnlyList<AppConfigurationAccount> Accounts);
 }

--- a/src/Areas/AppConfig/Models/KeyValueSetting.cs
+++ b/src/Areas/AppConfig/Models/KeyValueSetting.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 namespace AzureMcp.Areas.AppConfig.Models;
 
 public class KeyValueSetting
@@ -12,4 +14,9 @@ public class KeyValueSetting
     public ETag ETag { get; set; } = new();
     public DateTimeOffset? LastModified { get; set; }
     public bool? Locked { get; set; }
+
+    internal record KeyValueResult(string Key, string? Label = null, string? Value = null, string? IsLocked = null);
+
+    internal record KeyValueSettingsCollection(IReadOnlyList<KeyValueSetting> Settings);
+    internal record KeyValueSettingsResult(KeyValueSetting Setting);
 }

--- a/tests/Areas/AppConfig/UnitTests/Account/AccountListCommandTests.cs
+++ b/tests/Areas/AppConfig/UnitTests/Account/AccountListCommandTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using AzureMcp.Areas.AppConfig.Commands.Account;
+using AzureMcp.Areas.AppConfig.Models;
+using AzureMcp.Areas.AppConfig.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.AppConfig.UnitTests.Account;
+
+[Trait("Area", "AppConfig")]
+public class AccountListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAppConfigService _appConfigService;
+    private readonly ILogger<AccountListCommand> _logger;
+    private readonly AccountListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public AccountListCommandTests()
+    {
+        _appConfigService = Substitute.For<IAppConfigService>();
+        _logger = Substitute.For<ILogger<AccountListCommand>>();
+
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_appConfigService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsAccounts_WhenAccountsExist()
+    {
+        // Arrange
+        var expectedAccounts = new List<AppConfigurationAccount>
+        {
+            new() { Name = "account1", Location = "East US", Endpoint = "https://account1.azconfig.io" },
+            new() { Name = "account2", Location = "West US", Endpoint = "https://account2.azconfig.io" }
+        };
+        _appConfigService.GetAppConfigAccounts(
+            "sub123",
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(expectedAccounts);
+
+        var args = _parser.Parse(["--subscription", "sub123"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<AppConfigurationAccount.AppConfigurationAccountList>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Accounts.Count);
+        Assert.Equal("account1", result.Accounts[0].Name);
+        Assert.Equal("account2", result.Accounts[1].Name);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenNoAccountsExist()
+    {
+        // Arrange
+        var expectedAccounts = new List<AppConfigurationAccount>();
+
+        _appConfigService.GetAppConfigAccounts(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(expectedAccounts);
+
+        var args = _parser.Parse(["--subscription", "sub123"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.Null(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        _appConfigService.GetAppConfigAccounts(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromException<List<AppConfigurationAccount>>(new Exception("Service error")));
+
+        var args = _parser.Parse(["--subscription", "sub123"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service error", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns400_WhenSubscriptionIsMissing()
+    {
+        // Arrange && Act
+        var response = await _command.ExecuteAsync(_context, _parser.Parse([]));
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns503_WhenServiceIsUnavailable()
+    {
+        // Arrange
+        _appConfigService.GetAppConfigAccounts(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .ThrowsAsync(new HttpRequestException("Service Unavailable", null, System.Net.HttpStatusCode.ServiceUnavailable));
+
+        var args = _parser.Parse(["--subscription", "sub123"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(503, response.Status);
+        Assert.Contains("Service Unavailable", response.Message);
+    }
+}

--- a/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueDeleteCommandTests.cs
+++ b/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueDeleteCommandTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using AzureMcp.Areas.AppConfig.Commands.KeyValue;
+using AzureMcp.Areas.AppConfig.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using static AzureMcp.Areas.AppConfig.Models.KeyValueSetting;
+
+namespace AzureMcp.Tests.Areas.AppConfig.UnitTests.KeyValue;
+
+[Trait("Area", "AppConfig")]
+public class KeyValueDeleteCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAppConfigService _appConfigService;
+    private readonly ILogger<KeyValueDeleteCommand> _logger;
+    private readonly KeyValueDeleteCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public KeyValueDeleteCommandTests()
+    {
+        _appConfigService = Substitute.For<IAppConfigService>();
+        _logger = Substitute.For<ILogger<KeyValueDeleteCommand>>();
+
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_appConfigService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeletesKeyValue_WhenValidParametersProvided()
+    {
+        // Arrange
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _appConfigService.Received(1).DeleteKeyValue(
+            "account1",
+            "my-key",
+            "sub123",
+            null,
+            Arg.Any<RetryPolicyOptions>(), null);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Key);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeletesKeyValueWithLabel_WhenLabelProvided()
+    {
+        // Arrange
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key",
+            "--label", "prod"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _appConfigService.Received(1).DeleteKeyValue(
+            "account1",
+            "my-key",
+            "sub123", null,
+            Arg.Any<RetryPolicyOptions>(),
+            "prod");
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Key);
+        Assert.Equal("prod", result.Label);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        _appConfigService.DeleteKeyValue(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string>())
+            .Returns(Task.FromException<bool>(new Exception("Failed to delete key-value")));
+
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Failed to delete key-value", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account-name", "account1", "--key", "my-key")] // Missing subscription
+    [InlineData("--subscription", "sub123", "--key", "my-key")] // Missing account-name
+    [InlineData("--subscription", "sub123", "--account-name", "account1")] // Missing key
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        // Arrange
+        var parseResult = _parser.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueListCommandTests.cs
+++ b/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueListCommandTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using AzureMcp.Areas.AppConfig.Commands.KeyValue;
+using AzureMcp.Areas.AppConfig.Models;
+using AzureMcp.Areas.AppConfig.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.AppConfig.UnitTests.KeyValue;
+
+[Trait("Area", "AppConfig")]
+public class KeyValueListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAppConfigService _appConfigService;
+    private readonly ILogger<KeyValueListCommand> _logger;
+    private readonly KeyValueListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public KeyValueListCommandTests()
+    {
+        _appConfigService = Substitute.For<IAppConfigService>();
+        _logger = Substitute.For<ILogger<KeyValueListCommand>>();
+
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_appConfigService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsSettings_WhenSettingsExist()
+    {
+        // Arrange
+        var expectedSettings = new List<KeyValueSetting>
+        {
+            new() { Key = "key1", Value = "value1", Label = "prod" },
+            new() { Key = "key2", Value = "value2", Label = "dev" }
+        };
+        _appConfigService.ListKeyValues(
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<RetryPolicyOptions>())
+          .Returns(expectedSettings);
+
+        var args = _parser.Parse(["--subscription", "sub123", "--account-name", "account1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueSetting.KeyValueSettingsCollection>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Settings.Count);
+        Assert.Equal("key1", result.Settings[0].Key);
+        Assert.Equal("key2", result.Settings[1].Key);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFilteredSettings_WhenKeyFilterProvided()
+    {
+        // Arrange
+        var expectedSettings = new List<KeyValueSetting>
+        {
+            new() { Key = "key1", Value = "value1", Label = "prod" }
+        };
+        _appConfigService.ListKeyValues(
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<RetryPolicyOptions>())
+          .Returns(expectedSettings);
+
+        var args = _parser.Parse(["--subscription", "sub123", "--account-name", "account1", "--key", "key1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueSetting.KeyValueSettingsCollection>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Single(result.Settings);
+        Assert.Equal("key1", result.Settings[0].Key);
+        Assert.Equal("value1", result.Settings[0].Value);
+        Assert.Equal("prod", result.Settings[0].Label);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFilteredSettings_WhenLabelFilterProvided()
+    {
+        // Arrange
+        var expectedSettings = new List<KeyValueSetting>
+        {
+            new() { Key = "key1", Value = "value1", Label = "prod" }
+        };
+        _appConfigService.ListKeyValues(
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<string>(),
+          Arg.Any<RetryPolicyOptions>())
+          .Returns(expectedSettings);
+
+        var args = _parser.Parse(["--subscription", "sub123", "--account-name", "account1", "--label", "prod"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueSetting.KeyValueSettingsCollection>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Single(result.Settings);
+        Assert.Equal("key1", result.Settings[0].Key);
+        Assert.Equal("value1", result.Settings[0].Value);
+        Assert.Equal("prod", result.Settings[0].Label);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        _appConfigService.ListKeyValues(Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromException<List<KeyValueSetting>>(new Exception("Service error")));
+
+        var args = _parser.Parse(["--subscription", "sub123", "--account-name", "account1"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service error", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account-name", "account1")] // Missing subscription
+    [InlineData("--subscription", "sub123")] // Missing account-name
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        // Arrange
+        var parseResult = _parser.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueLockCommandTests.cs
+++ b/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueLockCommandTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using AzureMcp.Areas.AppConfig.Commands.KeyValue;
+using AzureMcp.Areas.AppConfig.Models;
+using AzureMcp.Areas.AppConfig.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using static AzureMcp.Areas.AppConfig.Models.KeyValueSetting;
+
+namespace AzureMcp.Tests.Areas.AppConfig.UnitTests.KeyValue;
+
+[Trait("Area", "AppConfig")]
+public class KeyValueLockCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAppConfigService _appConfigService;
+    private readonly ILogger<KeyValueLockCommand> _logger;
+    private readonly KeyValueLockCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public KeyValueLockCommandTests()
+    {
+        _appConfigService = Substitute.For<IAppConfigService>();
+        _logger = Substitute.For<ILogger<KeyValueLockCommand>>();
+
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_appConfigService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LocksKeyValue_WhenValidParametersProvided()
+    {
+        // Arrange
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _appConfigService.Received(1).LockKeyValue(
+            "account1",
+            "my-key",
+            "sub123",
+            null,
+            Arg.Any<RetryPolicyOptions>(), null);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Key);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LocksKeyValueWithLabel_WhenLabelProvided()
+    {
+        // Arrange
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key",
+            "--label", "prod"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _appConfigService.Received(1).LockKeyValue(
+            "account1",
+            "my-key",
+            "sub123", null,
+            Arg.Any<RetryPolicyOptions>(),
+            "prod");
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Key);
+        Assert.Equal("prod", result.Label);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        _appConfigService.LockKeyValue(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string>())
+            .Returns(Task.FromException<KeyValueSetting.KeyValueSettingsCollection>(new Exception("Failed to lock key-value")));
+
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Failed to lock key-value", response.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("--subscription sub123")]
+    [InlineData("--subscription sub123 --account-name account1")]
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(string args)
+    {
+        // Arrange
+        var parsedArgs = _parser.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parsedArgs);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueSetCommandTests.cs
+++ b/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueSetCommandTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using AzureMcp.Areas.AppConfig.Commands.KeyValue;
+using AzureMcp.Areas.AppConfig.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using static AzureMcp.Areas.AppConfig.Models.KeyValueSetting;
+
+namespace AzureMcp.Tests.Areas.AppConfig.UnitTests.KeyValue;
+
+[Trait("Area", "AppConfig")]
+public class KeyValueSetCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAppConfigService _appConfigService;
+    private readonly ILogger<KeyValueSetCommand> _logger;
+    private readonly KeyValueSetCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public KeyValueSetCommandTests()
+    {
+        _appConfigService = Substitute.For<IAppConfigService>();
+        _logger = Substitute.For<ILogger<KeyValueSetCommand>>();
+
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_appConfigService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetsKeyValue_WhenValidParametersProvided()
+    {
+        // Arrange
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key",
+            "--value", "my-value"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _appConfigService.Received(1).SetKeyValue(
+            "account1",
+            "my-key",
+            "my-value",
+            "sub123", null,
+            Arg.Any<RetryPolicyOptions>(),
+            null);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Key);
+        Assert.Equal("my-value", result.Value);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetsKeyValueWithLabel_WhenLabelProvided()
+    {
+        // Arrange
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key",
+            "--value", "my-value",
+            "--label", "prod"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _appConfigService.Received(1).SetKeyValue(
+            "account1",
+            "my-key",
+            "my-value", "sub123", null,
+            Arg.Any<RetryPolicyOptions>(),
+            "prod");
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Key);
+        Assert.Equal("my-value", result.Value);
+        Assert.Equal("prod", result.Label);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        _appConfigService.SetKeyValue(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string>())
+            .Returns(Task.FromException<KeyValueResult>(new Exception("Failed to set key-value")));
+
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key",
+            "--value", "my-value"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Failed to set key-value", response.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("--subscription sub123")]
+    [InlineData("--subscription sub123 --account-name account1")]
+    [InlineData("--subscription sub123 --account-name account1 --key my-key")]
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(string args)
+    {
+        // Arrange
+        var parsedArgs = _parser.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parsedArgs);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueShowCommandTests.cs
+++ b/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueShowCommandTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using AzureMcp.Areas.AppConfig.Commands.KeyValue;
+using AzureMcp.Areas.AppConfig.Models;
+using AzureMcp.Areas.AppConfig.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using static AzureMcp.Areas.AppConfig.Models.KeyValueSetting;
+
+namespace AzureMcp.Tests.Areas.AppConfig.UnitTests.KeyValue;
+
+[Trait("Area", "AppConfig")]
+public class KeyValueShowCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAppConfigService _appConfigService;
+    private readonly ILogger<KeyValueShowCommand> _logger;
+    private readonly KeyValueShowCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public KeyValueShowCommandTests()
+    {
+        _appConfigService = Substitute.For<IAppConfigService>();
+        _logger = Substitute.For<ILogger<KeyValueShowCommand>>();
+
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_appConfigService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsSetting_WhenSettingExists()
+    {
+        // Arrange
+        var expectedSetting = new KeyValueSetting
+        {
+            Key = "my-key",
+            Value = "my-value",
+            Label = "prod",
+            ContentType = "text/plain",
+            Locked = false
+        };
+        _appConfigService.GetKeyValue(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedSetting);
+
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key",
+            "--label", "prod"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueSettingsResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Setting.Key);
+        Assert.Equal("my-value", result.Setting.Value);
+        Assert.Equal("prod", result.Setting.Label);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsSetting_WhenNoLabelProvided()
+    {
+        // Arrange
+        var expectedSetting = new KeyValueSetting
+        {
+            Key = "my-key",
+            Value = "my-value",
+            Label = "",
+            ContentType = "text/plain",
+            Locked = false
+        };
+        _appConfigService.GetKeyValue(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string>())
+            .Returns(expectedSetting);
+
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueSettingsResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Setting.Key);
+        Assert.Equal("my-value", result.Setting.Value);
+    }
+
+    [Fact]  
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        _appConfigService.GetKeyValue(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string>())
+            .Returns(Task.FromException<KeyValueSetting>(new Exception("Setting not found")));
+
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Setting not found", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account-name", "account1", "--key", "my-key")] // Missing subscription
+    [InlineData("--subscription", "sub123", "--key", "my-key")] // Missing account-name  
+    [InlineData("--subscription", "sub123", "--account-name", "account1")] // Missing key
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        // Arrange
+        var parseResult = _parser.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueUnlockCommandTests.cs
+++ b/tests/Areas/AppConfig/UnitTests/KeyValue/KeyValueUnlockCommandTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using AzureMcp.Areas.AppConfig.Commands.KeyValue;
+using AzureMcp.Areas.AppConfig.Models;
+using AzureMcp.Areas.AppConfig.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using static AzureMcp.Areas.AppConfig.Models.KeyValueSetting;
+
+namespace AzureMcp.Tests.Areas.AppConfig.UnitTests.KeyValue;
+
+[Trait("Area", "AppConfig")]
+public class KeyValueUnlockCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAppConfigService _appConfigService;
+    private readonly ILogger<KeyValueUnlockCommand> _logger;
+    private readonly KeyValueUnlockCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public KeyValueUnlockCommandTests()
+    {
+        _appConfigService = Substitute.For<IAppConfigService>();
+        _logger = Substitute.For<ILogger<KeyValueUnlockCommand>>();
+
+        _command = new(_logger);
+        _parser = new(_command.GetCommand());
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(_appConfigService)
+            .BuildServiceProvider();
+        _context = new(_serviceProvider);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnlocksKeyValue_WhenValidParametersProvided()
+    {
+        // Arrange
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _appConfigService.Received(1).UnlockKeyValue(
+            "account1",
+            "my-key",
+            "sub123",
+            null,
+            Arg.Any<RetryPolicyOptions>(),
+            null);
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueResult> (json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Key);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnlocksKeyValueWithLabel_WhenLabelProvided()
+    {
+        // Arrange
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key",
+            "--label", "prod"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _appConfigService.Received(1).UnlockKeyValue(
+            "account1",
+            "my-key",
+            "sub123",
+            null,
+            Arg.Any<RetryPolicyOptions>(),
+            "prod");
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyValueResult>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("my-key", result.Key);
+        Assert.Equal("prod", result.Label);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Returns500_WhenServiceThrowsException()
+    {
+        // Arrange
+        _appConfigService.UnlockKeyValue(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string>())
+            .Returns(Task.FromException<KeyValueSetting>(new Exception("Failed to unlock key-value")));
+
+        var args = _parser.Parse([
+            "--subscription", "sub123",
+            "--account-name", "account1",
+            "--key", "my-key"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Failed to unlock key-value", response.Message);
+    }
+
+    [Theory]
+    [InlineData("--account-name", "account1", "--key", "my-key")] // Missing subscription
+    [InlineData("--subscription", "sub123", "--key", "my-key")] // Missing account-name
+    [InlineData("--subscription", "sub123", "--account-name", "account1")] // Missing key
+    public async Task ExecuteAsync_Returns400_WhenRequiredParametersAreMissing(params string[] args)
+    {
+        // Arrange
+        var parseResult = _parser.Parse(args);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("required", response.Message.ToLower());
+    }
+}

--- a/tests/Areas/Redis/UnitTests/CacheForRedis/AccessPolicyListCommandTests.cs
+++ b/tests/Areas/Redis/UnitTests/CacheForRedis/AccessPolicyListCommandTests.cs
@@ -48,7 +48,7 @@ public class AccessPolicyListCommandTests
             "rg1",
             "sub123",
             Arg.Any<string>(),
-            Arg.Any<Models.AuthMethod>(),
+            Arg.Any<AzureMcp.Models.AuthMethod>(),
             Arg.Any<AzureMcp.Options.RetryPolicyOptions>())
             .Returns(expectedAssignments);
 
@@ -84,7 +84,7 @@ public class AccessPolicyListCommandTests
             "rg1",
             "sub123",
             Arg.Any<string>(),
-            Arg.Any<Models.AuthMethod>(),
+            Arg.Any<AzureMcp.Models.AuthMethod>(),
             Arg.Any<AzureMcp.Options.RetryPolicyOptions>())
             .Returns([]);
 
@@ -107,7 +107,7 @@ public class AccessPolicyListCommandTests
             resourceGroupName: "rg1",
             subscriptionId: "sub123",
             tenant: Arg.Any<string>(),
-            authMethod: Arg.Any<Models.AuthMethod>(),
+            authMethod: Arg.Any<AzureMcp.Models.AuthMethod>(),
             retryPolicy: Arg.Any<AzureMcp.Options.RetryPolicyOptions>())
             .ThrowsAsync(new Exception("Test error"));
 

--- a/tests/Areas/Redis/UnitTests/CacheForRedis/CacheListCommandTests.cs
+++ b/tests/Areas/Redis/UnitTests/CacheForRedis/CacheListCommandTests.cs
@@ -39,7 +39,7 @@ public class CacheListCommandTests
     public async Task ExecuteAsync_ReturnsCaches_WhenCachesExist()
     {
         var expectedCaches = new CacheModel[] { new() { Name = "cache1" }, new() { Name = "cache2" } };
-        _redisService.ListCachesAsync("sub123", Arg.Any<string>(), Arg.Any<Models.AuthMethod>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListCachesAsync("sub123", Arg.Any<string>(), Arg.Any<AzureMcp.Models.AuthMethod>(), Arg.Any<RetryPolicyOptions>())
             .Returns(expectedCaches);
 
         var command = new CacheListCommand(_logger);
@@ -84,7 +84,7 @@ public class CacheListCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
-        _redisService.ListCachesAsync("sub123", Arg.Any<string>(), Arg.Any<Models.AuthMethod>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListCachesAsync("sub123", Arg.Any<string>(), Arg.Any<AzureMcp.Models.AuthMethod>(), Arg.Any<RetryPolicyOptions>())
             .ThrowsAsync(new Exception("Test error"));
 
         var command = new CacheListCommand(_logger);

--- a/tests/Areas/Redis/UnitTests/ManagedRedis/ClusterListCommandTests.cs
+++ b/tests/Areas/Redis/UnitTests/ManagedRedis/ClusterListCommandTests.cs
@@ -39,7 +39,7 @@ public class ClusterListCommandTests
     public async Task ExecuteAsync_ReturnsClusters_WhenClustersExist()
     {
         var expectedClusters = new ClusterModel[] { new() { Name = "cluster1" }, new() { Name = "cluster2" } };
-        _redisService.ListClustersAsync("sub123", Arg.Any<string>(), Arg.Any<Models.AuthMethod>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListClustersAsync("sub123", Arg.Any<string>(), Arg.Any<AzureMcp.Models.AuthMethod>(), Arg.Any<RetryPolicyOptions>())
             .Returns(expectedClusters);
 
         var command = new ClusterListCommand(_logger);
@@ -84,7 +84,7 @@ public class ClusterListCommandTests
     public async Task ExecuteAsync_HandlesException()
     {
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
-        _redisService.ListClustersAsync("sub123", Arg.Any<string>(), Arg.Any<Models.AuthMethod>(), Arg.Any<RetryPolicyOptions>())
+        _redisService.ListClustersAsync("sub123", Arg.Any<string>(), Arg.Any<AzureMcp.Models.AuthMethod>(), Arg.Any<RetryPolicyOptions>())
             .ThrowsAsync(new Exception("Test error"));
 
         var command = new ClusterListCommand(_logger);

--- a/tests/Areas/Redis/UnitTests/ManagedRedis/DatabaseListCommandTests.cs
+++ b/tests/Areas/Redis/UnitTests/ManagedRedis/DatabaseListCommandTests.cs
@@ -64,7 +64,7 @@ public class DatabaseListCommandTests
             "rg1",
             "sub123",
             Arg.Any<string>(),
-            Arg.Any<Models.AuthMethod>(),
+            Arg.Any<AzureMcp.Models.AuthMethod>(),
             Arg.Any<AzureMcp.Options.RetryPolicyOptions>())
             .Returns(expectedDatabases);
 
@@ -100,7 +100,7 @@ public class DatabaseListCommandTests
             "rg1",
             "sub123",
             Arg.Any<string>(),
-            Arg.Any<Models.AuthMethod>(),
+            Arg.Any<AzureMcp.Models.AuthMethod>(),
             Arg.Any<AzureMcp.Options.RetryPolicyOptions>())
             .Returns([]);
 
@@ -123,7 +123,7 @@ public class DatabaseListCommandTests
             "rg1",
             "sub123",
             Arg.Any<string>(),
-            Arg.Any<Models.AuthMethod>(),
+            Arg.Any<AzureMcp.Models.AuthMethod>(),
             Arg.Any<AzureMcp.Options.RetryPolicyOptions>())
             .ThrowsAsync(new Exception("Test error"));
 


### PR DESCRIPTION
The PR adds unit test files for AppConfig commands:

### Account Commands
- **`AccountListCommandTests.cs`** (126 lines)
  - Tests for listing App Configuration accounts
  - Covers success scenarios, empty results, error handling, and validation

### Key-Value Commands
- **`KeyValueDeleteCommandTests.cs`** (156 lines)
  - Tests for deleting key-value pairs
  - Includes tests with and without labels, error scenarios, and parameter validation

- **`KeyValueListCommandTests.cs`**
  - Tests for listing key-value pairs

- **`KeyValueLockCommandTests.cs`**
  - Tests for locking key-value pairs

- **`KeyValueSetCommandTests.cs`**
  - Tests for setting/creating key-value pairs

- **`KeyValueShowCommandTests.cs`**
  - Tests for showing specific key-value pairs

- **`KeyValueUnlockCommandTests.cs`**
  - Tests for unlocking key-value pairs

## Test Coverage
- ✅ Account management operations
- ✅ Complete CRUD operations for key-value pairs
- ✅ Lock/unlock functionality for configuration values
- ✅ Error handling and validation scenarios
- ✅ Support for labeled configuration values

## GitHub issue number?
https://github.com/Azure/azure-mcp-pr/issues/296
