### PR TITLE
Add workflow to auto-assign Copilot as reviewer on pull requests

### DIFF
--- a/.github/workflows/auto-assign-copilot-reviewer.yml
+++ b/.github/workflows/auto-assign-copilot-reviewer.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   assign-copilot:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-assign-copilot-reviewer.yml
+++ b/.github/workflows/auto-assign-copilot-reviewer.yml
@@ -1,0 +1,28 @@
+name: Auto-assign Copilot Reviewer
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  assign-copilot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Copilot as reviewer
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number,
+                reviewers: ['copilot']
+              });
+              console.log('Successfully added @copilot as reviewer');
+            } catch (error) {
+              console.log('Error adding @copilot as reviewer:', error.message);
+            }


### PR DESCRIPTION
Implement a GitHub Actions workflow that automatically assigns Copilot as a reviewer when a pull request is opened, reopened, or marked ready for review.