### PR TITLE
Fix AOT Analysis by Adding DisableWarningsAsErrors Property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,8 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Only treat warnings as errors when not specifically disabled (e.g., disabled to generate AOT warnings) -->
+    <TreatWarningsAsErrors Condition="'$(DisableWarningsAsErrors)' == 'true'">false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition="'$(DisableWarningsAsErrors)' != 'true'">true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Only treat warnings as errors when not specifically disabled (e.g., disabled to generate AOT warnings) -->
-    <TreatWarningsAsErrors Condition="'$(DisableWarningsAsErrors)' == 'true'">false</TreatWarningsAsErrors>
-    <TreatWarningsAsErrors Condition="'$(DisableWarningsAsErrors)' != 'true'">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/eng/scripts/Analyze-AOT-Compact.ps1
+++ b/eng/scripts/Analyze-AOT-Compact.ps1
@@ -127,7 +127,7 @@ $publishArgs = @(
     '--self-contained', 'true',
     '/p:PublishTrimmed=true',
     '/p:TrimmerSingleWarn=false',
-    '/p:DisableWarningsAsErrors=true'  # Disable treating warnings as errors so AOT warnings do not fail the analysis
+    '/p:TreatWarningsAsErrors=false'  # Disable treating warnings as errors so AOT warnings do not fail the analysis
 )
 
 Write-Host "Executing: dotnet $($publishArgs -join ' ')"

--- a/eng/scripts/Analyze-AOT-Compact.ps1
+++ b/eng/scripts/Analyze-AOT-Compact.ps1
@@ -126,7 +126,8 @@ $publishArgs = @(
     '--runtime', $runtime,
     '--self-contained', 'true',
     '/p:PublishTrimmed=true',
-    '/p:TrimmerSingleWarn=false'
+    '/p:TrimmerSingleWarn=false',
+    '/p:DisableWarningsAsErrors=true'  # Disable treating warnings as errors so AOT warnings do not fail the analysis
 )
 
 Write-Host "Executing: dotnet $($publishArgs -join ' ')"


### PR DESCRIPTION
AOT (Ahead-of-Time) compatibility analysis was failing after enabling `TreatWarningsAsErrors` in the build configuration in this [pr](https://github.com/Azure/azure-mcp/pull/435). Since AOT analysis intentionally generates IL warnings to identify potential compatibility issues, these warnings were being treated as errors, causing the analysis to fail prematurely.

To address this, `Analyze-AOT-Compact.ps1` will pass this property `TreatWarningsAsErrors ` as `false` to the dotnet publish command which runs the AOT analysis.