### PR TITLE
Fixing flaky RegistryServerProviderTests unit test

### DIFF
--- a/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryServerProviderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryServerProviderTests.cs
@@ -3,6 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using AzureMcp.Areas.Server.Commands.Discovery;
 using AzureMcp.Areas.Server.Models;
@@ -79,22 +83,23 @@ public class RegistryServerProviderTests
     {
         // Arrange
         string testId = "sseProvider";
+        using var server = new MockHttpTestServer();
         var serverInfo = new RegistryServerInfo
         {
             Description = "Test SSE Provider",
-            Url = "https://example.com/mcp"
+            Url = $"{server.Endpoint}/mcp"
         };
         var provider = new RegistryServerProvider(testId, serverInfo);
 
-        // Act & Assert - Should not throw, but we can't easily mock the actual client creation
-        // due to SseClientTransport using sealed classes
+        // Act & Assert
         var exception = await Record.ExceptionAsync(() => provider.CreateClientAsync(new McpClientOptions()));
-
-        // The specific exception may vary based on the implementation (HttpRequestException for 404, etc.)
-        // but we should get an exception of some kind
         Assert.NotNull(exception);
         // Not an InvalidOperationException about missing URL or invalid transport
         Assert.IsNotType<InvalidOperationException>(exception);
+        // Should be an HttpRequestException with 404 status
+        Assert.IsType<HttpRequestException>(exception);
+        var httpException = (HttpRequestException)exception;
+        Assert.Equal(HttpStatusCode.NotFound, httpException.StatusCode);
     }
 
     [Fact]
@@ -188,5 +193,75 @@ public class RegistryServerProviderTests
 
         Assert.Contains($"Registry server '{testId}' does not have a valid command for stdio transport.",
             exception.Message);
+    }
+}
+
+internal sealed class MockHttpTestServer : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+    private readonly TaskCompletionSource _ready;
+    public string Endpoint { get; }
+
+    public MockHttpTestServer()
+    {
+        var port = GetAvailablePort();
+        Endpoint = $"http://127.0.0.1:{port}";
+
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"{Endpoint}/");
+        _listener.Start();
+
+        _cancellationTokenSource = new CancellationTokenSource();
+        _ready = new TaskCompletionSource();
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                _ready.SetResult();
+
+                while (_listener.IsListening && !_cancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    var context = await _listener.GetContextAsync();
+                    if (context.Request.Url?.AbsolutePath == "/mcp")
+                    {
+                        context.Response.StatusCode = 404;
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 400;
+                    }
+                    context.Response.Close();
+                }
+            }
+            catch (Exception ex) when (ex is ObjectDisposedException or HttpListenerException)
+            {
+                // expected when listener is disposed or stopped.
+                if (!_ready.Task.IsCompleted)
+                {
+                    _ready.SetException(ex);
+                }
+            }
+        }, _cancellationTokenSource.Token);
+
+        _ready.Task.Wait(TimeSpan.FromSeconds(10));
+    }
+
+    private static int GetAvailablePort()
+    {
+        using var tempListener = new TcpListener(IPAddress.Loopback, 0);
+        tempListener.Start();
+        var port = ((IPEndPoint)tempListener.LocalEndpoint).Port;
+        tempListener.Stop();
+        return port;
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _listener.Stop();
+        _listener.Close();
+        _cancellationTokenSource.Dispose();
     }
 }


### PR DESCRIPTION
## What does this PR do?

The `CreateClientAsync_WithUrl_CreatesSseClient` test is flaky, it fails time to time with the error

```
Error Message:
 Assert.IsNotType() Failure: Value is the exact type 
  Expected: typeof(System.InvalidOperationException)
  Actual:   typeof(System.InvalidOperationException)
```

Test relies on external `example.com` domain and expects a 404 response for the non-existing `/sse` path. However, the domain is unreliable, so C# MCP SDK may fail to connect, resulting in an "`InvalidOperationException` with the message 'Failed to connect transport'". The test assumed that InvalidOperationException will be thrown only if URL format is invalid, which is not the case here.

## GitHub issue number?

## Pre-merge checklist
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) covering pull request process, code style, and testing**
- [ ] PR title is clear and informative
- [ ] Commit history is clean with informative messages (no previously merged commits appear in PR history). [See cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
- [ ] Added comprehensive tests for core features
- [ ] Added `CHANGELOG.md` entry for user-impacting changes (bug fixes, new features, UI/UX changes)
- [ ] For MCP tool changes, updated:
  - [ ] Documentation in `README.md`
  - [ ] Command list in `/docs/azmcp-commands.md` 
  - [ ] End-to-end test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] **Team member live testing:**
  - [ ] **Security review:** Review PR for security vulnerabilities and malicious code before running tests (e.g., cryptocurrency mining, email spam, data exfiltration, or other harmful activities)
  - [ ] **Test execution:** Add comment `/azp run azure - mcp` to trigger pipeline