### PR TITLE
Addressing invalid modification to HttpClient in KustoClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed invalid modification to HttpClient in KustoClient. [#433](https://github.com/Azure/azure-mcp/issues/433)
+
 ### Other Changes
 
 ## 0.2.4 (2025-06-24)

--- a/src/Areas/Kusto/Services/KustoClient.cs
+++ b/src/Areas/Kusto/Services/KustoClient.cs
@@ -6,26 +6,18 @@ using Azure.Core;
 
 namespace AzureMcp.Areas.Kusto.Services;
 
-public class KustoClient
+public class KustoClient(
+    string clusterUri,
+    TokenCredential tokenCredential,
+    string userAgent)
 {
-    private readonly string _clusterUri;
-    private readonly HttpClient _httpClient;
-    private readonly TokenCredential _tokenCredential;
-    private readonly string _userAgent;
+    private readonly string _clusterUri = clusterUri;
+    private readonly TokenCredential _tokenCredential = tokenCredential;
+    private readonly string _userAgent = userAgent;
+    private readonly HttpClient _httpClient = new() { BaseAddress = new Uri(clusterUri) };
     private static readonly string s_application = "AzureMCP";
     private static readonly string s_clientRequestIdPrefix = "AzMcp";
     private static readonly string s_default_scope = "https://kusto.kusto.windows.net/.default";
-
-    public KustoClient(string clusterUri, TokenCredential tokenCredential, string userAgent)
-    {
-        _clusterUri = clusterUri;
-        _tokenCredential = tokenCredential;
-        _userAgent = userAgent;
-        _httpClient = new HttpClient
-        {
-            BaseAddress = new Uri(clusterUri)
-        };
-    }
 
     public Task<KustoResult> ExecuteQueryCommandAsync(string database, string text, CancellationToken cancellationToken)
         => ExecuteCommandAsync("/v1/rest/query", database, text, cancellationToken);

--- a/src/Areas/Kusto/Services/KustoService.cs
+++ b/src/Areas/Kusto/Services/KustoService.cs
@@ -19,7 +19,6 @@ public sealed class KustoService(
 {
     private readonly ISubscriptionService _subscriptionService = subscriptionService ?? throw new ArgumentNullException(nameof(subscriptionService));
     private readonly ICacheService _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
-    private static readonly HttpClient _httpClient = new();
 
     private const string CacheGroup = "kusto";
     private const string KustoClustersCacheKey = "clusters";
@@ -286,7 +285,7 @@ public sealed class KustoService(
         if (kustoClient == null)
         {
             var tokenCredential = await GetCredential(tenant);
-            kustoClient = new KustoClient(clusterUri, _httpClient, tokenCredential, UserAgent);
+            kustoClient = new KustoClient(clusterUri, tokenCredential, UserAgent);
             await _cacheService.SetAsync(CacheGroup, providerCacheKey, kustoClient, s_providerCacheDuration);
         }
 
@@ -300,7 +299,7 @@ public sealed class KustoService(
         if (kustoClient == null)
         {
             var tokenCredential = await GetCredential(tenant);
-            kustoClient = new KustoClient(clusterUri, _httpClient, tokenCredential, UserAgent);
+            kustoClient = new KustoClient(clusterUri, tokenCredential, UserAgent);
             await _cacheService.SetAsync(CacheGroup, providerCacheKey, kustoClient, s_providerCacheDuration);
         }
 

--- a/tests/Areas/Kusto/LiveTests/KustoCommandTests.cs
+++ b/tests/Areas/Kusto/LiveTests/KustoCommandTests.cs
@@ -39,7 +39,7 @@ public class KustoCommandTests(LiveTestFixture liveTestFixture, ITestOutputHelpe
                 { "cluster-name", Settings.ResourceBaseName }
                 });
             var clusterUri = clusterInfo.AssertProperty("cluster").AssertProperty("clusterUri").GetString();
-            var kustoClient = new KustoClient(clusterUri ?? string.Empty, new HttpClient(), credentials, "ua");
+            var kustoClient = new KustoClient(clusterUri ?? string.Empty, credentials, "ua");
             var resp = await kustoClient.ExecuteControlCommandAsync(
                 TestDatabaseName,
                 ".set-or-replace ToDoList <| datatable (Title: string, IsCompleted: bool) [' Hello World!', false]",


### PR DESCRIPTION
This pr fixes https://github.com/Azure/azure-mcp/issues/433

The Kusto command was experiencing the error: "This instance has already started one or more requests. Properties can only be modified before sending the first request." This error occurred because the methods in KustoService class was attempting to set the BaseAddress property on the shared HttpClient after it had already processed requests. The BaseAddress is supposed to be set only once, and before the first request.
