### PR TITLE
Enable remaining Monitor live tests

### DIFF
--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -209,19 +209,26 @@ azmcp monitor table list --subscription <subscription> \
                          --resource-group <resource-group>
 
 # Query logs from Azure Monitor using KQL
-azmcp monitor log query --subscription <subscription> \
-                        --workspace <workspace> \
-                        --table-name <table-name> \
-                        --query "<kql-query>" \
-                        [--hours <hours>] \
-                        [--limit <limit>]
+azmcp monitor workspace log query --subscription <subscription> \
+                                  --workspace <workspace> \
+                                  --table-name <table-name> \
+                                  --query "<kql-query>" \
+                                  [--hours <hours>] \
+                                  [--limit <limit>]
+
+azmcp monitor resource log query --subscription <subscription> \
+                                 --resource-id <resource-id> \
+                                 --table-name <table-name> \
+                                 --query "<kql-query>" \
+                                 [--hours <hours>] \
+                                 [--limit <limit>]
 
 # Examples:
 # Query logs from a specific table
-azmcp monitor log query --subscription <subscription> \
-                        --workspace <workspace> \
-                        --table-name "AppEvents_CL" \
-                        --query "| order by TimeGenerated desc"
+azmcp monitor workspace log query --subscription <subscription> \
+                                  --workspace <workspace> \
+                                  --table-name "AppEvents_CL" \
+                                  --query "| order by TimeGenerated desc"
 ```
 
 #### Health Models

--- a/e2eTests/e2eTestPrompts.md
+++ b/e2eTests/e2eTestPrompts.md
@@ -144,7 +144,7 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp-monitor-metrics-query | Analyze the performance trends and response times for Application Insights resource <resource_name> over the last <time_period> |
 | azmcp-monitor-metrics-query | Check the availability metrics for my Application Insights resource <resource_name> for the last <time_period> |
 | azmcp-monitor-metrics-query | Get the <aggregation_type> <metric_name> metric for <resource_type> <resource_name> over the last <time_period> with intervals |
-| azmcp-monitor-resource-logs-query | Show me the logs for the past hour for the resource <resource_name> in the Log Analytics workspace <workspace_name> |
+| azmcp-monitor-resource-log-query | Show me the logs for the past hour for the resource <resource_name> in the Log Analytics workspace <workspace_name> |
 | azmcp-monitor-table-list | List all tables in the Log Analytics workspace <workspace_name> |
 | azmcp-monitor-table-list | Show me the tables in the Log Analytics workspace <workspace_name> |
 | azmcp-monitor-table-type-list | List all available table types in the Log Analytics workspace <workspace_name> |
@@ -152,7 +152,7 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp-monitor-workspace-list | List all Log Analytics workspaces in my subscription |
 | azmcp-monitor-workspace-list | Show me the Log Analytics workspaces in my subscription |
 | azmcp-monitor-workspace-list | Show me my Log Analytics workspaces |
-| azmcp-monitor-workspace-logs-query | Show me the logs for the past hour in the Log Analytics workspace <workspace_name> |
+| azmcp-monitor-workspace-log-query | Show me the logs for the past hour in the Log Analytics workspace <workspace_name> |
 
 ## Azure Native ISV
 

--- a/infra/services/monitor.bicep
+++ b/infra/services/monitor.bicep
@@ -1,7 +1,7 @@
 targetScope = 'resourceGroup'
 
 @minLength(4)
-@maxLength(63)
+@maxLength(24)
 @description('The base resource name.')
 param baseName string = resourceGroup().name
 
@@ -30,3 +30,156 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
     publicNetworkAccessForQuery: 'Enabled'
   }
 }
+
+// Reference the existing storage account created by the storage module
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+  name: baseName
+}
+
+// Reference the blob service within the storage account
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' existing = {
+  name: 'default'
+  parent: storageAccount
+}
+
+// Reference the table service within the storage account
+resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2022-09-01' existing = {
+  name: 'default'
+  parent: storageAccount
+}
+
+// Diagnostic settings for Storage Account (main account level)
+resource storageAccountDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'storage-account-diagnostics'
+  scope: storageAccount
+  properties: {
+    workspaceId: workspace.id
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'Capacity'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+    ]
+  }
+}
+
+// Diagnostic settings for Blob Service
+resource blobServiceDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'blob-service-diagnostics'
+  scope: blobService
+  properties: {
+    workspaceId: workspace.id
+    logs: [
+      {
+        category: 'StorageRead'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'StorageWrite'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'StorageDelete'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+    ]
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'Capacity'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+    ]
+  }
+}
+
+// Diagnostic settings for Table Service
+resource tableServiceDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'table-service-diagnostics'
+  scope: tableService
+  properties: {
+    workspaceId: workspace.id
+    logs: [
+      {
+        category: 'StorageRead'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'StorageWrite'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'StorageDelete'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+    ]
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'Capacity'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+    ]
+  }
+}
+
+output workspaceId string = workspace.id
+output workspaceCustomerId string = workspace.properties.customerId


### PR DESCRIPTION
## What does this PR do?
- Enables the remaining Monitor live tests that are currently marked as "skip".
- Adds an additional test for listing entries in a given table.
- Updates the `monitor.bicep `file to ensure logs will be present via operations on an already deployed Storage account.
- Adds missing Monitor tools in `azmcp-commands.md`.
- Corrects the names of two Monitor tools in `e2eTestPrompts.md`.

## GitHub issue number?
https://github.com/Azure/azure-mcp-pr/issues/155

## Checklist before merging
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) on pull request process, code style, and testing.**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR,  [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] For core features, I have added thorough tests.
- [ ] For user-impacting changes (bug fixes, new features, UI/UX changes), I have added a `CHANGELOG.md` entry linking to this PR.
- [ ] For MCP tool additions/updates, I have updated the documentation in `README.md`, the command list in `azmcp-commands.md`, and end-to-end test prompts in `/e2eTests/e2eTestPrompts.md`.
- [ ] Have a team member run [live tests](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md#live-tests):
   - [ ] Team Member: Inspect PR for security issues before queueing a test run
   - [ ] Team Member: Add this comment to the pr `/azp run azure - mcp` to start the run
