### PR TITLE
Fix obsoletion warnings for JsonSerializerOptions.IgnoreNullValues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/Areas/Server/Commands/ProxyToolOperations.cs
+++ b/src/Areas/Server/Commands/ProxyToolOperations.cs
@@ -347,7 +347,7 @@ public class ProxyToolOperations(IMcpClientService mcpClientService, ILogger<Pro
     private async Task<string> GetChildToolListJsonAsync(RequestContext<CallToolRequestParams> request, string tool)
     {
         var listTools = await GetChildToolListAsync(request, tool);
-        return JsonSerializer.Serialize(listTools, AzureProxyToolSerializationContext.Default.ListTool);
+        return JsonSerializer.Serialize(listTools, AzureProxyToolSerializationContext.Default.IEnumerableTool);
     }
 
     private async Task<Tool> GetChildToolAsync(RequestContext<CallToolRequestParams> request, string toolName, string commandName)

--- a/src/Areas/Server/Commands/Tools/AzureProxyTool.cs
+++ b/src/Areas/Server/Commands/Tools/AzureProxyTool.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
+using AzureMcp.Areas.Server.Commands.Tools;
 using Json.Schema;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;

--- a/src/Areas/Server/Commands/Tools/AzureProxyTool.cs
+++ b/src/Areas/Server/Commands/Tools/AzureProxyTool.cs
@@ -14,7 +14,6 @@ namespace AzureMcp.Commands.Server.Tools;
 [JsonSerializable(typeof(JsonSchema))]
 [JsonSerializable(typeof(ListToolsResult))]
 [JsonSerializable(typeof(IEnumerable<Tool>))]
-[JsonSerializable(typeof(List<Tool>))]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/src/Areas/Server/Commands/Tools/AzureProxyTool.cs
+++ b/src/Areas/Server/Commands/Tools/AzureProxyTool.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
-using AzureMcp.Areas.Server.Commands.Tools;
 using Json.Schema;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
@@ -13,11 +12,11 @@ namespace AzureMcp.Commands.Server.Tools;
 
 [JsonSerializable(typeof(JsonSchema))]
 [JsonSerializable(typeof(ListToolsResult))]
-[JsonSerializable(typeof(List<McpClientTool>))]
+[JsonSerializable(typeof(IEnumerable<Tool>))]
 [JsonSerializable(typeof(Dictionary<string, object?>))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     WriteIndented = true
 )]
 internal partial class AzureProxyToolSerializationContext : JsonSerializerContext
@@ -211,7 +210,7 @@ public sealed class AzureProxyTool(ILogger<AzureProxyTool> logger, IMcpClientSer
         }
 
         var listTools = await client.ListToolsAsync();
-        var toolsJson = JsonSerializer.Serialize(listTools, AzureProxyToolSerializationContext.Default.ListMcpClientTool);
+        var toolsJson = JsonSerializer.Serialize(listTools.Select(t => t.ProtocolTool), AzureProxyToolSerializationContext.Default.IEnumerableTool);
         _cachedToolListsJson[tool] = toolsJson;
 
         return toolsJson;

--- a/tests/Areas/Storage/UnitTests/Blob/Container/ContainerListCommandTests.cs
+++ b/tests/Areas/Storage/UnitTests/Blob/Container/ContainerListCommandTests.cs
@@ -26,7 +26,6 @@ public class ContainerListCommandTests
     private readonly Parser _parser;
     private readonly string _knownAccountName = "account123";
     private readonly string _knownSubscriptionId = "sub123";
-    private readonly string _knownTenantId = "tenant123";
 
     public ContainerListCommandTests()
     {


### PR DESCRIPTION
## What does this PR do?

AzureProxyTool is serializing `McpClientTool` instances, which have a JsonSerializerOptions (JSO) property, so the source generator was emitting logic to serialize a JSO. This was resulting in obsoletion warnings about obsolete properties on JSO. 

Instead of `McpClientTool`, we should be serializing the protocol-level Tool type (the `McpClientTool::ProtocolTool` property).

Also, serializing `McpClientTool` instances was resulting in unnecessary additional size for unnecessary source generated types and larger than necessary JSON. 



## GitHub issue number?

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] For core features, I have added thorough tests.
- [ ] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a CHANGELOG.md entry linking to this PR.
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
