### PR TITLE
Move Server option definitions out of common class

### DIFF
--- a/src/Areas/Server/Commands/Discovery/CommandGroupServerProvider.cs
+++ b/src/Areas/Server/Commands/Discovery/CommandGroupServerProvider.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Areas.Server.Options;
 using AzureMcp.Commands;
-using AzureMcp.Models.Option;
 using ModelContextProtocol.Client;
 
 namespace AzureMcp.Areas.Server.Commands.Discovery;
@@ -46,7 +46,7 @@ public sealed class CommandGroupServerProvider(CommandGroup commandGroup) : IMcp
 
         if (ReadOnly)
         {
-            arguments.Add($"--${OptionDefinitions.Service.ReadOnlyName}");
+            arguments.Add($"--${ServiceOptionDefinitions.ReadOnlyName}");
         }
 
         var transportOptions = new StdioClientTransportOptions

--- a/src/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/src/Areas/Server/Commands/ServiceStartCommand.cs
@@ -24,11 +24,11 @@ namespace AzureMcp.Areas.Server.Commands;
 public sealed class ServiceStartCommand : BaseCommand
 {
     private const string CommandTitle = "Start MCP Server";
-    private readonly Option<string> _transportOption = OptionDefinitions.Service.Transport;
-    private readonly Option<int> _portOption = OptionDefinitions.Service.Port;
-    private readonly Option<string[]?> _namespaceOption = OptionDefinitions.Service.Namespace;
-    private readonly Option<string?> _modeOption = OptionDefinitions.Service.Mode;
-    private readonly Option<bool?> _readOnlyOption = OptionDefinitions.Service.ReadOnly;
+    private readonly Option<string> _transportOption = ServiceOptionDefinitions.Transport;
+    private readonly Option<int> _portOption = ServiceOptionDefinitions.Port;
+    private readonly Option<string[]?> _namespaceOption = ServiceOptionDefinitions.Namespace;
+    private readonly Option<string?> _modeOption = ServiceOptionDefinitions.Mode;
+    private readonly Option<bool?> _readOnlyOption = ServiceOptionDefinitions.ReadOnly;
 
     /// <summary>
     /// Gets the name of the command.
@@ -68,19 +68,19 @@ public sealed class ServiceStartCommand : BaseCommand
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var port = parseResult.GetValueForOption(_portOption) == default
-            ? OptionDefinitions.Service.Port.GetDefaultValue()
+            ? ServiceOptionDefinitions.Port.GetDefaultValue()
             : parseResult.GetValueForOption(_portOption);
 
         var namespaces = parseResult.GetValueForOption(_namespaceOption) == default
-            ? OptionDefinitions.Service.Namespace.GetDefaultValue()
+            ? ServiceOptionDefinitions.Namespace.GetDefaultValue()
             : parseResult.GetValueForOption(_namespaceOption);
 
         var mode = parseResult.GetValueForOption(_modeOption) == default
-            ? OptionDefinitions.Service.Mode.GetDefaultValue()
+            ? ServiceOptionDefinitions.Mode.GetDefaultValue()
             : parseResult.GetValueForOption(_modeOption);
 
         var readOnly = parseResult.GetValueForOption(_readOnlyOption) == default
-            ? OptionDefinitions.Service.ReadOnly.GetDefaultValue()
+            ? ServiceOptionDefinitions.ReadOnly.GetDefaultValue()
             : parseResult.GetValueForOption(_readOnlyOption);
 
         var serverOptions = new ServiceStartOptions

--- a/src/Areas/Server/Options/ServiceOptionDefinitions.cs
+++ b/src/Areas/Server/Options/ServiceOptionDefinitions.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Areas.Server.Options;
+
+public static class ServiceOptionDefinitions
+{
+    public const string TransportName = "transport";
+    public const string PortName = "port";
+    public const string NamespaceName = "namespace";
+    public const string ModeName = "mode";
+    public const string ReadOnlyName = "read-only";
+
+    public static readonly Option<string> Transport = new(
+        $"--{TransportName}",
+        () => TransportTypes.StdIo,
+        "Transport mechanism to use for Azure MCP Server."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<int> Port = new(
+        $"--{PortName}",
+        () => 5008,
+        "Port to use for Azure MCP Server."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<string[]?> Namespace = new(
+        $"--{NamespaceName}",
+        () => null,
+        "The Azure service namespaces to expose on the MCP server (e.g., storage, keyvault, cosmos)."
+    )
+    {
+        IsRequired = false,
+        Arity = ArgumentArity.OneOrMore,
+        AllowMultipleArgumentsPerToken = true
+    };
+
+    public static readonly Option<string?> Mode = new Option<string?>(
+        $"--{ModeName}",
+        () => null,
+        "Mode for the MCP server. 'single' exposes one azure tool that routes to all services. 'namespace' exposes one tool per service namespace."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<bool?> ReadOnly = new(
+        $"--{ReadOnlyName}",
+        () => null,
+        "Whether the MCP server should be read-only. If true, no write operations will be allowed.");
+}

--- a/src/Docs/new-command.md
+++ b/src/Docs/new-command.md
@@ -75,18 +75,19 @@ This keeps all code, options, models, and tests for a service together. See `src
 
 A complete command requires:
 
-1. Options class: `src/Areas/{Area}/Options/{Resource}/{Operation}Options.cs`
-2. Command class: `src/Areas/{Area}/Commands/{Resource}/{Resource}{Operation}Command.cs`
-3. Service interface: `src/Areas/{Area}/Services/I{Service}Service.cs`
-4. Service implementation: `src/Areas/{Area}/Services/{Service}Service.cs`
+1. OptionDefinitions static class: `src/Areas/{Area}/Options/{Area}OptionDefinitions.cs`
+2. Options class: `src/Areas/{Area}/Options/{Resource}/{Operation}Options.cs`
+3. Command class: `src/Areas/{Area}/Commands/{Resource}/{Resource}{Operation}Command.cs`
+4. Service interface: `src/Areas/{Area}/Services/I{Service}Service.cs`
+5. Service implementation: `src/Areas/{Area}/Services/{Service}Service.cs`
    - {Area} and {Service} should not be considered synonymous
    - It's common for an area to have a single service class named after the
      area but some areas will have multiple service classes
-5. Unit test: `tests/Areas/{Area}/UnitTests/{Resource}/{Resource}{Operation}CommandTests.cs`
-6. Integration test: `tests/Areas/{Area}/LiveTests/{Area}CommandTests.cs`
-7. Command registration in RegisterCommands(): `src/Areas/{Area}/{Area}Setup.cs`
-8. Area registration in RegisterAreas(): `src/Program.cs`
-9. **Live test infrastructure** (if needed):
+6. Unit test: `tests/Areas/{Area}/UnitTests/{Resource}/{Resource}{Operation}CommandTests.cs`
+7. Integration test: `tests/Areas/{Area}/LiveTests/{Area}CommandTests.cs`
+8. Command registration in RegisterCommands(): `src/Areas/{Area}/{Area}Setup.cs`
+9. Area registration in RegisterAreas(): `src/Program.cs`
+10. **Live test infrastructure** (if needed):
    - Bicep template: `/infra/services/{area}.bicep`
    - Module registration in: `/infra/test-resources.bicep`
    - Optional post-deployment script: `/infra/services/{area}-post.ps1`
@@ -194,7 +195,7 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
     private readonly ILogger<{Resource}{Operation}Command> _logger = logger;
 
     // Define options from OptionDefinitions
-    private readonly Option<string> _newOption = OptionDefinitions.Service.NewOption;
+    private readonly Option<string> _newOption = {Area}OptionDefinitions.NewOption;
 
     public override string Name => "operation";
 
@@ -312,7 +313,7 @@ public abstract class Base{Service}Command<
     [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] TOptions>
     : SubscriptionCommand<TOptions> where TOptions : Base{Service}Options, new()
 {
-    protected readonly Option<string> _commonOption = OptionDefinitions.Service.CommonOption;
+    protected readonly Option<string> _commonOption = {Area}OptionDefinitions.CommonOption;
     protected readonly Option<string> _resourceGroupOption = OptionDefinitions.Common.ResourceGroup;
     protected virtual bool RequiresResourceGroup => true;
 
@@ -1017,6 +1018,7 @@ Failure to call `base.Dispose()` will prevent request and response data from `Ca
    - Use dashes in command group names
 
 2. Always:
+   - Create a static {Area}OptionDefinitions class for the area
    - Use OptionDefinitions for options
    - Follow exact file structure
    - Implement all base members

--- a/src/Models/Option/OptionDefinitions.cs
+++ b/src/Models/Option/OptionDefinitions.cs
@@ -109,58 +109,6 @@ public static partial class OptionDefinitions
         };
     }
 
-    public static class Service
-    {
-        public const string TransportName = "transport";
-        public const string PortName = "port";
-        public const string NamespaceName = "namespace";
-        public const string ModeName = "mode";
-        public const string ReadOnlyName = "read-only";
-
-        public static readonly Option<string> Transport = new(
-            $"--{TransportName}",
-            () => TransportTypes.StdIo,
-            "Transport mechanism to use for Azure MCP Server."
-        )
-        {
-            IsRequired = false
-        };
-
-        public static readonly Option<int> Port = new(
-            $"--{PortName}",
-            () => 5008,
-            "Port to use for Azure MCP Server."
-        )
-        {
-            IsRequired = false
-        };
-
-        public static readonly Option<string[]?> Namespace = new(
-            $"--{NamespaceName}",
-            () => null,
-            "The Azure service namespaces to expose on the MCP server (e.g., storage, keyvault, cosmos)."
-        )
-        {
-            IsRequired = false,
-            Arity = ArgumentArity.OneOrMore,
-            AllowMultipleArgumentsPerToken = true
-        };
-
-        public static readonly Option<string?> Mode = new Option<string?>(
-            $"--{ModeName}",
-            () => null,
-            "Mode for the MCP server. 'single' exposes one azure tool that routes to all services. 'namespace' exposes one tool per service namespace."
-        )
-        {
-            IsRequired = false
-        };
-
-        public static readonly Option<bool?> ReadOnly = new(
-            $"--{ReadOnlyName}",
-            () => null,
-            "Whether the MCP server should be read-only. If true, no write operations will be allowed.");
-    }
-
     public static class Authorization
     {
         public const string ScopeName = "scope";

--- a/tests/Areas/Server/UnitTests/ServiceStartCommandTests.cs
+++ b/tests/Areas/Server/UnitTests/ServiceStartCommandTests.cs
@@ -4,7 +4,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using AzureMcp.Areas.Server.Commands;
-using AzureMcp.Models.Option;
+using AzureMcp.Areas.Server.Options;
 using Xunit;
 
 namespace AzureMcp.Tests.Areas.Server.UnitTests;
@@ -38,10 +38,10 @@ public class ServiceStartCommandTests
         var parseResult = CreateParseResult(inputService);
 
         // Act
-        var actualServiceArray = parseResult.GetValueForOption(OptionDefinitions.Service.Namespace);
+        var actualServiceArray = parseResult.GetValueForOption(ServiceOptionDefinitions.Namespace);
         var actualService = (actualServiceArray != null && actualServiceArray.Length > 0) ? actualServiceArray[0] : "";
-        var actualPort = parseResult.GetValueForOption(OptionDefinitions.Service.Port);
-        var actualTransport = parseResult.GetValueForOption(OptionDefinitions.Service.Transport);
+        var actualPort = parseResult.GetValueForOption(ServiceOptionDefinitions.Port);
+        var actualTransport = parseResult.GetValueForOption(ServiceOptionDefinitions.Transport);
 
         // Assert
         Assert.Equal(expectedService, actualService ?? "");
@@ -53,9 +53,9 @@ public class ServiceStartCommandTests
     {
         var root = new RootCommand
         {
-            OptionDefinitions.Service.Namespace,
-            OptionDefinitions.Service.Port,
-            OptionDefinitions.Service.Transport
+            ServiceOptionDefinitions.Namespace,
+            ServiceOptionDefinitions.Port,
+            ServiceOptionDefinitions.Transport
         };
         var args = new List<string>();
         if (!string.IsNullOrEmpty(serviceValue))


### PR DESCRIPTION
## What does this PR do?
Server options definitions were still defined in the core option definitions class, this moves them out to their area

## GitHub issue number?

## Pre-merge checklist
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) covering pull request process, code style, and testing**
- [ ] PR title is clear and informative
- [ ] Commit history is clean with informative messages (no previously merged commits appear in PR history). [See cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
- [ ] Added comprehensive tests for core features
- [ ] Added `CHANGELOG.md` entry for user-impacting changes (bug fixes, new features, UI/UX changes)
- [ ] For MCP tool changes, updated:
  - [ ] Documentation in `README.md`
  - [ ] Command list in `/docs/azmcp-commands.md` 
  - [ ] End-to-end test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] **Team member live testing:**
  - [ ] **Security review:** Review PR for security vulnerabilities and malicious code before running tests (e.g., cryptocurrency mining, email spam, data exfiltration, or other harmful activities)
  - [ ] **Test execution:** Add comment `/azp run azure - mcp` to trigger pipeline
