### PR TITLE
Fix live test task false positives

### DIFF
--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -74,9 +74,10 @@ jobs:
       inputs:
         azureSubscription: ${{ parameters.CloudConfig.ServiceConnection }}
         azurePowerShellVersion: 'LatestVersion'
-        scriptType: FilePath
-        scriptPath: $(Build.SourcesDirectory)/eng/scripts/Test-Code.ps1
-        scriptArguments: -Live -CoverageSummary -Areas (ConvertFrom-Json $env:TESTAREAS)
+        scriptType: InlineScript
+        Inline: |
+          ./eng/scripts/Test-Code.ps1 -Live -CoverageSummary -Areas (ConvertFrom-Json $env:TESTAREAS)
+          exit $LastExitCode
         pwsh: true
         workingDirectory: $(Build.SourcesDirectory)
 

--- a/eng/scripts/Test-Code.ps1
+++ b/eng/scripts/Test-Code.ps1
@@ -113,7 +113,7 @@ if($CoverageSummary) {
         $xml = [xml](Get-Content $coverageFile.FullName)
 
         $classes = $xml.coverage.packages.package.classes.class |
-            Where-Object { $_.name -match 'AzureMcp\.Commands\.' -and $_.filename -notlike '*System.Text.Json.SourceGeneration*' }
+            Where-Object { $_.name -match 'AzureMcp\.(.*\.)?Commands\.' -and $_.filename -notlike '*System.Text.Json.SourceGeneration*' }
 
         $fileGroups = $classes |
             Group-Object { $_.filename } |


### PR DESCRIPTION
## What does this PR do?
The live test task passes even when tests fail.  Calling `exit $LastExitCode` in the script task seems to float the error code up correctly.


## Checklist before merging
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] For core features, I have added thorough tests.
- [ ] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a CHANGELOG.md entry linking to this PR.
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
