### PR TITLE
Don't make SBOMs in pull requests

### DIFF
--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -80,3 +80,4 @@ jobs:
       ArtifactPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: $(PipelineArtifactName)_$(System.JobName)
       CustomCondition: succeededOrFailed()
+      SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}

--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -79,5 +79,4 @@ jobs:
     parameters:
       ArtifactPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: $(PipelineArtifactName)_$(System.JobName)
-      CustomCondition: succeededOrFailed()
       SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}

--- a/eng/pipelines/templates/jobs/sign-and-pack.yml
+++ b/eng/pipelines/templates/jobs/sign-and-pack.yml
@@ -18,18 +18,6 @@ jobs:
     name: $(MACPOOL)
     vmImage: $(MACVMIMAGE)
     os: macos
-  templateContext:
-    outputParentDirectory: $(Build.ArtifactStagingDirectory)
-    outputs:
-    - ${{ if not(parameters.SkipSigning) }}:
-      - output: pipelineArtifact
-        artifact: $(PipelineArtifactName)_signed
-        path: $(Build.ArtifactStagingDirectory)/signed
-        condition: succeededOrFailed()
-    - output: pipelineArtifact
-      artifact: $(PipelineArtifactName)_packed
-      path: $(Build.ArtifactStagingDirectory)/packed
-      condition: succeededOrFailed()
   steps:
   - checkout: self
 
@@ -45,7 +33,7 @@ jobs:
         -ArtifactsPath '$(Pipeline.Workspace)'
         -ArtifactPrefix '$(PipelineArtifactName)_'
         -OutputPath '$(Build.ArtifactStagingDirectory)/signed'
-        
+
   - ${{ if not(parameters.SkipSigning) }}:
     - template: pipelines/steps/azd-cli-win-signing.yml@azure-sdk-build-tools
       parameters:
@@ -65,6 +53,13 @@ jobs:
       arguments: >
         -Path '$(Build.ArtifactStagingDirectory)/signed'
 
+  - ${{ if not(parameters.SkipSigning) }}:
+    - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+      parameters:
+        ArtifactPath: $(Build.ArtifactStagingDirectory)/signed
+        ArtifactName: $(PipelineArtifactName)_signed
+        SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
+
   - task: Powershell@2
     displayName: "Pack modules"
     inputs:
@@ -74,3 +69,9 @@ jobs:
         -ArtifactsPath '$(Build.ArtifactStagingDirectory)/signed'
         -OutputPath '$(Build.ArtifactStagingDirectory)/packed'
         -Version '$(Version)'
+
+  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+    parameters:
+      ArtifactPath: $(Build.ArtifactStagingDirectory)/packed
+      ArtifactName: $(PipelineArtifactName)_packed
+      SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}

--- a/eng/pipelines/templates/steps/analyze-aot-compact.yml
+++ b/eng/pipelines/templates/steps/analyze-aot-compact.yml
@@ -21,3 +21,4 @@ steps:
     parameters:
       ArtifactPath: ${{ parameters.sourceDirectory }}/.work/aotCompactReport
       ArtifactName: AOTCompatibilityReport
+      SbomEnabled: ${{ ne(variables['Build.Reason'], 'PullRequest') }}


### PR DESCRIPTION
## What does this PR do?
When running azure - mcp for PR validation against PRs for forks, we get a warning saying that SBOM generation isn't enabled for the organization. There's no reason to create an SBOM in a PR as we don't release anything. This PR disables SBOM generation as part of artifact upload, but only for PRs

## Checklist before merging
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] For core features, I have added thorough tests.
- [ ] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a CHANGELOG.md entry linking to this PR.
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
