### PR TITLE
Add Docker HealthCheck and linux package to support container healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,15 @@ RUN apt-get update && apt-get install -y \
     apt-transport-https \
     lsb-release \
     gnupg \
+    net-tools \
+    procps \
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the published application
 COPY --from=publish "/app/publish/linux-x64/dist" .
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD pids=$(pgrep -f "azmcp.dll") && [ -n "$pids" ] && echo "$pids" | head -1 | xargs -I {} netstat -tlnp | grep -q "{}/" || exit 1
 
 ENTRYPOINT ["dotnet", "azmcp.dll", "server", "start"]


### PR DESCRIPTION

## What does this PR do?

Solve #417

Add `procps` and `net-tools` to the Docker Image to support infrastructure health checks. It doesn't implement the application HealthCheck endpoint, but gives the possibility to check if the server is running correctly and exposed to a TCP Port.

 Add `HEALTHCHECK` to the Dockerfile. 

## GitHub issue number?

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] For core features, I have added thorough tests.
- [ ] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a CHANGELOG.md entry linking to this PR.
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
