### PR TITLE
Return an empty array instead of null to indicate successful response but empty result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ obj/
 .vs/
 TestResults/
 *.binlog
+.vscode/mcp.json
 
 node_modules/
 .npmrc

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,9 +1,0 @@
-{
-    "servers": {
-        "azure-mcp-server": {
-            "type": "stdio",
-            "command": "D:/dev/github.com/BrianCollet/azure-mcp/src/bin/Debug/net9.0/azmcp.exe",
-            "args": ["server", "start", "--service", "cosmos,redis"]
-        }
-    }
-}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+    "servers": {
+        "azure-mcp-server": {
+            "type": "stdio",
+            "command": "D:/dev/github.com/BrianCollet/azure-mcp/src/bin/Debug/net9.0/azmcp.exe",
+            "args": ["server", "start", "--service", "cosmos,redis"]
+        }
+    }
+}

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/Account/AccountListCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/Account/AccountListCommand.cs
@@ -48,11 +48,9 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = accounts?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new AccountListCommandResult(accounts),
-                    AppConfigJsonContext.Default.AccountListCommandResult) :
-                null;
+                    AppConfigJsonContext.Default.AccountListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueListCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueListCommand.cs
@@ -71,11 +71,9 @@ public sealed class KeyValueListCommand(ILogger<KeyValueListCommand> logger) : B
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = settings?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new KeyValueListCommandResult(settings),
-                    AppConfigJsonContext.Default.KeyValueListCommandResult) :
-                null;
+                    AppConfigJsonContext.Default.KeyValueListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/authorization/src/AzureMcp.Authorization/Commands/RoleAssignmentListCommand.cs
+++ b/areas/authorization/src/AzureMcp.Authorization/Commands/RoleAssignmentListCommand.cs
@@ -64,11 +64,9 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = assignments?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new RoleAssignmentListCommandResult(assignments),
-                    AuthorizationJsonContext.Default.RoleAssignmentListCommandResult) :
-                null;
+                    AuthorizationJsonContext.Default.RoleAssignmentListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/AccountListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/AccountListCommand.cs
@@ -47,11 +47,9 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = accounts?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new AccountListCommandResult(accounts),
-                    CosmosJsonContext.Default.AccountListCommandResult) :
-                null;
+                    CosmosJsonContext.Default.AccountListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/ContainerListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/ContainerListCommand.cs
@@ -50,11 +50,9 @@ public sealed class ContainerListCommand(ILogger<ContainerListCommand> logger) :
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = containers?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new ContainerListCommandResult(containers),
-                    CosmosJsonContext.Default.ContainerListCommandResult) :
-                null;
+                    CosmosJsonContext.Default.ContainerListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/DatabaseListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/DatabaseListCommand.cs
@@ -48,11 +48,9 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = databases?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new DatabaseListCommandResult(databases),
-                    CosmosJsonContext.Default.DatabaseListCommandResult) :
-                null;
+                    CosmosJsonContext.Default.DatabaseListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyListCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyListCommand.cs
@@ -67,11 +67,9 @@ public sealed class KeyListCommand(ILogger<KeyListCommand> logger) : Subscriptio
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = keys?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new KeyListCommandResult(keys),
-                    KeyVaultJsonContext.Default.KeyListCommandResult) :
-                null;
+                    KeyVaultJsonContext.Default.KeyListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/keyvault/tests/AzureMcp.KeyVault.UnitTests/Key/KeyListCommandTests.cs
+++ b/areas/keyvault/tests/AzureMcp.KeyVault.UnitTests/Key/KeyListCommandTests.cs
@@ -26,9 +26,8 @@ public class KeyListCommandTests
     private readonly KeyListCommand _command;
     private readonly CommandContext _context;
     private readonly Parser _parser;
-
-    private const string _knownSubscriptionId = "knownSubscriptionId";
-    private const string _knownVaultName = "knownVaultName";
+    private readonly string _knownSubscriptionId = "00000000-0000-0000-0000-000000000001";
+    private readonly string _knownVaultName = "vault123";
 
     public KeyListCommandTests()
     {
@@ -50,15 +49,12 @@ public class KeyListCommandTests
         // Arrange
         var expectedKeys = new List<string> { "key1", "key2" };
 
-        _keyVaultService.ListKeys(
-            Arg.Is(_knownVaultName),
-            Arg.Any<bool>(),
-            Arg.Is(_knownSubscriptionId),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
-            .Returns(expectedKeys);
+        _keyVaultService.ListKeys(Arg.Is(_knownVaultName), Arg.Any<bool>(), Arg.Is(_knownSubscriptionId), Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()).Returns(expectedKeys);
 
         var args = _parser.Parse([
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId,
             "--vault", _knownVaultName,
             "--subscription", _knownSubscriptionId
         ]);
@@ -78,18 +74,15 @@ public class KeyListCommandTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ReturnsNull_WhenNoKeys()
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoKeys()
     {
         // Arrange
-        _keyVaultService.ListKeys(
-            Arg.Is(_knownVaultName),
-            Arg.Any<bool>(),
-            Arg.Is(_knownSubscriptionId),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
-            .Returns([]);
+        _keyVaultService.ListKeys(_knownVaultName, Arg.Any<bool>(), Arg.Is(_knownSubscriptionId), Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()).Returns([]);
 
         var args = _parser.Parse([
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId,
             "--vault", _knownVaultName,
             "--subscription", _knownSubscriptionId
         ]);
@@ -99,7 +92,14 @@ public class KeyListCommandTests
 
         // Assert
         Assert.NotNull(response);
-        Assert.Null(response.Results);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<KeyListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Keys);
+        Assert.Empty(result.Keys);
     }
 
     [Fact]
@@ -108,15 +108,12 @@ public class KeyListCommandTests
         // Arrange
         var expectedError = "Test error";
 
-        _keyVaultService.ListKeys(
-            Arg.Is(_knownVaultName),
-            Arg.Any<bool>(),
-            Arg.Is(_knownSubscriptionId),
-            Arg.Any<string>(),
-            Arg.Any<RetryPolicyOptions>())
-            .ThrowsAsync(new Exception(expectedError));
+        _keyVaultService.ListKeys(_knownVaultName, Arg.Any<bool>(), Arg.Is(_knownSubscriptionId), Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()).ThrowsAsync(new Exception(expectedError));
 
         var args = _parser.Parse([
+            "--vault", _knownVaultName,
+            "--subscription", _knownSubscriptionId,
             "--vault", _knownVaultName,
             "--subscription", _knownSubscriptionId
         ]);

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterListCommand.cs
@@ -48,9 +48,7 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Sub
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = clusterNames?.Count > 0 ?
-                ResponseResult.Create(new ClusterListCommandResult(clusterNames), KustoJsonContext.Default.ClusterListCommandResult) :
-                null;
+            context.Response.Results = ResponseResult.Create(new ClusterListCommandResult(clusterNames), KustoJsonContext.Default.ClusterListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/DatabaseListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/DatabaseListCommand.cs
@@ -63,9 +63,7 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
                     options.RetryPolicy);
             }
 
-            context.Response.Results = databasesNames?.Count > 0 ?
-                ResponseResult.Create(new DatabaseListCommandResult(databasesNames), KustoJsonContext.Default.DatabaseListCommandResult) :
-                null;
+            context.Response.Results = ResponseResult.Create(new DatabaseListCommandResult(databasesNames), KustoJsonContext.Default.DatabaseListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/TableListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/TableListCommand.cs
@@ -64,9 +64,7 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseDat
                     options.RetryPolicy);
             }
 
-            context.Response.Results = tableNames?.Count > 0 ?
-                ResponseResult.Create(new TableListCommandResult(tableNames), KustoJsonContext.Default.TableListCommandResult) :
-                null;
+            context.Response.Results = ResponseResult.Create(new TableListCommandResult(tableNames), KustoJsonContext.Default.TableListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/kusto/tests/AzureMcp.Kusto.UnitTests/ClusterListCommandTests.cs
+++ b/areas/kusto/tests/AzureMcp.Kusto.UnitTests/ClusterListCommandTests.cs
@@ -20,18 +20,24 @@ namespace AzureMcp.Kusto.UnitTests;
 public sealed class ClusterListCommandTests
 {
     private readonly IServiceProvider _serviceProvider;
-    private readonly IKustoService _kusto;
+    private readonly IKustoService _kustoService;
     private readonly ILogger<ClusterListCommand> _logger;
+    private readonly ClusterListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+    private readonly string _knownSubscriptionId = "00000000-0000-0000-0000-000000000001";
 
     public ClusterListCommandTests()
     {
-        _kusto = Substitute.For<IKustoService>();
+        _kustoService = Substitute.For<IKustoService>();
         _logger = Substitute.For<ILogger<ClusterListCommand>>();
 
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_kusto);
+        var collection = new ServiceCollection().AddSingleton(_kustoService);
 
         _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
     }
 
     [Fact]
@@ -39,17 +45,14 @@ public sealed class ClusterListCommandTests
     {
         // Arrange
         var expectedClusters = new List<string> { "clusterA", "clusterB" };
-        _kusto.ListClusters(
-            "sub123", Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+        _kustoService.ListClusters(
+            Arg.Is(_knownSubscriptionId), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
             .Returns(expectedClusters);
 
-        var command = new ClusterListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123"]);
-        var context = new CommandContext(_serviceProvider);
-
+        var args = _parser.Parse(["--subscription", _knownSubscriptionId]);
 
         // Act
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         // Assert
         Assert.NotNull(response);
@@ -63,22 +66,27 @@ public sealed class ClusterListCommandTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ReturnsNull_WhenNoClustersExist()
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoClustersExist()
     {
         // Arrange
-        _kusto.ListClusters("sub123", null, null)
+        _kustoService.ListClusters(Arg.Is(_knownSubscriptionId), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
             .Returns([]);
 
-        var command = new ClusterListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123"]);
-        var context = new CommandContext(_serviceProvider);
+        var args = _parser.Parse(["--subscription", _knownSubscriptionId]);
 
         // Act
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         // Assert
         Assert.NotNull(response);
-        Assert.Null(response.Results);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ClusterListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Clusters);
+        Assert.Empty(result.Clusters);
     }
 
     [Fact]
@@ -86,18 +94,15 @@ public sealed class ClusterListCommandTests
     {
         // Arrange
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
-        var subscriptionId = "sub123";
 
         // Arrange
-        _kusto.ListClusters(subscriptionId, null, Arg.Any<RetryPolicyOptions>())
+        _kustoService.ListClusters(Arg.Is(_knownSubscriptionId), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
             .Returns(Task.FromException<List<string>>(new Exception("Test error")));
 
-        var command = new ClusterListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", subscriptionId]);
-        var context = new CommandContext(_serviceProvider);
+        var args = _parser.Parse(["--subscription", _knownSubscriptionId]);
 
         // Act
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         // Assert
         Assert.NotNull(response);
@@ -108,6 +113,6 @@ public sealed class ClusterListCommandTests
     private sealed class ClusterListResult
     {
         [JsonPropertyName("clusters")]
-        public List<string>? Clusters { get; set; }
+        public List<string> Clusters { get; set; } = [];
     }
 }

--- a/areas/kusto/tests/AzureMcp.Kusto.UnitTests/DatabaseListCommandTests.cs
+++ b/areas/kusto/tests/AzureMcp.Kusto.UnitTests/DatabaseListCommandTests.cs
@@ -76,7 +76,7 @@ public sealed class DatabaseListCommandTests
 
     [Theory]
     [MemberData(nameof(DatabaseArgumentMatrix))]
-    public async Task ExecuteAsync_ReturnsNull_WhenNoDatabasesExist(string cliArgs, bool useClusterUri)
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoDatabasesExist(string cliArgs, bool useClusterUri)
     {
         // Arrange
         if (useClusterUri)
@@ -92,6 +92,7 @@ public sealed class DatabaseListCommandTests
                 "sub1", "mycluster", Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>())
                 .Returns([]);
         }
+
         var command = new DatabaseListCommand(_logger);
         var parser = new Parser(command.GetCommand());
         var args = parser.Parse(cliArgs);
@@ -102,7 +103,14 @@ public sealed class DatabaseListCommandTests
 
         // Assert
         Assert.NotNull(response);
-        Assert.Null(response.Results);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<DatabaseListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Databases);
+        Assert.Empty(result.Databases);
     }
 
     [Theory]

--- a/areas/kusto/tests/AzureMcp.Kusto.UnitTests/TableListCommandTests.cs
+++ b/areas/kusto/tests/AzureMcp.Kusto.UnitTests/TableListCommandTests.cs
@@ -77,7 +77,7 @@ public sealed class TableListCommandTests
 
     [Theory]
     [MemberData(nameof(TableListArgumentMatrix))]
-    public async Task ExecuteAsync_ReturnsNull_WhenNoTables(string cliArgs, bool useClusterUri)
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoTables(string cliArgs, bool useClusterUri)
     {
         if (useClusterUri)
         {
@@ -94,14 +94,25 @@ public sealed class TableListCommandTests
                 Arg.Any<string>(), Arg.Any<AuthMethod?>(), Arg.Any<RetryPolicyOptions>())
                 .Returns(new List<string>());
         }
+
         var command = new TableListCommand(_logger);
         var parser = new Parser(command.GetCommand());
         var args = parser.Parse(cliArgs);
         var context = new CommandContext(_serviceProvider);
 
+        // Act
         var response = await command.ExecuteAsync(context, args);
+
+        // Assert
         Assert.NotNull(response);
-        Assert.Null(response.Results);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<TablesListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tables);
+        Assert.Empty(result.Tables);
     }
 
     [Theory]

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Table/TableListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Table/TableListCommand.cs
@@ -58,9 +58,7 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseMon
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = tables?.Count > 0 ?
-                ResponseResult.Create(new TableListCommandResult(tables), MonitorJsonContext.Default.TableListCommandResult) :
-                null;
+            context.Response.Results = ResponseResult.Create(new TableListCommandResult(tables), MonitorJsonContext.Default.TableListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/TableType/TableTypeListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/TableType/TableTypeListCommand.cs
@@ -58,12 +58,10 @@ public sealed class TableTypeListCommand(ILogger<TableTypeListCommand> logger) :
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = tableTypes?.Count > 0 ?
-                ResponseResult.Create<TableTypeListCommandResult>(
+            context.Response.Results = ResponseResult.Create<TableTypeListCommandResult>(
                     new TableTypeListCommandResult(tableTypes),
                     MonitorJsonContext.Default.TableTypeListCommandResult // Changed to match the expected type
-                ) :
-                null;
+                );
         }
         catch (Exception ex)
         {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Workspace/WorkspaceListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Workspace/WorkspaceListCommand.cs
@@ -49,11 +49,9 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger) :
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = workspaces?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new WorkspaceListCommandResult(workspaces),
-                    MonitorJsonContext.Default.WorkspaceListCommandResult) :
-                null;
+                    MonitorJsonContext.Default.WorkspaceListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseListCommand.cs
@@ -36,11 +36,9 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
 
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
             List<string> databases = await pgService.ListDatabasesAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!);
-            context.Response.Results = databases?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new DatabaseListCommandResult(databases),
-                    PostgresJsonContext.Default.DatabaseListCommandResult) :
-                null;
+                    PostgresJsonContext.Default.DatabaseListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/ServerListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/ServerListCommand.cs
@@ -37,11 +37,9 @@ public sealed class ServerListCommand(ILogger<ServerListCommand> logger) : BaseP
 
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
             List<string> servers = await pgService.ListServersAsync(options.Subscription!, options.ResourceGroup!, options.User!);
-            context.Response.Results = servers?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new ServerListCommandResult(servers),
-                    PostgresJsonContext.Default.ServerListCommandResult) :
-                null;
+                    PostgresJsonContext.Default.ServerListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Table/TableListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Table/TableListCommand.cs
@@ -35,11 +35,9 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseDat
 
             IPostgresService pgService = context.GetService<IPostgresService>() ?? throw new InvalidOperationException("PostgreSQL service is not available.");
             List<string> tables = await pgService.ListTablesAsync(options.Subscription!, options.ResourceGroup!, options.User!, options.Server!, options.Database!);
-            context.Response.Results = tables?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new TableListCommandResult(tables),
-                    PostgresJsonContext.Default.TableListCommandResult) :
-                null;
+                    PostgresJsonContext.Default.TableListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/postgres/tests/AzureMcp.Postgres.UnitTests/Database/DatabaseListCommandTests.cs
+++ b/areas/postgres/tests/AzureMcp.Postgres.UnitTests/Database/DatabaseListCommandTests.cs
@@ -22,29 +22,41 @@ public class DatabaseListCommandTests
     private readonly IServiceProvider _serviceProvider;
     private readonly IPostgresService _postgresService;
     private readonly ILogger<DatabaseListCommand> _logger;
+    private readonly DatabaseListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+    private readonly string _knownSubscriptionId = "00000000-0000-0000-0000-000000000001";
+    private readonly string _knownResourceGroup = "rg1";
+    private readonly string _knownUser = "user1";
+    private readonly string _knownServer = "server1";
 
     public DatabaseListCommandTests()
     {
         _postgresService = Substitute.For<IPostgresService>();
         _logger = Substitute.For<ILogger<DatabaseListCommand>>();
 
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_postgresService);
+        var collection = new ServiceCollection().AddSingleton(_postgresService);
 
         _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsDatabases_WhenDatabasesExist()
     {
         var expectedDatabases = new List<string> { "db1", "db2" };
-        _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").Returns(expectedDatabases);
+        _postgresService.ListDatabasesAsync(Arg.Is(_knownSubscriptionId), Arg.Is(_knownResourceGroup), Arg.Is(_knownUser), Arg.Is(_knownServer)).Returns(expectedDatabases);
 
-        var command = new DatabaseListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
-        var context = new CommandContext(_serviceProvider);
+        var args = _parser.Parse([
+            "--subscription", _knownSubscriptionId,
+            "--resource-group", _knownResourceGroup,
+            "--user-name", _knownUser,
+            "--server", _knownServer
+        ]);
 
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
         Assert.Equal(200, response.Status);
@@ -60,29 +72,43 @@ public class DatabaseListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsMessage_WhenNoDatabasesExist()
     {
-        _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").Returns([]);
+        _postgresService.ListDatabasesAsync(Arg.Is(_knownSubscriptionId), Arg.Is(_knownResourceGroup), Arg.Is(_knownUser), Arg.Is(_knownServer)).Returns([]);
 
-        var command = new DatabaseListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
-        var context = new CommandContext(_serviceProvider);
+        var args = _parser.Parse([
+            "--subscription", _knownSubscriptionId,
+            "--resource-group", _knownResourceGroup,
+            "--user-name", _knownUser,
+            "--server", _knownServer
+        ]);
 
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
+        Assert.NotNull(response.Results);
         Assert.Equal(200, response.Status);
         Assert.Equal("Success", response.Message);
-        Assert.Null(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<DatabaseListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Databases);
+        Assert.Empty(result.Databases);
     }
 
     [Fact]
     public async Task ExecuteAsync_HandlesException()
     {
-        _postgresService.ListDatabasesAsync("sub123", "rg1", "user1", "server1").ThrowsAsync(new Exception("Test exception"));
+        _postgresService.ListDatabasesAsync(Arg.Is(_knownSubscriptionId), Arg.Is(_knownResourceGroup), Arg.Is(_knownUser), Arg.Is(_knownServer)).ThrowsAsync(new Exception("Test exception"));
 
-        var command = new DatabaseListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args);
+        var args = _parser.Parse([
+            "--subscription", _knownSubscriptionId,
+            "--resource-group", _knownResourceGroup,
+            "--user-name", _knownUser,
+            "--server", _knownServer
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
         Assert.Equal(500, response.Status);
@@ -96,17 +122,15 @@ public class DatabaseListCommandTests
     [InlineData("--server")]
     public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
     {
-        var command = new DatabaseListCommand(_logger);
-        var args = command.GetCommand().Parse(new string[]
+        var args = _parser.Parse(new string[]
         {
-            missingParameter == "--subscription" ? "" : "--subscription", "sub123",
-            missingParameter == "--resource-group" ? "" : "--resource-group", "rg1",
-            missingParameter == "--user" ? "" : "--user", "user1",
-            missingParameter == "--server" ? "" : "--server", "server123",
+            missingParameter == "--subscription" ? "" : "--subscription", _knownSubscriptionId,
+            missingParameter == "--resource-group" ? "" : "--resource-group", _knownResourceGroup,
+            missingParameter == "--user-name" ? "" : "--user-name", _knownUser,
+            missingParameter == "--server" ? "" : "--server", _knownServer,
         });
 
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
         Assert.Equal(400, response.Status);

--- a/areas/postgres/tests/AzureMcp.Postgres.UnitTests/Server/ServerListCommandTests.cs
+++ b/areas/postgres/tests/AzureMcp.Postgres.UnitTests/Server/ServerListCommandTests.cs
@@ -22,27 +22,39 @@ public class ServerListCommandTests
     private readonly IServiceProvider _serviceProvider;
     private readonly IPostgresService _postgresService;
     private readonly ILogger<ServerListCommand> _logger;
+    private readonly ServerListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+    private readonly string _knownSubscriptionId = "00000000-0000-0000-0000-000000000001";
+    private readonly string _knownResourceGroup = "rg1";
+    private readonly string _knownUser = "user1";
 
     public ServerListCommandTests()
     {
         _postgresService = Substitute.For<IPostgresService>();
         _logger = Substitute.For<ILogger<ServerListCommand>>();
 
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_postgresService);
+        var collection = new ServiceCollection().AddSingleton(_postgresService);
 
         _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsServers_WhenServersExist()
     {
         var expectedServers = new List<string> { "server1", "server2" };
-        _postgresService.ListServersAsync("sub123", "rg1", "user1").Returns(expectedServers);
-        var command = new ServerListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args);
+        _postgresService.ListServersAsync(Arg.Is(_knownSubscriptionId), Arg.Is(_knownResourceGroup), Arg.Is(_knownUser)).Returns(expectedServers);
+
+        var args = _parser.Parse([
+            "--subscription", _knownSubscriptionId,
+            "--resource-group", _knownResourceGroup,
+            "--user-name", _knownUser
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
         Assert.Equal(200, response.Status);
@@ -51,38 +63,50 @@ public class ServerListCommandTests
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize<ServerListResult>(json);
+
         Assert.NotNull(result);
         Assert.Equal(expectedServers, result.Servers);
     }
 
     [Fact]
-    public async Task ExecuteAsync_ReturnsNull_WhenNoServers()
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoServers()
     {
-        _postgresService.ListServersAsync("sub123", "rg1", "user1").Returns([]);
+        _postgresService.ListServersAsync(Arg.Is(_knownSubscriptionId), Arg.Is(_knownResourceGroup), Arg.Is(_knownUser)).Returns([]);
 
-        var command = new ServerListCommand(_logger);
-        var parser = new Parser(command.GetCommand());
-        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args);
+        var args = _parser.Parse([
+            "--subscription", _knownSubscriptionId,
+            "--resource-group", _knownResourceGroup,
+            "--user-name", _knownUser
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
-        Assert.Null(response.Results);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ServerListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Servers);
+        Assert.Empty(result.Servers);
     }
 
     [Fact]
     public async Task ExecuteAsync_HandlesException()
     {
         var expectedError = "Test error. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.";
-        _postgresService.ListServersAsync("sub123", "rg1", "user1")
+
+        _postgresService.ListServersAsync(Arg.Is(_knownSubscriptionId), Arg.Is(_knownResourceGroup), Arg.Is(_knownUser))
             .ThrowsAsync(new Exception("Test error"));
 
-        var command = new ServerListCommand(_logger);
-        var parser = new Parser(command.GetCommand());
-        var args = parser.Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1"]);
-        var context = new CommandContext(_serviceProvider);
+        var args = _parser.Parse([
+            "--subscription", _knownSubscriptionId,
+            "--resource-group", _knownResourceGroup,
+            "--user-name", _knownUser
+        ]);
 
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
         Assert.Equal(500, response.Status);
@@ -95,16 +119,14 @@ public class ServerListCommandTests
     [InlineData("--user")]
     public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
     {
-        var command = new ServerListCommand(_logger);
-        var args = command.GetCommand().Parse(new string[]
+        var args = _parser.Parse(new string[]
         {
-            missingParameter == "--subscription" ? "" : "--subscription", "sub123",
-            missingParameter == "--resource-group" ? "" : "--resource-group", "rg1",
-            missingParameter == "--user" ? "" : "--user", "user1",
+            missingParameter == "--subscription" ? "" : "--subscription", _knownSubscriptionId,
+            missingParameter == "--resource-group" ? "" : "--resource-group", _knownResourceGroup,
+            missingParameter == "--user-name" ? "" : "--user-name", _knownUser,
         });
 
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
         Assert.Equal(400, response.Status);

--- a/areas/postgres/tests/AzureMcp.Postgres.UnitTests/Table/TableListCommandTests.cs
+++ b/areas/postgres/tests/AzureMcp.Postgres.UnitTests/Table/TableListCommandTests.cs
@@ -21,28 +21,43 @@ public class TableListCommandTests
     private readonly IServiceProvider _serviceProvider;
     private readonly IPostgresService _postgresService;
     private readonly ILogger<TableListCommand> _logger;
+    private readonly TableListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+    private readonly string _knownSubscriptionId = "00000000-0000-0000-0000-000000000001";
+    private readonly string _knownResourceGroup = "rg1";
+    private readonly string _knownUser = "user1";
+    private readonly string _knownServer = "server1";
+    private readonly string _knownDatabase = "db123";
 
     public TableListCommandTests()
     {
         _postgresService = Substitute.For<IPostgresService>();
         _logger = Substitute.For<ILogger<TableListCommand>>();
 
-        var collection = new ServiceCollection();
-        collection.AddSingleton(_postgresService);
+        var collection = new ServiceCollection().AddSingleton(_postgresService);
 
         _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsTables_WhenTablesExist()
     {
         var expectedTables = new List<string> { "table1", "table2" };
-        _postgresService.ListTablesAsync("sub123", "rg1", "user1", "server1", "db123").Returns(expectedTables);
+        _postgresService.ListTablesAsync(Arg.Is(_knownSubscriptionId), Arg.Is(_knownResourceGroup), Arg.Is(_knownUser), Arg.Is(_knownServer), Arg.Is(_knownDatabase)).Returns(expectedTables);
 
-        var command = new TableListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args);
+        var args = _parser.Parse([
+            "--subscription", _knownSubscriptionId,
+            "--resource-group", _knownResourceGroup,
+            "--user-name", _knownUser,
+            "--server", _knownServer,
+            "--database", _knownDatabase
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
         Assert.Equal(200, response.Status);
@@ -51,6 +66,7 @@ public class TableListCommandTests
 
         var json = JsonSerializer.Serialize(response.Results);
         var result = JsonSerializer.Deserialize<TableListResult>(json);
+
         Assert.NotNull(result);
         Assert.Equal(expectedTables, result.Tables);
     }
@@ -58,17 +74,29 @@ public class TableListCommandTests
     [Fact]
     public async Task ExecuteAsync_ReturnsEmptyList_WhenNoTablesExist()
     {
-        _postgresService.ListTablesAsync("sub123", "rg1", "user1", "server1", "db123").Returns([]);
+        _postgresService.ListTablesAsync(Arg.Is(_knownSubscriptionId), Arg.Is(_knownResourceGroup), Arg.Is(_knownUser), Arg.Is(_knownServer), Arg.Is(_knownDatabase)).Returns([]);
 
-        var command = new TableListCommand(_logger);
-        var args = command.GetCommand().Parse(["--subscription", "sub123", "--resource-group", "rg1", "--user", "user1", "--server", "server1", "--database", "db123"]);
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args);
+        var args = _parser.Parse([
+            "--subscription", _knownSubscriptionId,
+            "--resource-group", _knownResourceGroup,
+            "--user-name", _knownUser,
+            "--server", _knownServer,
+            "--database", _knownDatabase
+        ]);
+
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
+        Assert.NotNull(response.Results);
         Assert.Equal(200, response.Status);
         Assert.Equal("Success", response.Message);
-        Assert.Null(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<TableListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tables);
+        Assert.Empty(result.Tables);
     }
 
     [Theory]
@@ -79,18 +107,16 @@ public class TableListCommandTests
     [InlineData("--database")]
     public async Task ExecuteAsync_ReturnsError_WhenParameterIsMissing(string missingParameter)
     {
-        var command = new TableListCommand(_logger);
-        var args = command.GetCommand().Parse(new string[]
+        var args = _parser.Parse(new string[]
         {
-            missingParameter == "--subscription" ? "" : "--subscription", "sub123",
-            missingParameter == "--resource-group" ? "" : "--resource-group", "rg1",
-            missingParameter == "--user" ? "" : "--user", "user1",
-            missingParameter == "--server" ? "" : "--server", "server123",
-            missingParameter == "--database" ? "" : "--database", "db123"
+            missingParameter == "--subscription" ? "" : "--subscription", _knownSubscriptionId,
+            missingParameter == "--resource-group" ? "" : "--resource-group", _knownResourceGroup,
+            missingParameter == "--user-name" ? "" : "--user-name", _knownUser,
+            missingParameter == "--server" ? "" : "--server", _knownServer,
+            missingParameter == "--database" ? "" : "--database", _knownDatabase
         });
 
-        var context = new CommandContext(_serviceProvider);
-        var response = await command.ExecuteAsync(context, args);
+        var response = await _command.ExecuteAsync(_context, args);
 
         Assert.NotNull(response);
         Assert.Equal(400, response.Status);

--- a/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/AccessPolicyListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/AccessPolicyListCommand.cs
@@ -52,11 +52,9 @@ public sealed class AccessPolicyListCommand(ILogger<AccessPolicyListCommand> log
                 options.AuthMethod,
                 options.RetryPolicy);
 
-            context.Response.Results = accessPolicyAssignments.Any() ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new AccessPolicyListCommandResult(accessPolicyAssignments),
-                    RedisJsonContext.Default.AccessPolicyListCommandResult) :
-                null;
+                    RedisJsonContext.Default.AccessPolicyListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/CacheListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/CacheListCommand.cs
@@ -52,11 +52,9 @@ public sealed class CacheListCommand(ILogger<CacheListCommand> logger) : Subscri
                 options.AuthMethod,
                 options.RetryPolicy);
 
-            context.Response.Results = caches.Any() ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new CacheListCommandResult(caches),
-                    RedisJsonContext.Default.CacheListCommandResult) :
-                null;
+                    RedisJsonContext.Default.CacheListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/ClusterListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/ClusterListCommand.cs
@@ -52,11 +52,9 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Sub
                 options.AuthMethod,
                 options.RetryPolicy);
 
-            context.Response.Results = clusters.Any() ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new ClusterListCommandResult(clusters),
-                    RedisJsonContext.Default.ClusterListCommandResult) :
-                null;
+                    RedisJsonContext.Default.ClusterListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/DatabaseListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/DatabaseListCommand.cs
@@ -52,11 +52,9 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
                 options.AuthMethod,
                 options.RetryPolicy);
 
-            context.Response.Results = databases.Any() ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new DatabaseListCommandResult(databases),
-                    RedisJsonContext.Default.DatabaseListCommandResult) :
-                null;
+                    RedisJsonContext.Default.DatabaseListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexListCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexListCommand.cs
@@ -59,11 +59,9 @@ public sealed class IndexListCommand(ILogger<IndexListCommand> logger) : GlobalC
                 options.Service!,
                 options.RetryPolicy);
 
-            context.Response.Results = indexes?.Count > 0
-                ? ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new IndexListCommandResult(indexes),
-                    SearchJsonContext.Default.IndexListCommandResult)
-                : null;
+                    SearchJsonContext.Default.IndexListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/search/src/AzureMcp.Search/Commands/Service/ServiceListCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Service/ServiceListCommand.cs
@@ -49,10 +49,9 @@ public sealed class ServiceListCommand(ILogger<ServiceListCommand> logger) : Sub
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = services?.Count > 0 ?
-                ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new ServiceListCommandResult(services),
-                    SearchJsonContext.Default.ServiceListCommandResult) : null;
+                    SearchJsonContext.Default.ServiceListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Account/AccountListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Account/AccountListCommand.cs
@@ -49,9 +49,7 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = accounts?.Count > 0
-                ? ResponseResult.Create(new Result(accounts), StorageJsonContext.Default.AccountListCommandResult)
-                : null;
+            context.Response.Results = ResponseResult.Create(new Result(accounts), StorageJsonContext.Default.AccountListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/BlobListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/BlobListCommand.cs
@@ -52,9 +52,7 @@ public sealed class BlobListCommand(ILogger<BlobListCommand> logger) : BaseConta
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = blobs?.Count > 0
-                ? ResponseResult.Create(new BlobListCommandResult(blobs), StorageJsonContext.Default.BlobListCommandResult)
-                : null;
+            context.Response.Results = ResponseResult.Create(new BlobListCommandResult(blobs), StorageJsonContext.Default.BlobListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerListCommand.cs
@@ -49,11 +49,9 @@ public sealed class ContainerListCommand(ILogger<ContainerListCommand> logger) :
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = containers?.Count > 0
-                ? ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new ContainerListCommandResult(containers),
-                    StorageJsonContext.Default.ContainerListCommandResult)
-                : null;
+                    StorageJsonContext.Default.ContainerListCommandResult);
         }
         catch (Exception ex)
         {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Table/TableListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Table/TableListCommand.cs
@@ -50,9 +50,7 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseSto
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = tables?.Count > 0
-                ? ResponseResult.Create(new TableListCommandResult(tables), StorageJsonContext.Default.TableListCommandResult)
-                : null;
+            context.Response.Results = ResponseResult.Create(new TableListCommandResult(tables), StorageJsonContext.Default.TableListCommandResult);
 
             // Only show warning if we actually had to fall back to a different auth method
             if (context.Response.Results is not null && !string.IsNullOrEmpty(context.Response.Message))

--- a/areas/storage/tests/AzureMcp.Storage.UnitTests/Blob/BlobListCommandTests.cs
+++ b/areas/storage/tests/AzureMcp.Storage.UnitTests/Blob/BlobListCommandTests.cs
@@ -72,7 +72,7 @@ public class BlobListCommandTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ReturnsNull_WhenNoBlobs()
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoBlobs()
     {
         // Arrange
         _storageService.ListBlobs(Arg.Is(_knownAccountName), Arg.Is(_knownContainerName), Arg.Is(_knownSubscriptionId),
@@ -89,7 +89,14 @@ public class BlobListCommandTests
 
         // Assert
         Assert.NotNull(response);
-        Assert.Null(response.Results);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<BlobListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Blobs);
+        Assert.Empty(result.Blobs);
     }
 
     [Fact]

--- a/areas/storage/tests/AzureMcp.Storage.UnitTests/Blob/Container/ContainerListCommandTests.cs
+++ b/areas/storage/tests/AzureMcp.Storage.UnitTests/Blob/Container/ContainerListCommandTests.cs
@@ -70,7 +70,7 @@ public class ContainerListCommandTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ReturnsNull_WhenNoContainers()
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoContainers()
     {
         // Arrange
         _storageService.ListContainers(Arg.Is(_knownAccountName), Arg.Is(_knownSubscriptionId), Arg.Any<string>(),
@@ -86,7 +86,14 @@ public class ContainerListCommandTests
 
         // Assert
         Assert.NotNull(response);
-        Assert.Null(response.Results);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ContainerListResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Containers);
+        Assert.Empty(result.Containers);
     }
 
     [Fact]

--- a/areas/storage/tests/AzureMcp.Storage.UnitTests/Table/TableListCommandTests.cs
+++ b/areas/storage/tests/AzureMcp.Storage.UnitTests/Table/TableListCommandTests.cs
@@ -74,7 +74,7 @@ public class TableListCommandTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ReturnsNull_WhenNoTables()
+    public async Task ExecuteAsync_ReturnsEmptyList_WhenNoTables()
     {
         // Arrange
         _storageService.ListTables(Arg.Is(_knownAccountName), Arg.Is(_knownSubscriptionId),
@@ -92,7 +92,14 @@ public class TableListCommandTests
 
         // Assert
         Assert.NotNull(response);
-        Assert.Null(response.Results);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var results = JsonSerializer.Deserialize<TableListResult>(json);
+
+        Assert.NotNull(results);
+        Assert.NotNull(results.Tables);
+        Assert.Empty(results.Tables);
     }
 
     [Fact]

--- a/core/src/AzureMcp.Core/Areas/Group/Commands/GroupJsonContext.cs
+++ b/core/src/AzureMcp.Core/Areas/Group/Commands/GroupJsonContext.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 
 namespace AzureMcp.Core.Areas.Group.Commands;
 
-[JsonSerializable(typeof(GroupListCommand.Result))]
+[JsonSerializable(typeof(GroupListCommand.GroupListCommandResult))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal partial class GroupJsonContext : JsonSerializerContext
 {

--- a/core/src/AzureMcp.Core/Areas/Group/Commands/GroupListCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Group/Commands/GroupListCommand.cs
@@ -49,9 +49,7 @@ public sealed class GroupListCommand(ILogger<GroupListCommand> logger) : Subscri
                 options.Tenant,
                 options.RetryPolicy);
 
-            context.Response.Results = groups?.Count > 0 ?
-                ResponseResult.Create(new Result(groups), GroupJsonContext.Default.Result) :
-                null;
+            context.Response.Results = ResponseResult.Create(new GroupListCommandResult(groups), GroupJsonContext.Default.GroupListCommandResult);
         }
         catch (Exception ex)
         {
@@ -62,5 +60,5 @@ public sealed class GroupListCommand(ILogger<GroupListCommand> logger) : Subscri
         return context.Response;
     }
 
-    internal record class Result(List<ResourceGroupInfo> Groups);
+    internal record class GroupListCommandResult(List<ResourceGroupInfo> Groups);
 }

--- a/core/src/AzureMcp.Core/Areas/Subscription/Commands/SubscriptionListCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Subscription/Commands/SubscriptionListCommand.cs
@@ -41,11 +41,9 @@ public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> log
             var subscriptionService = context.GetService<ISubscriptionService>();
             var subscriptions = await subscriptionService.GetSubscriptions(options.Tenant, options.RetryPolicy);
 
-            context.Response.Results = subscriptions?.Count > 0
-                ? ResponseResult.Create(
+            context.Response.Results = ResponseResult.Create(
                     new SubscriptionListCommandResult(subscriptions),
-                    SubscriptionJsonContext.Default.SubscriptionListCommandResult)
-                : null;
+                    SubscriptionJsonContext.Default.SubscriptionListCommandResult);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## What does this PR do?
Returns empty array instead of omitting results field for successful responses
Updated tests to check for empty array instead of null

## GitHub issue number?
Fixes #382

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If it's a core feature, I have added thorough tests.
- [ ] If it's a noteworthy bug fix or new feature, I have added an entry in CHANGELOG.md with a link back to the PR or issue
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
