### PR TITLE
Fix 2 bugs in Get-AreasToTest.ps1

### DIFF
--- a/eng/scripts/Get-AreasToTest.ps1
+++ b/eng/scripts/Get-AreasToTest.ps1
@@ -20,13 +20,13 @@ try {
     if(!$isPullRequestBuild) {
         # If we're not in a pull request, test all areas
         $allAreas = Get-ChildItem ./src/Areas -Directory | Select-Object -ExpandProperty Name
-        [array]$areasToTest = $allAreas + 'Core' | Sort-Object -Unique
+        $areasToTest = @($allAreas + 'Core' | Sort-Object -Unique)
     } else {
         # If we're in a pull request, use the set of changed files to narrow down the set of areas to test.
         $changedFiles = Get-ChangedFiles
         Write-Host ''
 
-        [array]$changedAreas = $changedFiles | ForEach-Object { $_ -match '^(src|tests)/Areas/(.*?)/' ? $Matches[2] : 'Core' } | Sort-Object -Unique
+        $changedAreas = @($changedFiles | ForEach-Object { $_ -match '^(src|tests)/Areas/(.*?)/' ? $Matches[2] : 'Core' } | Sort-Object -Unique)
 
         if($changedAreas.Count -eq 1 -and $changedAreas[0] -eq 'Core')
         {
@@ -47,7 +47,7 @@ try {
         }
 
         # If there are core changes, ensure CoreTestAreas are in the list of areas to test
-        [array]$areasToTest = ($hasCoreChanges ? $changedAreas + $coreTestAreas : $changedAreas) | Sort-Object -Unique
+        $areasToTest = @(($hasCoreChanges ? $changedAreas + $coreTestAreas : $changedAreas) | Sort-Object -Unique)
     }
 
     if($SetDevOpsVariables) {

--- a/eng/scripts/Get-AreasToTest.ps1
+++ b/eng/scripts/Get-AreasToTest.ps1
@@ -20,13 +20,13 @@ try {
     if(!$isPullRequestBuild) {
         # If we're not in a pull request, test all areas
         $allAreas = Get-ChildItem ./src/Areas -Directory | Select-Object -ExpandProperty Name
-        $areasToTest = $allAreas + 'Core' | Sort-Object -Unique
+        [array]$areasToTest = $allAreas + 'Core' | Sort-Object -Unique
     } else {
         # If we're in a pull request, use the set of changed files to narrow down the set of areas to test.
         $changedFiles = Get-ChangedFiles
         Write-Host ''
 
-        [array]$changedAreas = $changedFiles | ForEach-Object { $_ -match '^(src|test)/Areas/(.*?)/' ? $Matches[2] : 'Core' } | Sort-Object -Unique
+        [array]$changedAreas = $changedFiles | ForEach-Object { $_ -match '^(src|tests)/Areas/(.*?)/' ? $Matches[2] : 'Core' } | Sort-Object -Unique
 
         if($changedAreas.Count -eq 1 -and $changedAreas[0] -eq 'Core')
         {
@@ -47,7 +47,7 @@ try {
         }
 
         # If there are core changes, ensure CoreTestAreas are in the list of areas to test
-        $areasToTest = ($hasCoreChanges ? $changedAreas + $coreTestAreas : $changedAreas) | Sort-Object -Unique
+        [array]$areasToTest = ($hasCoreChanges ? $changedAreas + $coreTestAreas : $changedAreas) | Sort-Object -Unique
     }
 
     if($SetDevOpsVariables) {


### PR DESCRIPTION
## What does this PR do?
Fix bug so a single changed area still sets the devops variable to a json array
Fix bug so changes in '/tests/Area/*' are properly mapped to their area

## Checklist before merging
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] For core features, I have added thorough tests.
- [ ] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a CHANGELOG.md entry linking to this PR.
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
