### PR TITLE
Adds support to launche MCP servers in read-only mode

### DIFF
--- a/src/Commands/Server/ToolOperations.cs
+++ b/src/Commands/Server/ToolOperations.cs
@@ -33,6 +33,8 @@ public class ToolOperations
 
     public ToolsCapability ToolsCapability { get; }
 
+    public bool ReadOnly { get; set; } = false;
+
     public string? CommandGroup
     {
         get => _commandGroup;
@@ -49,12 +51,11 @@ public class ToolOperations
             }
         }
     }
-
-    private ValueTask<ListToolsResult> OnListTools(RequestContext<ListToolsRequestParams> requestContext,
-        CancellationToken cancellationToken)
+    private ValueTask<ListToolsResult> OnListTools(RequestContext<ListToolsRequestParams> requestContext, CancellationToken cancellationToken)
     {
         var tools = CommandFactory.GetVisibleCommands(_toolCommands)
             .Select(kvp => GetTool(kvp.Key, kvp.Value))
+            .Where(tool => !ReadOnly || (tool.Annotations?.ReadOnlyHint == true))
             .ToList();
 
         var listToolsResult = new ListToolsResult { Tools = tools };

--- a/src/Commands/Server/Tools/McpCommandGroup.cs
+++ b/src/Commands/Server/Tools/McpCommandGroup.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Core;
 using AzureMcp.Commands;
 using AzureMcp.Commands.Server.Tools;
 using ModelContextProtocol.Client;
@@ -9,25 +8,46 @@ using ModelContextProtocol.Client;
 /// <summary>
 /// Represents a command group that provides metadata and MCP client creation.
 /// </summary>
-public sealed class McpCommandGroup(CommandGroup commandGroup, string? entryPoint = null) : IMcpClientProvider
+public sealed class McpCommandGroup(CommandGroup commandGroup) : IMcpClientProvider
 {
-    private readonly CommandGroup _commandGroup = commandGroup;
-    private readonly string _entryPoint = string.IsNullOrWhiteSpace(entryPoint)
-        ? System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
-        ?? throw new InvalidOperationException("Could not determine the entry point executable for the current process.")
-        : entryPoint;
+    private readonly CommandGroup _commandGroup = commandGroup; private string _entryPoint = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+        ?? throw new InvalidOperationException("Could not determine the entry point executable for the current process.");
+
+    /// <summary>
+    /// Gets or sets the entry point executable path for the MCP server.
+    /// If set to null or empty, defaults to the current process executable.
+    /// </summary>
+    public string EntryPoint
+    {
+        get => _entryPoint;
+        set => _entryPoint = string.IsNullOrWhiteSpace(value)
+            ? System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName
+                ?? throw new InvalidOperationException("Could not determine the entry point executable for the current process.")
+            : value;
+    }
+
+    /// <summary>
+    /// Gets or sets whether the MCP server should run in read-only mode.
+    /// </summary>
+    public bool ReadOnly { get; set; } = false;
 
     /// <summary>
     /// Creates an MCP client from a command group.
     /// </summary>
     public async Task<IMcpClient> CreateClientAsync(McpClientOptions clientOptions)
     {
-        var arguments = new[] { "server", "start", "--service", _commandGroup.Name };
+        var arguments = new List<string> { "server", "start", "--service", _commandGroup.Name };
+
+        if (ReadOnly)
+        {
+            arguments.Add("--read-only");
+        }
+
         var transportOptions = new StdioClientTransportOptions
         {
             Name = _commandGroup.Name,
-            Command = _entryPoint,
-            Arguments = arguments,
+            Command = EntryPoint,
+            Arguments = arguments.ToArray(),
         };
 
         var clientTransport = new StdioClientTransport(transportOptions);

--- a/src/Models/Option/OptionDefinitions.cs
+++ b/src/Models/Option/OptionDefinitions.cs
@@ -370,6 +370,7 @@ public static class OptionDefinitions
         public const string TransportName = "transport";
         public const string PortName = "port";
         public const string ServiceName = "service";
+        public const string ReadOnlyName = "read-only";
 
         public static readonly Option<string> Transport = new(
             $"--{TransportName}",
@@ -397,6 +398,12 @@ public static class OptionDefinitions
         {
             IsRequired = false,
         };
+
+        public static readonly Option<bool?> ReadOnly = new(
+            $"--{ReadOnlyName}",
+            () => null,
+            "Whether the MCP server should be read-only. If true, no write operations will be allowed."
+        );
     }
 
     public static class AppConfig

--- a/src/Options/Server/ServiceStartOptions.cs
+++ b/src/Options/Server/ServiceStartOptions.cs
@@ -15,4 +15,7 @@ public class ServiceStartOptions
 
     [JsonPropertyName("service")]
     public string? Service { get; set; } = null;
+
+    [JsonPropertyName("readOnly")]
+    public bool? ReadOnly { get; set; } = null;
 }

--- a/tests/Commands/Server/Tools/McpCommandGroupTests.cs
+++ b/tests/Commands/Server/Tools/McpCommandGroupTests.cs
@@ -50,7 +50,8 @@ namespace AzureMcp.Tests.Commands.Server.Tools
             var entryPoint = Path.Combine(testBinDir, exeName);
             Assert.True(File.Exists(entryPoint), $"{exeName} not found at {entryPoint}");
 
-            var mcpCommandGroup = new McpCommandGroup(storageGroup, entryPoint);
+            var mcpCommandGroup = new McpCommandGroup(storageGroup);
+            mcpCommandGroup.EntryPoint = entryPoint;
             var options = new McpClientOptions();
 
             // Act
@@ -58,6 +59,79 @@ namespace AzureMcp.Tests.Commands.Server.Tools
 
             // Assert
             Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void ReadOnly_Property_DefaultsToFalse()
+        {
+            // Arrange
+            var storageGroup = _commandFactory.RootGroup.SubGroup.First(g => g.Name == "storage");
+
+            // Act
+            var mcpCommandGroup = new McpCommandGroup(storageGroup);
+
+            // Assert
+            Assert.False(mcpCommandGroup.ReadOnly);
+        }
+
+        [Fact]
+        public void ReadOnly_Property_CanBeSet()
+        {
+            // Arrange
+            var storageGroup = _commandFactory.RootGroup.SubGroup.First(g => g.Name == "storage");
+            var mcpCommandGroup = new McpCommandGroup(storageGroup);
+
+            // Act
+            mcpCommandGroup.ReadOnly = true;
+
+            // Assert
+            Assert.True(mcpCommandGroup.ReadOnly);
+        }
+
+        [Fact]
+        public void EntryPoint_SetToNull_UsesDefault()
+        {
+            // Arrange
+            var storageGroup = _commandFactory.RootGroup.SubGroup.First(g => g.Name == "storage");
+            var mcpCommandGroup = new McpCommandGroup(storageGroup);
+            var originalEntryPoint = mcpCommandGroup.EntryPoint;
+            // Act
+            mcpCommandGroup.EntryPoint = null!;
+
+            // Assert
+            Assert.Equal(originalEntryPoint, mcpCommandGroup.EntryPoint);
+            Assert.False(string.IsNullOrWhiteSpace(mcpCommandGroup.EntryPoint));
+        }
+
+        [Fact]
+        public void EntryPoint_SetToEmpty_UsesDefault()
+        {
+            // Arrange
+            var storageGroup = _commandFactory.RootGroup.SubGroup.First(g => g.Name == "storage");
+            var mcpCommandGroup = new McpCommandGroup(storageGroup);
+            var originalEntryPoint = mcpCommandGroup.EntryPoint;
+
+            // Act
+            mcpCommandGroup.EntryPoint = "";
+
+            // Assert
+            Assert.Equal(originalEntryPoint, mcpCommandGroup.EntryPoint);
+            Assert.False(string.IsNullOrWhiteSpace(mcpCommandGroup.EntryPoint));
+        }
+
+        [Fact]
+        public void EntryPoint_SetToValidValue_UsesProvidedValue()
+        {
+            // Arrange
+            var storageGroup = _commandFactory.RootGroup.SubGroup.First(g => g.Name == "storage");
+            var mcpCommandGroup = new McpCommandGroup(storageGroup);
+            var customEntryPoint = "/custom/path/to/executable";
+
+            // Act
+            mcpCommandGroup.EntryPoint = customEntryPoint;
+
+            // Assert
+            Assert.Equal(customEntryPoint, mcpCommandGroup.EntryPoint);
         }
     }
 }

--- a/tests/Commands/Server/Tools/McpServerProviderTests.cs
+++ b/tests/Commands/Server/Tools/McpServerProviderTests.cs
@@ -51,7 +51,10 @@ namespace AzureMcp.Tests.Commands.Server.Tools
         [Fact]
         public async Task GetProviderClientAsync_ReturnsClientForValidProvider()
         {
-            var service = new McpClientService(_commandFactory, _entryPoint);
+            var service = new McpClientService(_commandFactory)
+            {
+                EntryPoint = _entryPoint
+            };
             var firstMeta = service.ListProviderMetadata()[0];
             var options = new McpClientOptions();
             var client = await service.GetProviderClientAsync(firstMeta.Id, options);
@@ -67,6 +70,34 @@ namespace AzureMcp.Tests.Commands.Server.Tools
             {
                 await service.GetProviderClientAsync("not-a-real-provider", options);
             });
+        }
+
+        [Fact]
+        public void EntryPoint_SetToValidValue_ReturnsSetValue()
+        {
+            var service = new McpClientService(_commandFactory);
+            var customEntryPoint = "/custom/path/to/executable";
+
+            service.EntryPoint = customEntryPoint;
+
+            Assert.Equal(customEntryPoint, service.EntryPoint);
+        }
+
+        [Fact]
+        public void ReadOnly_DefaultValue_IsFalse()
+        {
+            var service = new McpClientService(_commandFactory);
+            Assert.False(service.ReadOnly);
+        }
+
+        [Fact]
+        public void ReadOnly_SetToTrue_ReturnsTrue()
+        {
+            var service = new McpClientService(_commandFactory);
+
+            service.ReadOnly = true;
+
+            Assert.True(service.ReadOnly);
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Adds optional `--read-only` flag when starting MCP server.
When set, it only tools marked as `readonly` are included in the tool listing.

## GitHub issue number?

Resolves #39 

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
