### PR TITLE
Remove unused field causing build warning

### DIFF
--- a/tests/Commands/Storage/Blob/Container/ContainerListCommandTests.cs
+++ b/tests/Commands/Storage/Blob/Container/ContainerListCommandTests.cs
@@ -27,7 +27,6 @@ public class ContainerListCommandTests
     private readonly Parser _parser;
     private readonly string _knownAccountName = "account123";
     private readonly string _knownSubscriptionId = "sub123";
-    private readonly string _knownTenantId = "tenant123";
 
     public ContainerListCommandTests()
     {


### PR DESCRIPTION
## What does this PR do?

Remove unused field causing build warning.

Once this is merged and https://github.com/Azure/azure-mcp/pull/435 and https://github.com/Azure/azure-mcp/pull/436 are merged, which gets the project down to 0 build warnings, I'd suggest turning on warnings-as-errors to lock that in.

## GitHub issue number?

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] For core features, I have added thorough tests.
- [ ] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a CHANGELOG.md entry linking to this PR.
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
