### PR TITLE
Bug where CallToolResult is always success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix bug where CallToolResult is always successful.
+
 ### Other Changes
 
 ## 0.2.6 (2025-07-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix bug where CallToolResult is always successful.
+- Fix bug where CallToolResult is always successful. [#511](https://github.com/Azure/azure-mcp/pull/511)
 
 ### Other Changes
 

--- a/src/Areas/Server/Commands/ToolOperations.cs
+++ b/src/Areas/Server/Commands/ToolOperations.cs
@@ -112,6 +112,7 @@ public class ToolOperations
         {
             var commandResponse = await command.ExecuteAsync(commandContext, commandOptions);
             var jsonResponse = JsonSerializer.Serialize(commandResponse, ModelsJsonContext.Default.CommandResponse);
+            var isError = commandResponse.Status < 200 || commandResponse.Status >= 300;
 
             return new CallToolResult
             {
@@ -119,6 +120,7 @@ public class ToolOperations
                 [
                     new TextContentBlock { Text = jsonResponse }
                 ],
+                IsError = isError,
             };
         }
         catch (Exception ex)


### PR DESCRIPTION
## What does this PR do?

Fixes bug where CallToolResult is always success.

Before:
![image](https://github.com/user-attachments/assets/7600182d-3918-41b3-91a6-cf8dd7cb68db)

After:
![image](https://github.com/user-attachments/assets/c6900364-556f-40bd-aca5-45b23799a5c1)

## GitHub issue number?

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] For core features, I have added thorough tests.
- [x] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a `CHANGELOG.md` entry linking to this PR.
- [x] For MCP tool additions/updates, I have updated the documentation in `README.md`, the command list in `azmcp-commands.md`, and end-to-end test prompts in `/e2eTests/e2eTestPrompts.md`.
- [x] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [x] Team Member: Inspect PR for security issues before queueing a test run
   - [x] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
