### PR TITLE
Only run -post scripts for deployed areas

### DIFF
--- a/eng/scripts/Deploy-TestResources.ps1
+++ b/eng/scripts/Deploy-TestResources.ps1
@@ -42,13 +42,13 @@ try {
             -ResourceGroupName $ResourceGroupName `
             -BaseName $BaseName `
             -DeleteAfterHours $DeleteAfterHours `
-            -ArmTemplateParameters $armParameters
+            -AdditionalParameters $armParameters
     } else {
         ./eng/common/TestResources/New-TestResources.ps1 `
             -ResourceGroupName $ResourceGroupName `
             -BaseName $BaseName `
             -DeleteAfterHours $DeleteAfterHours `
-            -ArmTemplateParameters $armParameters
+            -AdditionalParameters $armParameters
     }
 }
 finally {


### PR DESCRIPTION
## What does this PR do?
Currently, test resource deployment runs all `*-post.ps1` scripts.  This fails when we've deployed a partial list of areas in PRs.
This change makes the generic test-resources-post.ps1 script area aware.

For example, if the `storage` resources are not deployed because a different area (such as AppConfig) is being tested, running the `storage-post.ps1` script will result in failure, as it attempts to interact with a storage resource that does not exist. So this pr ensures the `[area]-post.ps1` scripts are run only if `[area]` resource were deployed.

## Checklist before merging
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message.  This means that previously merged commits do not appear in the history of the PR.  For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] For core features, I have added thorough tests.
- [ ] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a CHANGELOG.md entry linking to this PR.
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
