### PR TITLE
✨📈 Support for Azure Workbooks

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -296,6 +296,12 @@
         "WINDOWSVMIMAGE",
         "winget",
         "xvfb",
-        "Xunit"
+        "Xunit",
+        "operationalinsights",
+        "piechart",
+        "timechart",
+        "myapp",
+        "mygroup",
+        "myworkbook"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   - `azmcp-keyvault-certificate-create`
   - `azmcp-keyvault-secret-list`
   - `azmcp-keyvault-secret-create`
+- Added support for Azure Workbooks management operations:
+  - `azmcp-workbooks-list` - List workbooks in a resource group with optional filtering
+  - `azmcp-workbooks-show` - Get detailed information about a specific workbook
+  - `azmcp-workbooks-create` - Create new workbooks with custom visualizations and content
+  - `azmcp-workbooks-update` - Update existing workbook configurations and metadata
+  - `azmcp-workbooks-delete` - Delete workbooks when no longer needed
 
 ### Breaking Changes
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Monitor.Ingestion" Version="1.1.2" />
     <PackageVersion Include="Azure.Monitor.Query" Version="1.6.0" />
+    <PackageVersion Include="Azure.ResourceManager.ApplicationInsights" Version="1.0.1" />
     <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.4.0" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.4" />
     <PackageVersion Include="Azure.ResourceManager.ContainerService" Version="1.2.3" />
@@ -36,6 +37,7 @@
     <PackageVersion Include="Azure.ResourceManager.Search" Version="1.2.3" />
     <PackageVersion Include="Azure.ResourceManager.Storage" Version="1.4.2" />
     <PackageVersion Include="Azure.ResourceManager.Grafana" Version="1.1.1" />
+    <PackageVersion Include="Azure.ResourceManager.ResourceGraph" Version="1.1.0-beta.3" />
     <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="13.0.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.72.1" />
     <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.3" />

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Here's a short (16 seconds) video to help you get the Azure MCP Server installed
 | Storage                   | Manage storage accounts and blob data.                           | [![Install](https://img.shields.io/badge/VS_Code-Install_storage-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=Azure%20Storage&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22@azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%2C%22--namespace%22%2C%22storage%22%5D%7D) | [![Install](https://img.shields.io/badge/VS_Code-Install_storage-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=Azure%20Storage%20Read%20Only&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22@azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%2C%22--namespace%22%2C%22storage%22%2C%22--read-only%22%5D%7D) |
 | Subscription              | Manage Azure subscription details.                               | [![Install](https://img.shields.io/badge/VS_Code-Install_subscription-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=Azure%20Subscription&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22@azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%2C%22--namespace%22%2C%22subscription%22%5D%7D) | [![Install](https://img.shields.io/badge/VS_Code-Install_subscription-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=Azure%20Subscription%20Read%20Only&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22@azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%2C%22--namespace%22%2C%22subscription%22%2C%22--read-only%22%5D%7D) |
 | Terraform Best Practices  | Secure, production-grade Azure Terraform guidance.               | [![Install](https://img.shields.io/badge/VS_Code-Install_terraform-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=Azure%20Terraform%20Best%20Practices&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22@azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%2C%22--namespace%22%2C%22azureterraformbestpractices%22%5D%7D) | [![Install](https://img.shields.io/badge/VS_Code-Install_terraform-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=Azure%20Terraform%20Best%20Practices%20Read%20Only&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22@azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%2C%22--namespace%22%2C%22azureterraformbestpractices%22%2C%22--read-only%22%5D%7D) |
+| Workbooks                 | Manage Azure Workbooks for data visualization.                   | [![Install](https://img.shields.io/badge/VS_Code-Install_workbooks-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=Azure%20Workbooks&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22@azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%2C%22--namespace%22%2C%22workbooks%22%5D%7D) | [![Install](https://img.shields.io/badge/VS_Code-Install_workbooks-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=Azure%20Workbooks%20Read%20Only&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22@azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%2C%22--namespace%22%2C%22workbooks%22%2C%22--read-only%22%5D%7D) |
 
 ### ▶️ Getting Started
 
@@ -259,6 +260,14 @@ The Azure MCP Server supercharges your agents with Azure context. Here are some 
 ### 🏗️ Azure Terraform Best Practices
 
 * Get secure, production-grade Azure Terraform best practices for effective code generation and command execution
+
+### 📊 Azure Workbooks
+
+* List workbooks in resource groups
+* Create new workbooks with custom visualizations
+* Update existing workbook configurations
+* Get workbook details and metadata
+* Delete workbooks when no longer needed
 
 ### 🏗️ Bicep
 

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -748,7 +748,7 @@ azmcp workbooks list --subscription <subscription> \
                      [--source-id <source-id>]
 
 # Show details of a specific workbook by resource ID
-azmcp workbooks show --workbook-id <azure-resource-id>
+azmcp workbooks show --workbook-id <workbook-resource-id>
 
 # Create a new workbook
 azmcp workbooks create --subscription <subscription> \
@@ -758,12 +758,12 @@ azmcp workbooks create --subscription <subscription> \
                        [--source-id <source-id>]
 
 # Update an existing workbook  
-azmcp workbooks update --workbook-id <azure-resource-id> \
+azmcp workbooks update --workbook-id <workbook-resource-id> \
                        [--display-name <display-name>] \
                        [--serialized-content <json-content>]
 
 # Delete a workbook
-azmcp workbooks delete --workbook-id <azure-resource-id>
+azmcp workbooks delete --workbook-id <workbook-resource-id>
 ```
 
 ### Azure Subscription Management

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -737,6 +737,35 @@ azmcp storage datalake file-system list-paths --subscription <subscription> \
                                               --file-system-name <file-system-name>
 ```
 
+### Azure Workbooks Operations
+
+```bash
+# List Azure Monitor workbooks in a resource group
+azmcp workbooks list --subscription <subscription> \
+                     --resource-group <resource-group> \
+                     [--category <category>] \
+                     [--kind <kind>] \
+                     [--source-id <source-id>]
+
+# Show details of a specific workbook by resource ID
+azmcp workbooks show --workbook-id <azure-resource-id>
+
+# Create a new workbook
+azmcp workbooks create --subscription <subscription> \
+                       --resource-group <resource-group> \
+                       --display-name <display-name> \
+                       --serialized-content <json-content> \
+                       [--source-id <source-id>]
+
+# Update an existing workbook  
+azmcp workbooks update --workbook-id <azure-resource-id> \
+                       [--display-name <display-name>] \
+                       [--serialized-content <json-content>]
+
+# Delete a workbook
+azmcp workbooks delete --workbook-id <azure-resource-id>
+```
+
 ### Azure Subscription Management
 
 ```bash

--- a/e2eTests/e2eTestPrompts.md
+++ b/e2eTests/e2eTestPrompts.md
@@ -169,6 +169,19 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp-tool-list | List all available tools in the Azure MCP server |
 | azmcp-tool-list | Show me the available tools in the Azure MCP server |
 
+## Azure Load Testing
+
+| Tool Name | Test Prompt |
+|:----------|:----------|
+| azmcp-loadtesting-testresource-list | List all load testing resources in the resource group <resource-group> in my subscription |
+| azmcp-loadtesting-testresource-create | Create a load test resource <load-test-resource-name> in the resource group <resource-group> in my subscription |
+| azmcp-loadtesting-test-get | Get the load test with id <test-id> in the load test resource <test-resource> in resource group <resource-group> |
+| azmcp-loadtesting-test-create | Create a basic URL test using the following endpoint URL <test-url> that runs for 30 minutes with 45 virtual users. The test name is <sample-name> with the test id <test-id> and the load testing resource is <load-test-resource> in the resource group <resource-group> in my subscription |
+| azmcp-loadtesting-testrun-get | Get the load test run with id <testrun-id> in the load test resource <test-resource> in resource group <resource-group> |
+| azmcp-loadtesting-testrun-list |  Get all the load test runs for the test with id <test-id> in the load test resource <test-resource> in resource group <resource-group> |
+| azmcp-loadtesting-testrun-create | Create a test run using the id <testrun-id> for test <test-id> in the load testing resource <load-testing-resource> in resource group <resource-group>. Use the name of test run <display-name> and description as <description> |
+| azmcp-loadtesting-testrun-update | Update a test run display name as <display-name> for the id <testrun-id> for test <test-id> in the load testing resource <load-testing-resource> in resource group <resource-group>.|
+
 ## Azure Monitor
 
 | Tool Name | Test Prompt |
@@ -290,6 +303,18 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp-storage-datalake-file-system-list-paths | Show me the paths in the Data Lake file system <file_system_name> in the storage account <account_name> |
 | azmcp-storage-table-list | List all tables in the storage account <account_name> |
 | azmcp-storage-table-list | Show me the tables in the storage account <account_name> |
+
+## Azure Workbooks
+
+| Tool Name | Test Prompt |
+|:----------|:----------|
+| azmcp-workbooks-list | List all workbooks in my resource group <resource_group_name> |
+| azmcp-workbooks-list | What workbooks do I have in resource group <resource_group_name>? |
+| azmcp-workbooks-show | Show me the workbook with display name <workbook_display_name> |
+| azmcp-workbooks-show | Get information about the workbook with resource ID <workbook_resource_id> |
+| azmcp-workbooks-create | Create a new workbook named <workbook_name> |
+| azmcp-workbooks-update | Update the workbook <workbook_resource_id> with a new text step |
+| azmcp-workbooks-delete | Delete the workbook with resource ID <workbook_resource_id> |
 
 ## Azure Subscription Management
 

--- a/infra/services/workbooks.bicep
+++ b/infra/services/workbooks.bicep
@@ -1,0 +1,470 @@
+targetScope = 'resourceGroup'
+
+@minLength(4)
+@maxLength(24)
+@description('The base resource name.')
+param baseName string = resourceGroup().name
+
+@description('The location of the resource. By default, this is the same as the resource group.')
+param location string = resourceGroup().location
+
+@description('The tenant ID to which the application and resources belong.')
+param tenantId string = '72f988bf-86f1-41af-91ab-2d7cd011db47'
+
+@description('The client OID to grant access to test resources.')
+param testApplicationOid string
+
+// Reference the existing Log Analytics workspace created by the monitor module
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: baseName
+}
+
+// Basic Azure Monitor Workbook
+resource basicMonitoringWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('${baseName}-basic-monitoring')
+  location: location
+  kind: 'shared'
+  properties: {
+    displayName: '${baseName} Basic Monitoring Dashboard'
+    description: 'Basic monitoring workbook for testing Azure MCP workbook operations'
+    category: 'workbook'
+    sourceId: workspace.id
+    serializedData: string({
+      version: 'Notebook/1.0'
+      items: [
+        {
+          type: 1
+          content: {
+            json: '# Basic Monitoring Dashboard\n\nThis workbook provides basic monitoring capabilities for testing purposes.'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'Heartbeat\n| where TimeGenerated > ago(1h)\n| summarize count() by Computer\n| order by count_ desc'
+            size: 0
+            title: 'Heartbeat Count by Computer (Last Hour)'
+            timeContext: {
+              durationMs: 3600000
+            }
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'table'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'AzureActivity\n| where TimeGenerated > ago(24h)\n| summarize count() by ActivityStatus\n| render piechart'
+            size: 0
+            title: 'Azure Activity Status (Last 24 Hours)'
+            timeContext: {
+              durationMs: 86400000
+            }
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'piechart'
+          }
+        }
+      ]
+      styleSettings: {}
+      '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
+    })
+    tags: {
+      purpose: 'testing'
+      environment: 'development'
+      project: 'azure-mcp'
+    }
+  }
+}
+
+// Performance Monitoring Workbook
+resource performanceWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('${baseName}-performance')
+  location: location
+  kind: 'shared'
+  properties: {
+    displayName: '${baseName} Performance Monitoring'
+    description: 'Performance monitoring workbook for testing Azure MCP performance metrics'
+    category: 'workbook'
+    sourceId: workspace.id
+    serializedData: string({
+      version: 'Notebook/1.0'
+      items: [
+        {
+          type: 1
+          content: {
+            json: '# Performance Monitoring\n\nThis workbook tracks performance metrics for testing purposes.'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'Perf\n| where TimeGenerated > ago(4h)\n| where CounterName == "% Processor Time"\n| summarize avg(CounterValue) by Computer, bin(TimeGenerated, 10m)\n| render timechart'
+            size: 0
+            title: 'CPU Usage Over Time'
+            timeContext: {
+              durationMs: 14400000
+            }
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'timechart'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'Perf\n| where TimeGenerated > ago(4h)\n| where CounterName == "Available MBytes"\n| summarize avg(CounterValue) by Computer, bin(TimeGenerated, 10m)\n| render timechart'
+            size: 0
+            title: 'Available Memory Over Time'
+            timeContext: {
+              durationMs: 14400000
+            }
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'timechart'
+          }
+        }
+      ]
+      styleSettings: {}
+      '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
+    })
+    tags: {
+      purpose: 'testing'
+      environment: 'development'
+      project: 'azure-mcp'
+      category: 'performance'
+    }
+  }
+}
+
+// Security Monitoring Workbook
+resource securityWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('${baseName}-security')
+  location: location
+  kind: 'shared'
+  properties: {
+    displayName: '${baseName} Security Monitoring'
+    description: 'Security monitoring workbook for testing Azure MCP security insights'
+    category: 'workbook'
+    sourceId: workspace.id
+    serializedData: string({
+      version: 'Notebook/1.0'
+      items: [
+        {
+          type: 1
+          content: {
+            json: '# Security Monitoring\n\nThis workbook provides security insights for testing purposes.'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'SecurityEvent\n| where TimeGenerated > ago(24h)\n| summarize count() by EventID\n| order by count_ desc\n| take 10'
+            size: 0
+            title: 'Top 10 Security Events (Last 24 Hours)'
+            timeContext: {
+              durationMs: 86400000
+            }
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'table'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'AzureActivity\n| where TimeGenerated > ago(24h)\n| where ActivityStatus == "Failed"\n| summarize count() by Caller\n| order by count_ desc'
+            size: 0
+            title: 'Failed Azure Activities by Caller'
+            timeContext: {
+              durationMs: 86400000
+            }
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'table'
+          }
+        }
+      ]
+      styleSettings: {}
+      '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
+    })
+    tags: {
+      purpose: 'testing'
+      environment: 'development'
+      project: 'azure-mcp'
+      category: 'security'
+    }
+  }
+}
+
+// Application Insights Workbook (if Application Insights is available)
+resource applicationInsightsWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('${baseName}-app-insights')
+  location: location
+  kind: 'shared'
+  properties: {
+    displayName: '${baseName} Application Insights'
+    description: 'Application insights workbook for testing Azure MCP application monitoring'
+    category: 'workbook'
+    sourceId: workspace.id
+    serializedData: string({
+      version: 'Notebook/1.0'
+      items: [
+        {
+          type: 1
+          content: {
+            json: '# Application Insights\n\nThis workbook provides application monitoring capabilities for testing purposes.'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'requests\n| where timestamp > ago(24h)\n| summarize count() by bin(timestamp, 1h)\n| render timechart'
+            size: 0
+            title: 'Request Count Over Time'
+            timeContext: {
+              durationMs: 86400000
+            }
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'timechart'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'exceptions\n| where timestamp > ago(24h)\n| summarize count() by type\n| order by count_ desc'
+            size: 0
+            title: 'Exception Types (Last 24 Hours)'
+            timeContext: {
+              durationMs: 86400000
+            }
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'table'
+          }
+        }
+      ]
+      styleSettings: {}
+      '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
+    })
+    tags: {
+      purpose: 'testing'
+      environment: 'development'
+      project: 'azure-mcp'
+      category: 'application'
+    }
+  }
+}
+
+// Simple Test Workbook for CRUD operations
+resource simpleTestWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('${baseName}-simple-test')
+  location: location
+  kind: 'shared'
+  properties: {
+    displayName: '${baseName} Simple Test Workbook'
+    description: 'Simple workbook for testing basic CRUD operations with Azure MCP'
+    category: 'workbook'
+    sourceId: workspace.id
+    serializedData: string({
+      version: 'Notebook/1.0'
+      items: [
+        {
+          type: 1
+          content: {
+            json: '# Simple Test Workbook\n\nThis is a simple workbook for testing basic operations.\n\n## Purpose\nThis workbook is designed to test:\n- Create operations\n- Read operations\n- Update operations\n- Delete operations\n\n## Test Data\nThis workbook contains minimal test data for validation purposes.'
+          }
+        }
+        {
+          type: 9
+          content: {
+            version: 'ParametersItem/1.0'
+            parameters: [
+              {
+                id: 'timeRange'
+                version: 'KqlParameterItem/1.0'
+                name: 'TimeRange'
+                type: 4
+                value: {
+                  durationMs: 3600000
+                }
+                typeSettings: {
+                  selectableValues: [
+                    {
+                      durationMs: 3600000
+                    }
+                    {
+                      durationMs: 14400000
+                    }
+                    {
+                      durationMs: 43200000
+                    }
+                    {
+                      durationMs: 86400000
+                    }
+                  ]
+                }
+              }
+            ]
+            style: 'pills'
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+          }
+        }
+        {
+          type: 3
+          content: {
+            version: 'KqlItem/1.0'
+            query: 'print "Test Query Result", now(), "Azure MCP Workbook Test"'
+            size: 0
+            title: 'Test Query'
+            timeContext: {
+              durationMs: 0
+            }
+            timeContextFromParameter: 'TimeRange'
+            queryType: 0
+            resourceType: 'microsoft.operationalinsights/workspaces'
+            visualization: 'table'
+          }
+        }
+      ]
+      styleSettings: {}
+      '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
+    })
+    tags: {
+      purpose: 'testing'
+      environment: 'development'
+      project: 'azure-mcp'
+      category: 'crud-test'
+    }
+  }
+}
+
+// User workbook for testing different kind
+resource userWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('${baseName}-user-workbook')
+  location: location
+  kind: 'user'
+  properties: {
+    displayName: '${baseName} User Workbook'
+    description: 'User workbook for testing different kind filter'
+    category: 'workbook'
+    sourceId: workspace.id
+    serializedData: string({
+      version: 'Notebook/1.0'
+      items: [
+        {
+          type: 1
+          content: {
+            json: '# User Workbook\n\nThis is a user workbook for testing kind filters.'
+          }
+        }
+      ]
+      styleSettings: {}
+      '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
+    })
+  }
+  tags: {
+    purpose: 'testing'
+    environment: 'development'
+    project: 'azure-mcp'
+    category: 'filter-test'
+  }
+}
+
+// Sentinel workbook for testing different category
+resource sentinelWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('${baseName}-sentinel-workbook')
+  location: location
+  kind: 'shared'
+  properties: {
+    displayName: '${baseName} Sentinel Workbook'
+    description: 'Sentinel workbook for testing different category filter'
+    category: 'sentinel'
+    sourceId: workspace.id
+    serializedData: string({
+      version: 'Notebook/1.0'
+      items: [
+        {
+          type: 1
+          content: {
+            json: '# Sentinel Workbook\n\nThis is a Sentinel workbook for testing category filters.'
+          }
+        }
+      ]
+      styleSettings: {}
+      '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
+    })
+  }
+  tags: {
+    purpose: 'testing'
+    environment: 'development'
+    project: 'azure-mcp'
+    category: 'filter-test'
+  }
+}
+
+// TSG workbook for testing different category
+resource tsgWorkbook 'Microsoft.Insights/workbooks@2023-06-01' = {
+  name: guid('${baseName}-tsg-workbook')
+  location: location
+  kind: 'shared'
+  properties: {
+    displayName: '${baseName} TSG Workbook'
+    description: 'TSG workbook for testing different category filter'
+    category: 'TSG'
+    sourceId: 'azure monitor'
+    serializedData: string({
+      version: 'Notebook/1.0'
+      items: [
+        {
+          type: 1
+          content: {
+            json: '# TSG Workbook\n\nThis is a TSG workbook for testing category and source ID filters.'
+          }
+        }
+      ]
+      styleSettings: {}
+      '$schema': 'https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json'
+    })
+  }
+  tags: {
+    purpose: 'testing'
+    environment: 'development'
+    project: 'azure-mcp'
+    category: 'filter-test'
+  }
+}
+
+// Output the workbook IDs for testing purposes
+output basicMonitoringWorkbookId string = basicMonitoringWorkbook.id
+output performanceWorkbookId string = performanceWorkbook.id
+output securityWorkbookId string = securityWorkbook.id
+output applicationInsightsWorkbookId string = applicationInsightsWorkbook.id
+output simpleTestWorkbookId string = simpleTestWorkbook.id
+output userWorkbookId string = userWorkbook.id
+output sentinelWorkbookId string = sentinelWorkbook.id
+output tsgWorkbookId string = tsgWorkbook.id
+
+output workbookNames array = [
+  basicMonitoringWorkbook.properties.displayName
+  performanceWorkbook.properties.displayName
+  securityWorkbook.properties.displayName
+  applicationInsightsWorkbook.properties.displayName
+  simpleTestWorkbook.properties.displayName
+  userWorkbook.properties.displayName
+  sentinelWorkbook.properties.displayName
+  tsgWorkbook.properties.displayName
+]
+
+output workspaceId string = workspace.id

--- a/infra/test-resources.bicep
+++ b/infra/test-resources.bicep
@@ -174,6 +174,19 @@ module storage 'services/storage.bicep' = if (empty(areas) || contains(areas, 'S
   }
 }
 
+module workbooks 'services/workbooks.bicep' = if (empty(areas) || contains(areas, 'Workbooks')) {
+  name: '${deploymentName}-workbooks'
+  params: {
+    baseName: baseName
+    location: location
+    tenantId: tenantId
+    testApplicationOid: testApplicationOid
+  }
+  dependsOn: [
+    monitoring
+  ]
+}
+
 module loadtesting 'services/loadtesting.bicep' = {
   name: '${deploymentName}-loadtesting'
   params: {

--- a/src/Areas/Workbooks/Commands/BaseWorkbooksCommand.cs
+++ b/src/Areas/Workbooks/Commands/BaseWorkbooksCommand.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using AzureMcp.Areas.Workbooks.Options;
+using AzureMcp.Commands;
+
+namespace AzureMcp.Areas.Workbooks.Commands;
+
+public abstract class BaseWorkbooksCommand<
+    [DynamicallyAccessedMembers(TrimAnnotations.CommandAnnotations)] T>
+    : GlobalCommand<T>
+    where T : BaseWorkbooksOptions, new();

--- a/src/Areas/Workbooks/Commands/Workbooks/CreateWorkbooksCommand.cs
+++ b/src/Areas/Workbooks/Commands/Workbooks/CreateWorkbooksCommand.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Areas.Workbooks.Options;
+using AzureMcp.Areas.Workbooks.Options.Workbook;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Commands;
+using AzureMcp.Commands.Subscription;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Areas.Workbooks.Commands.Workbook;
+
+public sealed class CreateWorkbooksCommand(ILogger<CreateWorkbooksCommand> logger) : SubscriptionCommand<CreateWorkbookOptions>
+{
+    private const string CommandTitle = "Create Workbook";
+    private readonly ILogger<CreateWorkbooksCommand> _logger = logger;
+
+    private readonly Option<string> _displayNameOption = WorkbooksOptionDefinitions.DisplayNameRequired;
+    private readonly Option<string> _serializedContentOption = WorkbooksOptionDefinitions.SerializedContentRequired;
+    private readonly Option<string> _sourceIdOption = WorkbooksOptionDefinitions.SourceId;
+
+    public override string Name => "create";
+
+    public override string Description =>
+        """
+        Create a new workbook in the specified resource group and subscription. 
+        You can set the display name and serialized data JSON content for the workbook.
+        Returns the created workbook information upon successful completion.
+        """;
+
+    public override string Title => CommandTitle;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_resourceGroupOption);
+        command.AddOption(_displayNameOption);
+        command.AddOption(_serializedContentOption);
+        command.AddOption(_sourceIdOption);
+    }
+
+    protected override CreateWorkbookOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGroup = parseResult.GetValueForOption(_resourceGroupOption);
+        options.DisplayName = parseResult.GetValueForOption(_displayNameOption);
+        options.SerializedContent = parseResult.GetValueForOption(_serializedContentOption);
+        options.SourceId = parseResult.GetValueForOption(_sourceIdOption);
+        return options;
+    }
+
+    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var workbooksService = context.GetService<IWorkbooksService>();
+            var createdWorkbook = await workbooksService.CreateWorkbook(
+                options.Subscription!,
+                options.ResourceGroup!,
+                options.DisplayName!,
+                options.SerializedContent!,
+                /**
+                 * The source ID is optional, defaulting to "azure monitor" if not provided.
+                 * "azure monitor" is the default for workbooks created in the Azure Monitor extension,
+                 * otherwise the workbook will display an error when opening.
+                 */
+                options.SourceId ?? "azure monitor",
+                options.RetryPolicy,
+                options.Tenant) ?? throw new InvalidOperationException("Failed to create workbook");
+
+            context.Response.Results = ResponseResult.Create(
+                new CreateWorkbooksCommandResult(createdWorkbook),
+                WorkbooksJsonContext.Default.CreateWorkbooksCommandResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating workbook '{DisplayName}' in resource group '{ResourceGroup}'", options.DisplayName, options.ResourceGroup);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    public sealed record CreateWorkbooksCommandResult(WorkbookInfo Workbook);
+}

--- a/src/Areas/Workbooks/Commands/Workbooks/DeleteWorkbooksCommand.cs
+++ b/src/Areas/Workbooks/Commands/Workbooks/DeleteWorkbooksCommand.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Workbooks.Options;
+using AzureMcp.Areas.Workbooks.Options.Workbook;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Commands;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Areas.Workbooks.Commands.Workbook;
+
+public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logger) : GlobalCommand<DeleteWorkbookOptions>
+{
+    private const string CommandTitle = "Delete Workbook";
+    private readonly ILogger<DeleteWorkbooksCommand> _logger = logger;
+
+    private static readonly Option<string> _workbookIdOption = WorkbooksOptionDefinitions.WorkbookId;
+
+    public override string Name => "delete";
+
+    public override string Description =>
+        """
+        Delete a workbook by its Azure resource ID. 
+        This command soft deletes the workbook: it will be retained for 90 days.
+        If needed, you can restore it from the Recycle Bin through the Azure Portal.
+        
+        To learn more, visit: https://learn.microsoft.com/azure/azure-monitor/visualize/workbooks-manage
+        """;
+
+    public override string Title => CommandTitle;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_workbookIdOption);
+    }
+
+    protected override DeleteWorkbookOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.WorkbookId = parseResult.GetValueForOption(_workbookIdOption);
+        return options;
+    }
+
+    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var workbooksService = context.GetService<IWorkbooksService>();
+            var deleted = await workbooksService.DeleteWorkbook(options.WorkbookId!, options.RetryPolicy, options.Tenant);
+
+            if (deleted)
+            {
+                context.Response.Results = ResponseResult.Create(
+                            new DeleteWorkbooksCommandResult(options.WorkbookId!, "Successfully deleted"),
+                            WorkbooksJsonContext.Default.DeleteWorkbooksCommandResult);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Failed to delete workbook with ID '{options.WorkbookId}'");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting workbook with ID: {WorkbookId}", options.WorkbookId);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    public sealed record DeleteWorkbooksCommandResult(string WorkbookId, string Message);
+}

--- a/src/Areas/Workbooks/Commands/Workbooks/ListWorkbooksCommand.cs
+++ b/src/Areas/Workbooks/Commands/Workbooks/ListWorkbooksCommand.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Areas.Workbooks.Options;
+using AzureMcp.Areas.Workbooks.Options.Workbook;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Commands.Subscription;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Areas.Workbooks.Commands.Workbook;
+
+public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger) : SubscriptionCommand<ListWorkbooksOptions>
+{
+    private const string CommandTitle = "List Workbooks";
+    private readonly ILogger<ListWorkbooksCommand> _logger = logger;
+
+    private readonly Option<string> _kindOption = WorkbooksOptionDefinitions.Kind;
+    private readonly Option<string> _categoryOption = WorkbooksOptionDefinitions.Category;
+    private readonly Option<string> _sourceIdOption = WorkbooksOptionDefinitions.SourceIdFilter;
+
+    public override string Name => "list";
+
+    public override string Description =>
+        """
+        List all workbooks in a specific resource group. This command retrieves all workbooks available
+        in the specified resource group within the given subscription. Resource group is required.
+        Optionally filter by kind (shared/user), category (workbook/sentinel/etc), or source resource ID.
+        """;
+
+    public override string Title => CommandTitle;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_resourceGroupOption);
+        command.AddOption(_kindOption);
+        command.AddOption(_categoryOption);
+        command.AddOption(_sourceIdOption);
+    }
+
+    protected override ListWorkbooksOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.ResourceGroup = parseResult.GetValueForOption(_resourceGroupOption);
+        options.Kind = parseResult.GetValueForOption(_kindOption);
+        options.Category = parseResult.GetValueForOption(_categoryOption);
+        options.SourceId = parseResult.GetValueForOption(_sourceIdOption);
+        return options;
+    }
+
+    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var workbooksService = context.GetService<IWorkbooksService>();
+            var filters = options.ToFilters();
+            var workbooks = await workbooksService.ListWorkbooks(
+                options.Subscription!,
+                options.ResourceGroup!,
+                filters,
+                options.RetryPolicy,
+                options.Tenant);
+
+            context.Response.Results = workbooks?.Count > 0
+                ? ResponseResult.Create(new ListWorkbooksCommandResult(workbooks), WorkbooksJsonContext.Default.ListWorkbooksCommandResult)
+                : null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error listing workbooks for subscription: {Subscription}", options.Subscription);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    internal record ListWorkbooksCommandResult(List<WorkbookInfo> Workbooks);
+}

--- a/src/Areas/Workbooks/Commands/Workbooks/ShowWorkbooksCommand.cs
+++ b/src/Areas/Workbooks/Commands/Workbooks/ShowWorkbooksCommand.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Areas.Workbooks.Options;
+using AzureMcp.Areas.Workbooks.Options.Workbook;
+using AzureMcp.Areas.Workbooks.Services;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Areas.Workbooks.Commands.Workbook;
+
+public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger) : BaseWorkbooksCommand<ShowWorkbooksOptions>
+{
+    private const string CommandTitle = "Get Workbook";
+    private readonly ILogger<ShowWorkbooksCommand> _logger = logger;
+    private readonly Option<string> _workbookIdOption = WorkbooksOptionDefinitions.WorkbookId;
+
+    public override string Name => "show";
+
+    public override string Description =>
+        """
+        Gets information about a specific workbook by its Azure resource ID.
+        Returns workbook details including JSON serialized content, display name, description, category,
+        location, kind, tags, version, modification time, and other metadata.
+        """;
+
+    public override string Title => CommandTitle;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_workbookIdOption);
+    }
+
+    protected override ShowWorkbooksOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.WorkbookId = parseResult.GetValueForOption(_workbookIdOption);
+        return options;
+    }
+
+    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var workbooksService = context.GetService<IWorkbooksService>();
+            var workbook = await workbooksService.GetWorkbook(options.WorkbookId!, options.RetryPolicy, options.Tenant) ?? throw new InvalidOperationException("Failed to retrieve workbook");
+
+            context.Response.Results = ResponseResult.Create(
+                new ShowWorkbooksCommandResult(workbook),
+                WorkbooksJsonContext.Default.ShowWorkbooksCommandResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving workbook with ID: {WorkbookId}", options.WorkbookId);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    internal record ShowWorkbooksCommandResult(WorkbookInfo Workbook);
+}

--- a/src/Areas/Workbooks/Commands/Workbooks/UpdateWorkbooksCommand.cs
+++ b/src/Areas/Workbooks/Commands/Workbooks/UpdateWorkbooksCommand.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Areas.Workbooks.Options;
+using AzureMcp.Areas.Workbooks.Options.Workbook;
+using AzureMcp.Areas.Workbooks.Services;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Areas.Workbooks.Commands.Workbook;
+
+public sealed class UpdateWorkbooksCommand(ILogger<UpdateWorkbooksCommand> logger) : BaseWorkbooksCommand<UpdateWorkbooksOptions>
+{
+    private const string CommandTitle = "Update Workbook";
+    private readonly ILogger<UpdateWorkbooksCommand> _logger = logger;
+    private readonly Option<string> _workbookIdOption = WorkbooksOptionDefinitions.WorkbookId;
+    private readonly Option<string> _displayNameOption = WorkbooksOptionDefinitions.DisplayName;
+    private readonly Option<string> _serializedContentOption = WorkbooksOptionDefinitions.SerializedContent;
+
+    public override string Name => "update";
+
+    public override string Description =>
+        """
+        Updates properties of a workbook, including its display name and serialized content.
+        At least one property must be provided for the update operation.
+        Returns the updated workbook object upon successful completion.
+        """;
+
+    public override string Title => CommandTitle;
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_workbookIdOption);
+        command.AddOption(_displayNameOption);
+        command.AddOption(_serializedContentOption);
+    }
+
+    protected override UpdateWorkbooksOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.WorkbookId = parseResult.GetValueForOption(_workbookIdOption);
+        options.DisplayName = parseResult.GetValueForOption(_displayNameOption);
+        options.SerializedContent = parseResult.GetValueForOption(_serializedContentOption);
+        return options;
+    }
+
+    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var workbooksService = context.GetService<IWorkbooksService>();
+            var updatedWorkbook = await workbooksService.UpdateWorkbook(
+                options.WorkbookId!,
+                options.DisplayName,
+                options.SerializedContent,
+                options.RetryPolicy,
+                options.Tenant) ?? throw new InvalidOperationException("Failed to update workbook");
+
+            context.Response.Results = ResponseResult.Create(
+                new UpdateWorkbooksCommandResult(updatedWorkbook),
+                WorkbooksJsonContext.Default.UpdateWorkbooksCommandResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating workbook with ID: {WorkbookId}", options.WorkbookId);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    internal record UpdateWorkbooksCommandResult(WorkbookInfo Workbook);
+}

--- a/src/Areas/Workbooks/Commands/WorkbooksJsonContext.cs
+++ b/src/Areas/Workbooks/Commands/WorkbooksJsonContext.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using AzureMcp.Areas.Workbooks.Commands.Workbook;
+using AzureMcp.Areas.Workbooks.Models;
+
+namespace AzureMcp.Areas.Workbooks.Commands;
+
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(WorkbookInfo))]
+[JsonSerializable(typeof(ListWorkbooksCommand.ListWorkbooksCommandResult))]
+[JsonSerializable(typeof(ShowWorkbooksCommand.ShowWorkbooksCommandResult))]
+[JsonSerializable(typeof(UpdateWorkbooksCommand.UpdateWorkbooksCommandResult))]
+[JsonSerializable(typeof(CreateWorkbooksCommand.CreateWorkbooksCommandResult))]
+[JsonSerializable(typeof(DeleteWorkbooksCommand.DeleteWorkbooksCommandResult))]
+internal partial class WorkbooksJsonContext : JsonSerializerContext;

--- a/src/Areas/Workbooks/Models/WorkbookFilters.cs
+++ b/src/Areas/Workbooks/Models/WorkbookFilters.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Areas.Workbooks.Models;
+
+/// <summary>
+/// Represents filtering options for workbook queries.
+/// </summary>
+public sealed record WorkbookFilters
+{
+    /// <summary>
+    /// Filter workbooks by kind (e.g., 'shared', 'user').
+    /// </summary>
+    public string? Kind { get; init; }
+
+    /// <summary>
+    /// Filter workbooks by category (e.g., 'workbook', 'sentinel', 'TSG').
+    /// </summary>
+    public string? Category { get; init; }
+
+    /// <summary>
+    /// Filter workbooks by source resource ID (e.g., Application Insights resource, Log Analytics workspace).
+    /// </summary>
+    public string? SourceId { get; init; }
+
+    /// <summary>
+    /// Creates an empty filter (no filtering applied).
+    /// </summary>
+    public static WorkbookFilters Empty => new();
+
+    /// <summary>
+    /// Checks if any filters are applied.
+    /// </summary>
+    public bool HasFilters => !string.IsNullOrEmpty(Kind) || !string.IsNullOrEmpty(Category) || !string.IsNullOrEmpty(SourceId);
+}

--- a/src/Areas/Workbooks/Models/WorkbookInfo.cs
+++ b/src/Areas/Workbooks/Models/WorkbookInfo.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Areas.Workbooks.Models;
+
+public sealed record WorkbookInfo(
+    string WorkbookId,
+    string? DisplayName,
+    string? Description,
+    string? Category,
+    string? Location,
+    string? Kind,
+    string? Tags,
+    string? SerializedData,
+    string? Version,
+    DateTimeOffset? TimeModified,
+    string? UserId,
+    string? SourceId
+);

--- a/src/Areas/Workbooks/Options/BaseWorkbooksOptions.cs
+++ b/src/Areas/Workbooks/Options/BaseWorkbooksOptions.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using AzureMcp.Options;
+
+namespace AzureMcp.Areas.Workbooks.Options;
+
+public class BaseWorkbooksOptions : GlobalOptions;

--- a/src/Areas/Workbooks/Options/Workbook/CreateWorkbookOptions.cs
+++ b/src/Areas/Workbooks/Options/Workbook/CreateWorkbookOptions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using AzureMcp.Options;
+
+namespace AzureMcp.Areas.Workbooks.Options.Workbook;
+
+public class CreateWorkbookOptions : SubscriptionOptions
+{
+    [JsonPropertyName(WorkbooksOptionDefinitions.DisplayNameText)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName(WorkbooksOptionDefinitions.SerializedContentText)]
+    public string? SerializedContent { get; set; }
+
+    [JsonPropertyName(WorkbooksOptionDefinitions.SourceIdText)]
+    public string? SourceId { get; set; }
+}

--- a/src/Areas/Workbooks/Options/Workbook/DeleteWorkbookOptions.cs
+++ b/src/Areas/Workbooks/Options/Workbook/DeleteWorkbookOptions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using AzureMcp.Options;
+
+namespace AzureMcp.Areas.Workbooks.Options.Workbook;
+
+public class DeleteWorkbookOptions : GlobalOptions
+{
+    [JsonPropertyName(WorkbooksOptionDefinitions.WorkbookIdText)]
+    public string? WorkbookId { get; set; }
+}

--- a/src/Areas/Workbooks/Options/Workbook/ListWorkbooksOptions.cs
+++ b/src/Areas/Workbooks/Options/Workbook/ListWorkbooksOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Options;
+
+namespace AzureMcp.Areas.Workbooks.Options.Workbook;
+
+public class ListWorkbooksOptions : SubscriptionOptions
+{
+    public string? Kind { get; set; }
+    public string? Category { get; set; }
+    public string? SourceId { get; set; }
+
+    /// <summary>
+    /// Creates a WorkbookFilters object from the command options.
+    /// </summary>
+    public WorkbookFilters ToFilters() => new()
+    {
+        Kind = Kind,
+        Category = Category,
+        SourceId = SourceId
+    };
+}

--- a/src/Areas/Workbooks/Options/Workbook/ShowWorkbooksOptions.cs
+++ b/src/Areas/Workbooks/Options/Workbook/ShowWorkbooksOptions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using AzureMcp.Areas.Workbooks.Options;
+
+namespace AzureMcp.Areas.Workbooks.Options.Workbook;
+
+public class ShowWorkbooksOptions : BaseWorkbooksOptions
+{
+    [JsonPropertyName(WorkbooksOptionDefinitions.WorkbookIdText)]
+    public string? WorkbookId { get; set; }
+}

--- a/src/Areas/Workbooks/Options/Workbook/UpdateWorkbooksOptions.cs
+++ b/src/Areas/Workbooks/Options/Workbook/UpdateWorkbooksOptions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using AzureMcp.Areas.Workbooks.Options;
+
+namespace AzureMcp.Areas.Workbooks.Options.Workbook;
+
+public class UpdateWorkbooksOptions : BaseWorkbooksOptions
+{
+    [JsonPropertyName(WorkbooksOptionDefinitions.WorkbookIdText)]
+    public string? WorkbookId { get; set; }
+
+    [JsonPropertyName(WorkbooksOptionDefinitions.DisplayNameText)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName(WorkbooksOptionDefinitions.SerializedContentText)]
+    public string? SerializedContent { get; set; }
+}

--- a/src/Areas/Workbooks/Options/WorkbooksOptionDefinitions.cs
+++ b/src/Areas/Workbooks/Options/WorkbooksOptionDefinitions.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Areas.Workbooks.Options;
+
+public static class WorkbooksOptionDefinitions
+{
+    public const string WorkbookIdText = "workbook-id";
+    public const string DisplayNameText = "display-name";
+    public const string SerializedContentText = "serialized-content";
+    public const string SourceIdText = "source-id";
+    public const string KindText = "kind";
+    public const string CategoryText = "category";
+
+    public static readonly Option<string> WorkbookId = new(
+        $"--{WorkbookIdText}",
+        "The Azure Resource ID of the workbook to retrieve."
+    )
+    {
+        IsRequired = true
+    };
+
+    public static readonly Option<string> DisplayName = new(
+        $"--{DisplayNameText}",
+        "The display name of the workbook."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<string> SerializedContent = new(
+        $"--{SerializedContentText}",
+        "The JSON serialized content/data of the workbook."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<string> SourceId = new(
+        $"--{SourceIdText}",
+        "The linked resource ID for the workbook. By default, this is 'azure monitor'."
+    )
+    {
+        IsRequired = false,
+    };
+
+    // Command-specific variations for required fields
+    public static readonly Option<string> DisplayNameRequired = new(
+        $"--{DisplayNameText}",
+        "The display name of the workbook.")
+    {
+        IsRequired = true
+    };
+
+    public static readonly Option<string> SerializedContentRequired = new(
+        $"--{SerializedContentText}",
+        "The serialized JSON content of the workbook.")
+    {
+        IsRequired = true
+    };
+
+    // Filter options for listing workbooks
+    public static readonly Option<string> Kind = new(
+        $"--{KindText}",
+        "Filter workbooks by kind (e.g., 'shared', 'user'). If not specified, all kinds will be returned."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<string> Category = new(
+        $"--{CategoryText}",
+        "Filter workbooks by category (e.g., 'workbook', 'sentinel', 'TSG'). If not specified, all categories will be returned."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<string> SourceIdFilter = new(
+        $"--{SourceIdText}",
+        "Filter workbooks by source resource ID (e.g., Application Insights resource, Log Analytics workspace). If not specified, all workbooks will be returned."
+    )
+    {
+        IsRequired = false
+    };
+}

--- a/src/Areas/Workbooks/Services/IWorkbooksService.cs
+++ b/src/Areas/Workbooks/Services/IWorkbooksService.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Options;
+
+namespace AzureMcp.Areas.Workbooks.Services;
+
+public interface IWorkbooksService
+{
+    Task<List<WorkbookInfo>> ListWorkbooks(string subscriptionId, string resourceGroupName, WorkbookFilters? filters = null, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
+    Task<WorkbookInfo?> CreateWorkbook(string subscriptionId, string resourceGroupName, string displayName, string serializedData, string sourceId, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
+    Task<WorkbookInfo?> GetWorkbook(string workbookId, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
+    Task<WorkbookInfo?> UpdateWorkbook(string workbookId, string? displayName = null, string? serializedContent = null, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
+    Task<bool> DeleteWorkbook(string workbookId, RetryPolicyOptions? retryPolicy = null, string? tenant = null);
+}

--- a/src/Areas/Workbooks/Services/WorkbooksService.cs
+++ b/src/Areas/Workbooks/Services/WorkbooksService.cs
@@ -1,0 +1,352 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Options;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Areas.Workbooks.Services;
+
+using Azure.ResourceManager.ApplicationInsights;
+using Azure.ResourceManager.ApplicationInsights.Models;
+using Azure.ResourceManager.ResourceGraph;
+using Azure.ResourceManager.ResourceGraph.Models;
+using AzureMcp.Services.Azure;
+using AzureMcp.Services.Azure.Subscription;
+using AzureMcp.Services.Azure.Tenant;
+
+public class WorkbooksService(ISubscriptionService _subscriptionService, ITenantService tenantService, ILogger<WorkbooksService> logger) : BaseAzureService(tenantService), IWorkbooksService
+{
+    private readonly ILogger<WorkbooksService> _logger = logger;
+    private readonly ITenantService _tenantService = tenantService;
+
+    public async Task<List<WorkbookInfo>> ListWorkbooks(string subscriptionId, string resourceGroupName, WorkbookFilters? filters = null, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
+    {
+        ValidateRequiredParameters(subscriptionId, resourceGroupName);
+
+        try
+        {
+            var armClient = await CreateArmClientAsync(tenant, retryPolicy);
+
+            var tenants = await _tenantService.GetTenants();
+            var currentTenant = tenants.FirstOrDefault() ?? throw new InvalidOperationException("No accessible tenants found");
+
+            var queryText = BuildWorkbooksQuery(subscriptionId, resourceGroupName, filters);
+            var query = new ResourceQueryContent(queryText);
+
+            var resources = await currentTenant.GetResourcesAsync(query);
+
+            var workbooksInRg = new List<WorkbookInfo>();
+
+            // The Resource Graph API returns data directly as a JSON array
+            var resourceGraphData = resources.Value.Data;
+            using JsonDocument document = JsonDocument.Parse(resourceGraphData.ToStream());
+            JsonElement resourcesArray = document.RootElement;
+
+            foreach (JsonElement resource in resourcesArray.EnumerateArray())
+            {
+                // Each resource is a complete JSON object with id, name, location, tags, properties
+                var resourceId = resource.GetProperty("id").GetString() ?? "";
+                var resourceName = resource.GetProperty("name").GetString() ?? "";
+                var location = resource.GetProperty("location").GetString() ?? "";
+                var kind = resource.GetProperty("kind").GetString() ?? "";
+                var tags = resource.TryGetProperty("tags", out var tagsElement) ? tagsElement : default;
+                var properties = resource.GetProperty("properties");
+
+                workbooksInRg.Add(new WorkbookInfo(
+                    WorkbookId: resourceId,
+                    DisplayName: properties.TryGetProperty("displayName", out var displayName) ? displayName.GetString() : null,
+                    Description: properties.TryGetProperty("description", out var desc) ? desc.GetString() : null,
+                    Category: properties.TryGetProperty("category", out var cat) ? cat.GetString() : null,
+                    Location: location,
+                    Kind: kind,
+                    Tags: tags.ValueKind != JsonValueKind.Undefined && tags.ValueKind != JsonValueKind.Null ? ConvertTagsToString(tags) : null,
+                    SerializedData: properties.TryGetProperty("serializedData", out var data) ? data.GetString() : null,
+                    Version: properties.TryGetProperty("version", out var ver) ? ver.GetString() : null,
+                    TimeModified: properties.TryGetProperty("timeModified", out var modified) ? modified.GetDateTimeOffset() : null,
+                    UserId: properties.TryGetProperty("userId", out var user) ? user.GetString() : null,
+                    SourceId: properties.TryGetProperty("sourceId", out var source) ? source.GetString() : null
+                ));
+            }
+
+            return workbooksInRg;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to list workbooks in resource group '{ResourceGroup}' for subscription '{Subscription}'", resourceGroupName, subscriptionId);
+            throw new Exception($"Failed to list workbooks: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<WorkbookInfo?> GetWorkbook(string workbookId, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
+    {
+        if (string.IsNullOrEmpty(workbookId))
+        {
+            _logger.LogWarning("Null or empty workbook ID provided");
+            return null;
+        }
+
+        try
+        {
+            var armClient = await CreateArmClientAsync(tenant, retryPolicy);
+
+            // Parse the workbook resource ID to get the workbook directly
+            var workbookResourceId = new ResourceIdentifier(workbookId);
+            var workbookResource = armClient.GetApplicationInsightsWorkbookResource(workbookResourceId) ?? throw new Exception($"Workbook with ID '{workbookId}' not found");
+
+            // Get the workbook
+            var workbookResponse = await workbookResource.GetAsync(true);
+            var workbook = workbookResponse.Value;
+
+            if (workbook?.Data == null)
+            {
+                _logger.LogWarning("Workbook data is null for ID {WorkbookId}", workbookId);
+                return null;
+            }
+
+            var workbookInfo = new WorkbookInfo(
+                WorkbookId: workbook.Id?.ToString() ?? workbookId,
+                DisplayName: workbook.Data.DisplayName,
+                Description: workbook.Data.Description,
+                Category: workbook.Data.Category,
+                Location: workbook.Data.Location.ToString(),
+                Kind: workbook.Data.Kind?.ToString(),
+                Tags: ConvertTagsToString(workbook.Data.Tags),
+                SerializedData: workbook.Data.SerializedData,
+                Version: workbook.Data.Version,
+                TimeModified: workbook.Data.ModifiedOn,
+                UserId: workbook.Data.UserId,
+                SourceId: workbook.Data.SourceId
+            );
+
+            _logger.LogInformation("Successfully retrieved workbook with ID: {WorkbookId}", workbookId);
+            return workbookInfo;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving workbook with ID: {WorkbookId}", workbookId);
+            throw new Exception($"Failed to get workbook: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<WorkbookInfo?> UpdateWorkbook(string workbookId, string? displayName = null, string? serializedContent = null, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
+    {
+        if (string.IsNullOrEmpty(workbookId))
+        {
+            _logger.LogWarning("Null or empty workbook ID provided");
+            return null;
+        }
+
+        try
+        {
+            var armClient = await CreateArmClientAsync(tenant, retryPolicy);
+
+            // Parse the workbook resource ID to get the workbook directly
+            var workbookResourceId = new ResourceIdentifier(workbookId);
+            var workbookResource = armClient.GetApplicationInsightsWorkbookResource(workbookResourceId) ?? throw new Exception($"Workbook with ID '{workbookId}' not found");
+
+            // Get the current workbook data
+            var workbookResponse = await workbookResource.GetAsync(true);
+            var workbook = workbookResponse.Value;
+
+            if (workbook?.Data == null)
+            {
+                _logger.LogWarning("Workbook data is null for ID {WorkbookId}", workbookId);
+                return null;
+            }
+
+            // Create a patch document with the updated properties
+            var patchData = new ApplicationInsightsWorkbookPatch();
+
+            if (!string.IsNullOrEmpty(displayName))
+            {
+                patchData.DisplayName = displayName;
+            }
+
+            if (!string.IsNullOrEmpty(serializedContent))
+            {
+                patchData.SerializedData = serializedContent;
+            }
+
+            // If not set, won't be able to save?
+            patchData.Kind = "shared";
+
+            // Update the workbook
+            var updateResponse = await workbookResource.UpdateAsync(patchData);
+            var updatedWorkbook = updateResponse.Value;
+
+            _logger.LogInformation("Successfully updated workbook with ID: {WorkbookId}", workbookId);
+
+            return new WorkbookInfo(
+                WorkbookId: updatedWorkbook.Id?.ToString() ?? workbookId,
+                DisplayName: updatedWorkbook.Data.DisplayName,
+                Description: updatedWorkbook.Data.Description,
+                Category: updatedWorkbook.Data.Category,
+                Location: updatedWorkbook.Data.Location.ToString(),
+                Kind: updatedWorkbook.Data.Kind?.ToString(),
+                Tags: ConvertTagsToString(updatedWorkbook.Data.Tags),
+                SerializedData: updatedWorkbook.Data.SerializedData,
+                Version: updatedWorkbook.Data.Version,
+                TimeModified: updatedWorkbook.Data.ModifiedOn,
+                UserId: updatedWorkbook.Data.UserId,
+                SourceId: updatedWorkbook.Data.SourceId
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating workbook with ID: {WorkbookId}", workbookId);
+            throw new Exception($"Failed to update workbook: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<WorkbookInfo?> CreateWorkbook(string subscriptionId, string resourceGroupName, string displayName, string serializedData, string sourceId, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
+    {
+        ValidateRequiredParameters(subscriptionId, resourceGroupName, displayName, serializedData, sourceId);
+
+        try
+        {
+            // Get the subscription resource
+            var subscriptionResource = await _subscriptionService.GetSubscription(subscriptionId, tenant, retryPolicy) ?? throw new Exception($"Subscription '{subscriptionId}' not found");
+            // Get the resource group
+            var resourceGroupResource = await subscriptionResource.GetResourceGroups().GetAsync(resourceGroupName);
+            if (resourceGroupResource?.Value == null)
+            {
+                throw new Exception($"Resource group '{resourceGroupName}' not found in subscription '{subscriptionId}'");
+            }
+
+            // Create the workbook data
+            var workbookData = new ApplicationInsightsWorkbookData(resourceGroupResource.Value.Data.Location)
+            {
+                DisplayName = displayName,
+                SerializedData = serializedData,
+                Category = "workbook",
+                Kind = "shared",
+                SourceId = new ResourceIdentifier(sourceId)
+            };
+
+
+            // Generate a unique name for the workbook
+            var workbookName = Guid.NewGuid().ToString();
+
+            // Create the workbook
+            var workbookCollection = resourceGroupResource.Value.GetApplicationInsightsWorkbooks();
+            var createOperation = await workbookCollection.CreateOrUpdateAsync(Azure.WaitUntil.Completed, workbookName, workbookData);
+            var createdWorkbook = createOperation.Value;
+
+            _logger.LogInformation("Successfully created workbook with name: {WorkbookName} in resource group: {ResourceGroup}", workbookName, resourceGroupName);
+
+            return new WorkbookInfo(
+                WorkbookId: createdWorkbook.Id?.ToString() ?? "",
+                DisplayName: createdWorkbook.Data.DisplayName ?? displayName,
+                Description: createdWorkbook.Data.Description,
+                Category: createdWorkbook.Data.Category,
+                Location: createdWorkbook.Data.Location.ToString(),
+                Kind: createdWorkbook.Data.Kind?.ToString(),
+                Tags: ConvertTagsToString(createdWorkbook.Data.Tags),
+                SerializedData: createdWorkbook.Data.SerializedData,
+                Version: createdWorkbook.Data.Version,
+                TimeModified: createdWorkbook.Data.ModifiedOn,
+                UserId: createdWorkbook.Data.UserId,
+                SourceId: createdWorkbook.Data.SourceId
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating workbook '{DisplayName}' in resource group '{ResourceGroup}'", displayName, resourceGroupName);
+            throw new Exception($"Failed to create workbook: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<bool> DeleteWorkbook(string workbookId, RetryPolicyOptions? retryPolicy = null, string? tenant = null)
+    {
+        ValidateRequiredParameters(workbookId);
+
+        try
+        {
+            var armClient = await CreateArmClientAsync(tenant, retryPolicy);
+
+            // Parse the workbook resource ID to get the workbook directly
+            var workbookResourceId = new ResourceIdentifier(workbookId);
+            var workbookResource = armClient.GetApplicationInsightsWorkbookResource(workbookResourceId) ?? throw new Exception($"Workbook with ID '{workbookId}' not found");
+
+            // Delete the workbook
+            var response = await workbookResource.DeleteAsync(Azure.WaitUntil.Completed);
+
+            _logger.LogInformation("Successfully deleted workbook with ID: {WorkbookId}", workbookId);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting workbook with ID: {WorkbookId}", workbookId);
+            throw new Exception($"Failed to delete workbook: {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Converts a JsonElement containing tags to a comma-separated string representation.
+    /// This helps keep the output flat for the model.
+    /// </summary>
+    private static string? ConvertTagsToString(JsonElement tagsElement)
+    {
+        if (tagsElement.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var tags = new List<string>();
+        foreach (var tag in tagsElement.EnumerateObject())
+        {
+            var value = tag.Value.GetString() ?? "";
+            tags.Add($"{tag.Name}={value}");
+        }
+
+        return tags.Count > 0 ? string.Join(", ", tags) : null;
+    }
+
+    /// <summary>
+    /// Converts a dictionary of tags to a comma-separated string representation.
+    /// This helps keep the output flat for the model.
+    /// </summary>
+    private static string? ConvertTagsToString(IDictionary<string, string>? tags)
+    {
+        return tags?.Count > 0 ? string.Join(", ", tags.Select(kvp => $"{kvp.Key}={kvp.Value}")) : null;
+    }
+
+    /// <summary>
+    /// Builds a KQL query for retrieving workbooks with optional filters.
+    /// </summary>
+    private static string BuildWorkbooksQuery(string subscriptionId, string resourceGroupName, WorkbookFilters? filters)
+    {
+        var queryText = $@"
+            resources
+            | where type == 'microsoft.insights/workbooks'
+            | where resourceGroup =~ '{resourceGroupName}'
+            | where subscriptionId =~ '{subscriptionId}'";
+
+        // Add optional filters if provided
+        if (filters?.HasFilters == true)
+        {
+            if (!string.IsNullOrEmpty(filters.Kind))
+            {
+                queryText += $@"
+            | where kind =~ '{filters.Kind}'";
+            }
+
+            if (!string.IsNullOrEmpty(filters.Category))
+            {
+                queryText += $@"
+            | where properties.category =~ '{filters.Category}'";
+            }
+
+            if (!string.IsNullOrEmpty(filters.SourceId))
+            {
+                queryText += $@"
+            | where properties.sourceId =~ '{filters.SourceId}'";
+            }
+        }
+
+        queryText += @"
+            | project id, kind, name, location, tags, properties";
+
+        return queryText;
+    }
+}

--- a/src/Areas/Workbooks/WorkbooksSetup.cs
+++ b/src/Areas/Workbooks/WorkbooksSetup.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Workbooks.Commands.Workbook;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Commands;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Areas.Workbooks;
+
+public class WorkbooksSetup : IAreaSetup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSingleton<IWorkbooksService, WorkbooksService>();
+    }
+
+    public void RegisterCommands(CommandGroup rootGroup, ILoggerFactory loggerFactory)
+    {
+        var workbooks = new CommandGroup("workbooks", "Workbooks operations - Commands for managing Azure Workbooks resources.");
+        rootGroup.AddSubGroup(workbooks);
+
+        workbooks.AddCommand("list", new ListWorkbooksCommand(
+            loggerFactory.CreateLogger<ListWorkbooksCommand>()));
+
+        workbooks.AddCommand("show", new ShowWorkbooksCommand(
+            loggerFactory.CreateLogger<ShowWorkbooksCommand>()));
+
+        workbooks.AddCommand("update", new UpdateWorkbooksCommand(
+            loggerFactory.CreateLogger<UpdateWorkbooksCommand>()));
+
+        workbooks.AddCommand("create", new CreateWorkbooksCommand(
+            loggerFactory.CreateLogger<CreateWorkbooksCommand>()));
+
+        workbooks.AddCommand("delete", new DeleteWorkbooksCommand(
+            loggerFactory.CreateLogger<DeleteWorkbooksCommand>()));
+    }
+}

--- a/src/AzureMcp.csproj
+++ b/src/AzureMcp.csproj
@@ -60,6 +60,7 @@
     <PackageReference Include="Azure.Identity.Broker" />
     <PackageReference Include="Azure.Messaging.ServiceBus" />
     <PackageReference Include="Azure.Monitor.Query" />
+    <PackageReference Include="Azure.ResourceManager.ApplicationInsights" />
     <PackageReference Include="Azure.ResourceManager.AppConfiguration" />
     <PackageReference Include="Azure.ResourceManager.Authorization" />
     <PackageReference Include="Azure.ResourceManager.ContainerService" />
@@ -80,6 +81,7 @@
     <PackageReference Include="Azure.ResourceManager.OperationalInsights" />
     <PackageReference Include="Azure.ResourceManager.Search" />
     <PackageReference Include="Azure.ResourceManager.Storage" />
+    <PackageReference Include="Azure.ResourceManager.ResourceGraph" />
     <PackageReference Include="Azure.ResourceManager.Datadog" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" />
     <PackageReference Include="ModelContextProtocol" />

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -76,6 +76,7 @@ internal class Program
             new AzureMcp.Areas.ServiceBus.ServiceBusSetup(),
             new AzureMcp.Areas.Sql.SqlSetup(),
             new AzureMcp.Areas.Storage.StorageSetup(),
+            new AzureMcp.Areas.Workbooks.WorkbooksSetup(),
             new AzureMcp.Areas.BicepSchema.BicepSchemaSetup(),
             new AzureMcp.Areas.AzureTerraformBestPractices.AzureTerraformBestPracticesSetup(),
             new AzureMcp.Areas.LoadTesting.LoadTestingSetup(),

--- a/tests/Areas/Workbooks/LiveTests/WorkbooksCommandTests.cs
+++ b/tests/Areas/Workbooks/LiveTests/WorkbooksCommandTests.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using AzureMcp.Tests.Client;
+using AzureMcp.Tests.Client.Helpers;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.Workbooks.LiveTests;
+
+[Trait("Area", "Workbooks")]
+public class WorkbooksCommandTests(LiveTestFixture fixture, ITestOutputHelper output)
+    : CommandTestsBase(fixture, output), IClassFixture<LiveTestFixture>
+{
+    // Test workbook content for CRUD operations
+    private const string TestWorkbookContent = """
+        {
+            "version": "Notebook/1.0",
+            "items": [
+                {
+                    "type": 1,
+                    "content": {
+                        "json": "# Test Workbook\n\nThis is a test workbook created by Azure MCP live tests."
+                    }
+                }
+            ],
+            "styleSettings": {},
+            "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+        }
+        """;
+
+    [Fact]
+    [Trait("Category", "Live")]
+    public async Task Should_list_workbooks()
+    {
+        var result = await CallToolAsync(
+            "azmcp_workbooks_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName }
+            });
+
+        var workbooks = result.AssertProperty("Workbooks");
+        Assert.Equal(JsonValueKind.Array, workbooks.ValueKind);
+
+        // Should have workbooks from bicep template
+        var workbooksArray = workbooks.EnumerateArray();
+        Assert.NotEmpty(workbooksArray);
+
+        // Verify basic properties exist
+        foreach (var workbook in workbooksArray)
+        {
+            Assert.True(workbook.TryGetProperty("WorkbookId", out _));
+            Assert.True(workbook.TryGetProperty("DisplayName", out _));
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Live")]
+    public async Task Should_show_workbook_details()
+    {
+        // First get the list of workbooks to find a valid ID
+        var listResult = await CallToolAsync(
+            "azmcp_workbooks_list",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName }
+            });
+
+        var workbooks = listResult.AssertProperty("Workbooks");
+        var workbooksArray = workbooks.EnumerateArray().ToArray();
+        Assert.NotEmpty(workbooksArray);
+
+        // Use the first workbook
+        var firstWorkbook = workbooksArray[0];
+        Assert.True(firstWorkbook.TryGetProperty("WorkbookId", out var workbookId));
+
+        // Now get the detailed workbook
+        var result = await CallToolAsync(
+            "azmcp_workbooks_show",
+            new()
+            {
+                { "workbook-id", workbookId.GetString()! }
+            });
+
+        var workbook = result.AssertProperty("Workbook");
+        Assert.True(workbook.TryGetProperty("WorkbookId", out _));
+        Assert.True(workbook.TryGetProperty("DisplayName", out var displayName));
+
+        // SerializedData property must be present (but may be null due to Azure API limitation)
+        Assert.True(workbook.TryGetProperty("SerializedData", out _));
+    }
+
+    [Fact]
+    [Trait("Category", "Live")]
+    public async Task Should_perform_basic_crud_operations()
+    {
+        var workbookName = $"Test Workbook {Guid.NewGuid():N}";
+        string? workbookId = null;
+
+        try
+        {
+            // CREATE
+            var createResult = await CallToolAsync(
+                "azmcp_workbooks_create",
+                new()
+                {
+                    { "subscription", Settings.SubscriptionId },
+                    { "resource-group", Settings.ResourceGroupName },
+                    { "display-name", workbookName },
+                    { "serialized-content", TestWorkbookContent },
+                    { "source-id", "azure monitor" }
+                });
+
+            var createdWorkbook = createResult.AssertProperty("Workbook");
+            Assert.True(createdWorkbook.TryGetProperty("WorkbookId", out var workbookIdProperty));
+            workbookId = workbookIdProperty.GetString();
+            Assert.NotNull(workbookId);
+
+            Assert.True(createdWorkbook.TryGetProperty("DisplayName", out var displayNameProperty));
+            Assert.Equal(workbookName, displayNameProperty.GetString());
+
+            // UPDATE
+            var updatedName = $"Updated {workbookName}";
+            var updateResult = await CallToolAsync(
+                "azmcp_workbooks_update",
+                new()
+                {
+                    { "workbook-id", workbookId },
+                    { "display-name", updatedName }
+                });
+
+            var updatedWorkbook = updateResult.AssertProperty("Workbook");
+            Assert.True(updatedWorkbook.TryGetProperty("DisplayName", out var updatedDisplayName));
+            Assert.Equal(updatedName, updatedDisplayName.GetString());
+
+            // READ (verify exists)
+            var showResult = await CallToolAsync(
+                "azmcp_workbooks_show",
+                new()
+                {
+                    { "workbook-id", workbookId }
+                });
+
+            var shownWorkbook = showResult.AssertProperty("Workbook");
+            Assert.True(shownWorkbook.TryGetProperty("WorkbookId", out _));
+            Assert.True(shownWorkbook.TryGetProperty("DisplayName", out var shownDisplayName));
+            Assert.Equal(updatedName, shownDisplayName.GetString());
+        }
+        finally
+        {
+            // DELETE
+            if (!string.IsNullOrEmpty(workbookId))
+            {
+                var deleteResult = await CallToolAsync(
+                    "azmcp_workbooks_delete",
+                    new()
+                    {
+                        { "workbook-id", workbookId }
+                    });
+
+                Assert.NotNull(deleteResult);
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Live")]
+    public async Task Should_delete_workbook()
+    {
+        var workbookName = $"Delete Test Workbook {Guid.NewGuid():N}";
+        string? workbookId = null;
+
+        // Create a workbook to delete
+        var createResult = await CallToolAsync(
+            "azmcp_workbooks_create",
+            new()
+            {
+                { "subscription", Settings.SubscriptionId },
+                { "resource-group", Settings.ResourceGroupName },
+                { "display-name", workbookName },
+                { "serialized-content", TestWorkbookContent },
+                { "source-id", "azure monitor" }
+            });
+
+        var createdWorkbook = createResult.AssertProperty("Workbook");
+        Assert.True(createdWorkbook.TryGetProperty("WorkbookId", out var workbookIdProperty));
+        workbookId = workbookIdProperty.GetString();
+        Assert.NotNull(workbookId);
+
+        // Delete the workbook
+        var deleteResult = await CallToolAsync(
+            "azmcp_workbooks_delete",
+            new()
+            {
+                { "workbook-id", workbookId }
+            });
+
+        // Verify delete operation succeeded
+        Assert.NotNull(deleteResult);
+        Assert.True(deleteResult.Value.TryGetProperty("WorkbookId", out var deletedWorkbookId));
+        Assert.Equal(workbookId, deletedWorkbookId.GetString());
+        Assert.True(deleteResult.Value.TryGetProperty("Message", out var deleteMessage));
+        Assert.Equal("Successfully deleted", deleteMessage.GetString());
+
+        // Verify workbook no longer exists by trying to show it (should return error)
+        var showResult = await CallToolAsync(
+            "azmcp_workbooks_show",
+            new()
+            {
+                { "workbook-id", workbookId }
+            });
+
+        // Should return an error response (500) since workbook was deleted
+        Assert.NotNull(showResult);
+        Assert.True(showResult.Value.TryGetProperty("message", out var errorMessage));
+        Assert.True(showResult.Value.TryGetProperty("type", out var errorType));
+        Assert.Equal("Exception", errorType.GetString());
+        Assert.Contains("not found", errorMessage.GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+
+}

--- a/tests/Areas/Workbooks/UnitTests/CreateWorkbooksCommandTests.cs
+++ b/tests/Areas/Workbooks/UnitTests/CreateWorkbooksCommandTests.cs
@@ -1,0 +1,532 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using AzureMcp.Areas.Workbooks.Commands.Workbook;
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Commands;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.Workbooks.UnitTests;
+
+[Trait("Area", "Workbooks")]
+public class CreateWorkbooksCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IWorkbooksService _service;
+    private readonly ILogger<CreateWorkbooksCommand> _logger;
+    private readonly CreateWorkbooksCommand _command;
+
+    public CreateWorkbooksCommandTests()
+    {
+        _service = Substitute.For<IWorkbooksService>();
+        _logger = Substitute.For<ILogger<CreateWorkbooksCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("create", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("workbook", command.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("resource group", command.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectValue()
+    {
+        Assert.Equal("create", _command.Name);
+    }
+
+    [Fact]
+    public void Title_ReturnsCorrectValue()
+    {
+        Assert.Equal("Create Workbook", _command.Title);
+    }
+
+    [Fact]
+    public void Description_ContainsRequiredInformation()
+    {
+        var description = _command.Description;
+        Assert.NotNull(description);
+        Assert.Contains("workbook", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("resource group", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("subscription", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("display name", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("serialized", description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreatesWorkbook_WhenValidParametersProvided()
+    {
+        // Arrange
+        var workbook = new WorkbookInfo(
+            WorkbookId: "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/workbooks/test-id",
+            DisplayName: "Test Workbook",
+            Description: null,
+            Category: "workbook",
+            Location: "West US 2",
+            Kind: "shared",
+            Tags: null,
+            SerializedData: """{"items":[{"type":"text","content":"Test content"}]}""",
+            Version: null,
+            TimeModified: null,
+            UserId: null,
+            SourceId: "azure monitor"
+        );
+
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(workbook);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Test Workbook",
+            "--serialized-content", """{"items":[{"type":"text","content":"Test content"}]}""");
+
+        // Act
+        var result = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(context.Response, result);
+        Assert.NotNull(result.Results);
+        Assert.Equal(200, result.Status);
+
+        await _service.Received(1).CreateWorkbook(
+            "test-sub",
+            "test-rg",
+            "Test Workbook",
+            """{"items":[{"type":"text","content":"Test content"}]}""",
+            "azure monitor",
+            Arg.Any<RetryPolicyOptions?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UsesProvidedSourceId_WhenSpecified()
+    {
+        // Arrange
+        var workbook = new WorkbookInfo(
+            WorkbookId: "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/workbooks/test-id",
+            DisplayName: "Test Workbook",
+            Description: null,
+            Category: null,
+            Location: "West US 2",
+            Kind: null,
+            Tags: null,
+            SerializedData: """{"items":[{"type":"text","content":"Test content"}]}""",
+            Version: null,
+            TimeModified: null,
+            UserId: null,
+            SourceId: null
+        );
+
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(workbook);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Test Workbook",
+            "--serialized-content", """{"items":[{"type":"text","content":"Test content"}]}""",
+            "--source-id", "custom-source");
+
+        // Act
+        await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        await _service.Received(1).CreateWorkbook(
+            "test-sub",
+            "test-rg",
+            "Test Workbook",
+            """{"items":[{"type":"text","content":"Test content"}]}""",
+            "custom-source",
+            Arg.Any<RetryPolicyOptions?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsError_WhenServiceReturnsNull()
+    {
+        // Arrange
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns((WorkbookInfo?)null);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Test Workbook",
+            "--serialized-content", """{"items":[{"type":"text","content":"Test content"}]}""");
+
+        // Act
+        var result = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(context.Response, result);
+        Assert.Equal(500, result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceErrors()
+    {
+        // Arrange
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(Task.FromException<WorkbookInfo?>(new InvalidOperationException("Service error")));
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Test Workbook",
+            "--serialized-content", """{"items":[{"type":"text","content":"Test content"}]}""");
+
+        // Act
+        var result = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(context.Response, result);
+        Assert.Equal(500, result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesCorrectParameters_ToService()
+    {
+        // Arrange
+        var workbook = new WorkbookInfo(
+            WorkbookId: "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/workbooks/test-id",
+            DisplayName: null,
+            Description: null,
+            Category: null,
+            Location: null,
+            Kind: null,
+            Tags: null,
+            SerializedData: null,
+            Version: null,
+            TimeModified: null,
+            UserId: null,
+            SourceId: null
+        );
+
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(workbook);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-subscription",
+            "--resource-group", "test-resource-group",
+            "--display-name", "My Test Workbook",
+            "--serialized-content", """{"version": "Notebook/1.0","items": [{"type": "1","content": "Hello World"}]}""");
+
+        // Act
+        await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        await _service.Received(1).CreateWorkbook(
+            "test-subscription",
+            "test-resource-group",
+            "My Test Workbook",
+            """{"version": "Notebook/1.0","items": [{"type": "1","content": "Hello World"}]}""",
+            "azure monitor",
+            Arg.Any<RetryPolicyOptions?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesNullTenant_WhenTenantNotProvided()
+    {
+        // Arrange
+        var workbook = new WorkbookInfo("test-id", null, null, null, null, null, null, null, null, null, null, null);
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(workbook);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Test Workbook",
+            "--serialized-content", """{"items":[]}""");
+
+        // Act
+        await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        await _service.Received(1).CreateWorkbook(
+            "test-sub",
+            "test-rg",
+            "Test Workbook",
+            """{"items":[]}""",
+            "azure monitor",
+            Arg.Any<RetryPolicyOptions?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAuthMethod_PassesCorrectParameters()
+    {
+        // Arrange
+        var workbook = new WorkbookInfo("test-id", null, null, null, null, null, null, null, null, null, null, null);
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(workbook);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Test Workbook",
+            "--serialized-content", """{"items":[]}""",
+            "--auth-method", "1",
+            "--tenant", "test-tenant");
+
+        // Act
+        await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        await _service.Received(1).CreateWorkbook(
+            "test-sub",
+            "test-rg",
+            "Test Workbook",
+            """{"items":[]}""",
+            "azure monitor",
+            Arg.Any<RetryPolicyOptions?>(),
+            "test-tenant");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public async Task ExecuteAsync_WithInvalidDisplayName_ReturnsValidationError(string? invalidDisplayName)
+    {
+        // Arrange
+        var context = new CommandContext(_serviceProvider);
+        var args = new List<string> { "--subscription", "test-sub", "--resource-group", "test-rg", "--serialized-content", """{"items":[]}""" };
+
+        if (invalidDisplayName != null)
+        {
+            args.AddRange(["--display-name", invalidDisplayName]);
+        }
+
+        var parseResult = CreateParseResult([.. args]);
+
+        // Act
+        var result = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(context.Response, result);
+        Assert.Equal(400, result.Status);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public async Task ExecuteAsync_WithInvalidSerializedContent_ReturnsValidationError(string? invalidSerializedContent)
+    {
+        // Arrange
+        var context = new CommandContext(_serviceProvider);
+        var args = new List<string> { "--subscription", "test-sub", "--resource-group", "test-rg", "--display-name", "Test Workbook" };
+
+        if (invalidSerializedContent != null)
+        {
+            args.AddRange(["--serialized-content", invalidSerializedContent]);
+        }
+
+        var parseResult = CreateParseResult([.. args]);
+
+        // Act
+        var result = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(context.Response, result);
+        Assert.Equal(400, result.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithComplexSerializedContent_HandlesCorrectly()
+    {
+        // Arrange
+        var complexSerializedData = """
+        {
+            "version": "Notebook/1.0",
+            "items": [
+                {
+                    "type": 1,
+                    "content": "# Azure Workbook Dashboard\n\nThis is a test workbook with complex content."
+                },
+                {
+                    "type": 3,
+                    "content": {
+                        "version": "KqlItem/1.0",
+                        "query": "AzureActivity | summarize count() by ActivityStatus",
+                        "size": 1,
+                        "queryType": 0,
+                        "resourceType": "microsoft.operationalinsights/workspaces"
+                    }
+                }
+            ]
+        }
+        """;
+
+        var workbook = new WorkbookInfo(
+            WorkbookId: "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/workbooks/complex-id",
+            DisplayName: "Complex Test Workbook",
+            Description: null,
+            Category: "workbook",
+            Location: "West US 2",
+            Kind: "shared",
+            Tags: """{"Environment": "Test", "Team": "DevOps"}""",
+            SerializedData: complexSerializedData,
+            Version: null,
+            TimeModified: null,
+            UserId: null,
+            SourceId: "azure monitor"
+        );
+
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(workbook);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Complex Test Workbook",
+            "--serialized-content", complexSerializedData);
+
+        // Act
+        var result = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(context.Response, result);
+        Assert.Equal(200, result.Status);
+        Assert.NotNull(result.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithRetryOptions_PassesCorrectParameters()
+    {
+        // Arrange
+        var workbook = new WorkbookInfo("test-id", null, null, null, null, null, null, null, null, null, null, null);
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(workbook);
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Test Workbook",
+            "--serialized-content", """{"items":[]}""",
+            "--retry-max-retries", "5",
+            "--retry-delay", "2.5",
+            "--retry-max-delay", "30",
+            "--retry-mode", "1");
+
+        // Act
+        await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        await _service.Received(1).CreateWorkbook(
+            "test-sub",
+            "test-rg",
+            "Test Workbook",
+            """{"items":[]}""",
+            "azure monitor",
+            Arg.Is<RetryPolicyOptions?>(opts =>
+                opts != null &&
+                opts.MaxRetries == 5 &&
+                opts.DelaySeconds == 2.5 &&
+                opts.MaxDelaySeconds == 30));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesExceptionCorrectly_WhenExceptionOccurs()
+    {
+        // Arrange
+        _service.CreateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions?>())
+            .Returns(Task.FromException<WorkbookInfo?>(new ArgumentException("Invalid workbook data")));
+
+        var context = new CommandContext(_serviceProvider);
+        var parseResult = CreateParseResult("--subscription", "test-sub",
+            "--resource-group", "test-rg",
+            "--display-name", "Test Workbook",
+            "--serialized-content", """{"items":[]}""");
+
+        // Act
+        var result = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(context.Response, result);
+        Assert.Equal(500, result.Status);
+    }
+
+    private ParseResult CreateParseResult(params string[] args)
+    {
+        var command = _command.GetCommand();
+        return command.Parse(args);
+    }
+}

--- a/tests/Areas/Workbooks/UnitTests/DeleteWorkbooksCommandTests.cs
+++ b/tests/Areas/Workbooks/UnitTests/DeleteWorkbooksCommandTests.cs
@@ -1,0 +1,372 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Text.Json;
+using Azure.Core;
+using AzureMcp.Areas.Workbooks.Commands.Workbook;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.Workbooks.UnitTests;
+
+[Trait("Area", "Workbooks")]
+public class DeleteWorkbooksCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IWorkbooksService _service;
+    private readonly ILogger<DeleteWorkbooksCommand> _logger;
+    private readonly DeleteWorkbooksCommand _command;
+
+    public DeleteWorkbooksCommandTests()
+    {
+        _service = Substitute.For<IWorkbooksService>();
+        _logger = Substitute.For<ILogger<DeleteWorkbooksCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("delete", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectValue()
+    {
+        Assert.Equal("delete", _command.Name);
+    }
+
+    [Fact]
+    public void Title_ReturnsCorrectValue()
+    {
+        Assert.Equal("Delete Workbook", _command.Title);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsSuccess_WhenWorkbookDeletedSuccessfully()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        _service.DeleteWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(true);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<DeleteWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(workbookId, result.WorkbookId);
+        Assert.Equal("Successfully deleted", result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsError_WhenWorkbookDeletionFails()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        _service.DeleteWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(false);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains($"Failed to delete workbook with ID '{workbookId}'", response.Message);
+        Assert.Contains("troubleshooting", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceErrors()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        _service.DeleteWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(Task.FromException<bool>(new Exception("Service error")));
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service error", response.Message);
+        Assert.Contains("troubleshooting", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesCorrectParameters_ToService()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/test-sub/resourceGroups/test-rg/providers/microsoft.insights/workbooks/test-workbook";
+
+        _service.DeleteWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(true);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--tenant", "test-tenant"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).DeleteWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Is("test-tenant"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesNullTenant_WhenTenantNotProvided()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/test-sub/resourceGroups/test-rg/providers/microsoft.insights/workbooks/test-workbook";
+
+        _service.DeleteWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(true);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).DeleteWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Is((string?)null));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAuthMethod_PassesCorrectParameters()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/test-sub/resourceGroups/test-rg/providers/microsoft.insights/workbooks/test-workbook";
+
+        _service.DeleteWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(true);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--auth-method", "1"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).DeleteWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteAsync_WithInvalidWorkbookId_ReturnsValidationError(string invalidWorkbookId)
+    {
+        // Arrange
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", invalidWorkbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("workbook", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMissingWorkbookId_ReturnsValidationError()
+    {
+        // Arrange - Parse without required workbook-id parameter
+        var parseResult = _command.GetCommand().Parse([]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, parseResult);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("workbook", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidResourceId_ProcessesCorrectly()
+    {
+        // Arrange
+        var validWorkbookId = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/my-rg/providers/microsoft.insights/workbooks/my-workbook-guid";
+
+        _service.DeleteWorkbook(
+            Arg.Is(validWorkbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(true);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", validWorkbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<DeleteWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(validWorkbookId, result.WorkbookId);
+        Assert.Equal("Successfully deleted", result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithDisplayNameAsWorkbookId_ProcessesCorrectly()
+    {
+        // Arrange
+        var displayName = "My Test Workbook";
+
+        _service.DeleteWorkbook(
+            Arg.Is(displayName),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(true);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", displayName
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<DeleteWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(displayName, result.WorkbookId);
+        Assert.Equal("Successfully deleted", result.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithRetryPolicy_PassesRetryOptions()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        _service.DeleteWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(true);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--retry-max-retries", "5",
+            "--retry-delay", "2"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).DeleteWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is<RetryPolicyOptions>(options =>
+                options.MaxRetries == 5 &&
+                options.DelaySeconds == 2),
+            Arg.Any<string?>());
+    }
+
+    private class DeleteWorkbooksCommandResult
+    {
+        public string WorkbookId { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+    }
+}

--- a/tests/Areas/Workbooks/UnitTests/ListWorkbooksCommandTests.cs
+++ b/tests/Areas/Workbooks/UnitTests/ListWorkbooksCommandTests.cs
@@ -1,0 +1,849 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Text.Json;
+using AzureMcp.Areas.Workbooks.Commands.Workbook;
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.Workbooks.UnitTests;
+
+[Trait("Area", "Workbooks")]
+public class ListWorkbooksCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IWorkbooksService _service;
+    private readonly ILogger<ListWorkbooksCommand> _logger;
+    private readonly ListWorkbooksCommand _command;
+
+    public ListWorkbooksCommandTests()
+    {
+        _service = Substitute.For<IWorkbooksService>();
+        _logger = Substitute.For<ILogger<ListWorkbooksCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("list", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("workbooks", command.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("resource group", command.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectValue()
+    {
+        Assert.Equal("list", _command.Name);
+    }
+
+    [Fact]
+    public void Title_ReturnsCorrectValue()
+    {
+        Assert.Equal("List Workbooks", _command.Title);
+    }
+
+    [Fact]
+    public void Description_ContainsRequiredInformation()
+    {
+        var description = _command.Description;
+        Assert.NotNull(description);
+        Assert.Contains("workbooks", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("resource group", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("subscription", description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsWorkbooks_WhenWorkbooksExist()
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>
+        {
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1",
+                DisplayName: "Test Workbook 1",
+                Description: "Test Description 1",
+                Category: "workbook",
+                Location: "eastus",
+                Kind: "shared",
+                Tags: "{}",
+                SerializedData: "{\"version\":\"Notebook/1.0\"}",
+                Version: "1.0",
+                TimeModified: DateTimeOffset.UtcNow,
+                UserId: "user1",
+                SourceId: "azure monitor"
+            ),
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook2",
+                DisplayName: "Test Workbook 2",
+                Description: "Test Description 2",
+                Category: "workbook",
+                Location: "eastus",
+                Kind: "shared",
+                Tags: "{}",
+                SerializedData: "{\"version\":\"Notebook/1.0\"}",
+                Version: "1.0",
+                TimeModified: DateTimeOffset.UtcNow,
+                UserId: "user2",
+                SourceId: "azure monitor"
+            )
+        };
+
+        _service.ListWorkbooks(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+                    "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--tenant", "tenant123"
+                ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ListWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedWorkbooks.Count, result.Workbooks.Count);
+        Assert.Collection(result.Workbooks,
+            workbook =>
+            {
+                Assert.Equal("Test Workbook 1", workbook.DisplayName);
+                Assert.Contains("workbook1", workbook.WorkbookId);
+            },
+            workbook =>
+            {
+                Assert.Equal("Test Workbook 2", workbook.DisplayName);
+                Assert.Contains("workbook2", workbook.WorkbookId);
+            });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNullResults_WhenNoWorkbooksExist()
+    {
+        // Arrange
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(new List<WorkbookInfo>());
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--tenant", "tenant123"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+        Assert.Equal(200, response.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNullResults_WhenServiceReturnsNull()
+    {
+        // Arrange
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(Task.FromResult<List<WorkbookInfo>>(null!));
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--tenant", "tenant123"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Null(response.Results);
+        Assert.Equal(200, response.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceErrors()
+    {
+        // Arrange
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(Task.FromException<List<WorkbookInfo>>(new Exception("Service error")));
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--tenant", "tenant123"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service error", response.Message);
+        Assert.Contains("troubleshooting", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesCorrectParameters_ToService()
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>();
+        _service.ListWorkbooks(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "test-subscription",
+            "--resource-group", "test-resource-group",
+            "--tenant", "test-tenant"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).ListWorkbooks(
+            Arg.Is("test-subscription"),
+            Arg.Is("test-resource-group"),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesNullTenant_WhenTenantNotProvided()
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>();
+        _service.ListWorkbooks(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "test-subscription",
+            "--resource-group", "test-resource-group"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).ListWorkbooks(
+            Arg.Is("test-subscription"),
+            Arg.Is("test-resource-group"),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAuthMethod_PassesCorrectParameters()
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>();
+        _service.ListWorkbooks(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "test-subscription",
+            "--resource-group", "test-resource-group",
+            "--auth-method", "1"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).ListWorkbooks(
+            Arg.Is("test-subscription"),
+            Arg.Is("test-resource-group"),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteAsync_WithInvalidSubscription_ReturnsValidationError(string invalidSubscription)
+    {
+        // Arrange
+        var args = _command.GetCommand().Parse([
+            "--subscription", invalidSubscription,
+            "--resource-group", "valid-rg"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("subscription", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteAsync_WithInvalidResourceGroup_ReturnsValidationError(string invalidResourceGroup)
+    {
+        // Arrange
+        var args = _command.GetCommand().Parse([
+            "--subscription", "valid-sub",
+            "--resource-group", invalidResourceGroup
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("resource", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithComplexWorkbookData_SerializesCorrectly()
+    {
+        // Arrange
+        var complexSerializedData = @"{
+            ""version"": ""Notebook/1.0"",
+            ""items"": [
+                {
+                    ""type"": 1,
+                    ""content"": {
+                        ""json"": ""# Complex Workbook\n\nThis is a complex test workbook.""
+                    }
+                }
+            ]
+        }";
+
+        var expectedWorkbooks = new List<WorkbookInfo>
+        {
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/complex",
+                DisplayName: "Complex Test Workbook",
+                Description: "A workbook with complex data",
+                Category: "workbook",
+                Location: "westus2",
+                Kind: "shared",
+                Tags: @"{""environment"": ""test"", ""team"": ""data""}",
+                SerializedData: complexSerializedData,
+                Version: "2.0",
+                TimeModified: new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero),
+                UserId: "complex-user-id",
+                SourceId: "azure monitor"
+            )
+        };
+
+        _service.ListWorkbooks(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<WorkbookFilters?>(),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ListWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Workbooks);
+
+        var workbook = result.Workbooks.First();
+        Assert.Equal("Complex Test Workbook", workbook.DisplayName);
+        Assert.Equal("2.0", workbook.Version);
+        Assert.Contains("complex", workbook.WorkbookId);
+        Assert.Contains("Notebook/1.0", workbook.SerializedData);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithKindFilter_PassesCorrectFilter()
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>
+        {
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1",
+                DisplayName: "Shared Workbook",
+                Description: "A shared workbook",
+                Category: "workbook",
+                Location: "eastus",
+                Kind: "shared",
+                Tags: null,
+                SerializedData: "{\"version\":\"Notebook/1.0\"}",
+                Version: "1.0",
+                TimeModified: DateTimeOffset.UtcNow,
+                UserId: "user1",
+                SourceId: "azure monitor"
+            )
+        };
+
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared"),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--kind", "shared"
+        ]);
+
+        // Act
+        var context = new CommandContext(_serviceProvider);
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        await _service.Received(1).ListWorkbooks(
+            "sub123",
+            "rg123",
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared"),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCategoryFilter_PassesCorrectFilter()
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>
+        {
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1",
+                DisplayName: "Sentinel Workbook",
+                Description: "A sentinel workbook",
+                Category: "sentinel",
+                Location: "eastus",
+                Kind: "shared",
+                Tags: null,
+                SerializedData: "{\"version\":\"Notebook/1.0\"}",
+                Version: "1.0",
+                TimeModified: DateTimeOffset.UtcNow,
+                UserId: "user1",
+                SourceId: "azure monitor"
+            )
+        };
+
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Category == "sentinel"),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--category", "sentinel"
+        ]);
+
+        // Act
+        var context = new CommandContext(_serviceProvider);
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        await _service.Received(1).ListWorkbooks(
+            "sub123",
+            "rg123",
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Category == "sentinel"),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithSourceIdFilter_PassesCorrectFilter()
+    {
+        // Arrange
+        var sourceId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/components/myapp";
+        var expectedWorkbooks = new List<WorkbookInfo>
+        {
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1",
+                DisplayName: "App Insights Workbook",
+                Description: "A workbook linked to App Insights",
+                Category: "workbook",
+                Location: "eastus",
+                Kind: "shared",
+                Tags: null,
+                SerializedData: "{\"version\":\"Notebook/1.0\"}",
+                Version: "1.0",
+                TimeModified: DateTimeOffset.UtcNow,
+                UserId: "user1",
+                SourceId: sourceId
+            )
+        };
+
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Is<WorkbookFilters?>(f => f != null && f.SourceId == sourceId),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--source-id", sourceId
+        ]);
+
+        // Act
+        var context = new CommandContext(_serviceProvider);
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        await _service.Received(1).ListWorkbooks(
+            "sub123",
+            "rg123",
+            Arg.Is<WorkbookFilters?>(f => f != null && f.SourceId == sourceId),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMultipleFilters_PassesCorrectFilters()
+    {
+        // Arrange
+        var sourceId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/components/myapp";
+        var expectedWorkbooks = new List<WorkbookInfo>
+        {
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1",
+                DisplayName: "Filtered Workbook",
+                Description: "A workbook with multiple filters",
+                Category: "sentinel",
+                Location: "eastus",
+                Kind: "shared",
+                Tags: null,
+                SerializedData: "{\"version\":\"Notebook/1.0\"}",
+                Version: "1.0",
+                TimeModified: DateTimeOffset.UtcNow,
+                UserId: "user1",
+                SourceId: sourceId
+            )
+        };
+
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared" && f.Category == "sentinel" && f.SourceId == sourceId),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--kind", "shared",
+            "--category", "sentinel",
+            "--source-id", sourceId
+        ]);
+
+        // Act
+        var context = new CommandContext(_serviceProvider);
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        await _service.Received(1).ListWorkbooks(
+            "sub123",
+            "rg123",
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared" && f.Category == "sentinel" && f.SourceId == sourceId),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAllFiltersApplied_PassesCorrectFilters()
+    {
+        // Arrange
+        var sourceId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/components/myapp";
+        var expectedWorkbooks = new List<WorkbookInfo>
+        {
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1",
+                DisplayName: "Filtered Workbook",
+                Description: "A workbook with multiple filters",
+                Category: "sentinel",
+                Location: "eastus",
+                Kind: "shared",
+                Tags: null,
+                SerializedData: "{\"version\":\"Notebook/1.0\"}",
+                Version: "1.0",
+                TimeModified: DateTimeOffset.UtcNow,
+                UserId: "user1",
+                SourceId: sourceId
+            )
+        };
+
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared" && f.Category == "sentinel" && f.SourceId == sourceId),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--kind", "shared",
+            "--category", "sentinel",
+            "--source-id", sourceId
+        ]);
+
+        // Act
+        var context = new CommandContext(_serviceProvider);
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        await _service.Received(1).ListWorkbooks(
+            "sub123",
+            "rg123",
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == "shared" && f.Category == "sentinel" && f.SourceId == sourceId),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithoutFilters_PassesEmptyFilters()
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>
+        {
+            new WorkbookInfo(
+                WorkbookId: "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1",
+                DisplayName: "Unfiltered Workbook",
+                Description: "A workbook without filters",
+                Category: "workbook",
+                Location: "eastus",
+                Kind: "shared",
+                Tags: null,
+                SerializedData: "{\"version\":\"Notebook/1.0\"}",
+                Version: "1.0",
+                TimeModified: DateTimeOffset.UtcNow,
+                UserId: "user1",
+                SourceId: "azure monitor"
+            )
+        };
+
+        _service.ListWorkbooks(
+            Arg.Is("sub123"),
+            Arg.Is("rg123"),
+            Arg.Is<WorkbookFilters?>(f => f != null && !f.HasFilters),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123"
+        ]);
+
+        // Act
+        var context = new CommandContext(_serviceProvider);
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        await _service.Received(1).ListWorkbooks(
+            "sub123",
+            "rg123",
+            Arg.Is<WorkbookFilters?>(f => f != null && !f.HasFilters),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Theory]
+    [InlineData("shared")]
+    [InlineData("user")]
+    public async Task ExecuteAsync_WithValidKind_AcceptsKindValue(string kind)
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>();
+        _service.ListWorkbooks(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == kind),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--kind", kind
+        ]);
+
+        // Act
+        var context = new CommandContext(_serviceProvider);
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+
+        await _service.Received(1).ListWorkbooks(
+            "sub123",
+            "rg123",
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Kind == kind),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    [Theory]
+    [InlineData("workbook")]
+    [InlineData("sentinel")]
+    [InlineData("TSG")]
+    [InlineData("application")]
+    public async Task ExecuteAsync_WithValidCategory_AcceptsCategoryValue(string category)
+    {
+        // Arrange
+        var expectedWorkbooks = new List<WorkbookInfo>();
+        _service.ListWorkbooks(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Category == category),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbooks);
+
+        var args = _command.GetCommand().Parse([
+            "--subscription", "sub123",
+            "--resource-group", "rg123",
+            "--category", category
+        ]);
+
+        // Act
+        var context = new CommandContext(_serviceProvider);
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+
+        await _service.Received(1).ListWorkbooks(
+            "sub123",
+            "rg123",
+            Arg.Is<WorkbookFilters?>(f => f != null && f.Category == category),
+            Arg.Any<RetryPolicyOptions?>(),
+            Arg.Any<string?>());
+    }
+
+    private class ListWorkbooksCommandResult
+    {
+        public List<WorkbookInfo> Workbooks { get; set; } = [];
+    }
+}

--- a/tests/Areas/Workbooks/UnitTests/ShowWorkbooksCommandTests.cs
+++ b/tests/Areas/Workbooks/UnitTests/ShowWorkbooksCommandTests.cs
@@ -1,0 +1,441 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Text.Json;
+using AzureMcp.Areas.Workbooks.Commands.Workbook;
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.Workbooks.UnitTests;
+
+[Trait("Area", "Workbooks")]
+public class ShowWorkbooksCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IWorkbooksService _service;
+    private readonly ILogger<ShowWorkbooksCommand> _logger;
+    private readonly ShowWorkbooksCommand _command;
+
+    public ShowWorkbooksCommandTests()
+    {
+        _service = Substitute.For<IWorkbooksService>();
+        _logger = Substitute.For<ILogger<ShowWorkbooksCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("show", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("workbook", command.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("resource ID", command.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectValue()
+    {
+        Assert.Equal("show", _command.Name);
+    }
+
+    [Fact]
+    public void Title_ReturnsCorrectValue()
+    {
+        Assert.Equal("Get Workbook", _command.Title);
+    }
+
+    [Fact]
+    public void Description_ContainsRequiredInformation()
+    {
+        var description = _command.Description;
+        Assert.NotNull(description);
+        Assert.Contains("workbook", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("resource ID", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("JSON", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("metadata", description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsWorkbook_WhenWorkbookExists()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var expectedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Test Workbook",
+            Description: "Test Description",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{\"version\":\"Notebook/1.0\",\"items\":[]}",
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.GetWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ShowWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Workbook);
+        Assert.Equal("Test Workbook", result.Workbook.DisplayName);
+        Assert.Equal(workbookId, result.Workbook.WorkbookId);
+        Assert.Equal("Test Description", result.Workbook.Description);
+        Assert.Contains("Notebook/1.0", result.Workbook.SerializedData);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsError_WhenWorkbookNotFound()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/nonexistent";
+
+        _service.GetWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(Task.FromResult<WorkbookInfo?>(null));
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Failed to retrieve workbook", response.Message);
+        Assert.Contains("troubleshooting", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceErrors()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        _service.GetWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(Task.FromException<WorkbookInfo?>(new Exception("Service error")));
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service error", response.Message);
+        Assert.Contains("troubleshooting", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesCorrectParameters_ToService()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var expectedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Test",
+            Description: "Test",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{}",
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.GetWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--tenant", "test-tenant"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).GetWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Is("test-tenant"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesNullTenant_WhenTenantNotProvided()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var expectedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Test",
+            Description: "Test",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{}",
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.GetWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).GetWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Is((string?)null));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAuthMethod_PassesCorrectParameters()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var expectedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Test",
+            Description: "Test",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{}",
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.GetWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--auth-method", "1"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).GetWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExecuteAsync_WithInvalidWorkbookId_ReturnsValidationError(string invalidWorkbookId)
+    {
+        // Arrange
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", invalidWorkbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("workbook", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMalformedWorkbookId_ReturnsServiceError()
+    {
+        // Arrange
+        var invalidWorkbookId = "invalid-resource-id";
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", invalidWorkbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("workbook", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithComplexWorkbookData_SerializesCorrectly()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/complex";
+        var complexSerializedData = @"{
+            ""version"": ""Notebook/1.0"",
+            ""items"": [
+                {
+                    ""type"": 1,
+                    ""content"": {
+                        ""json"": ""# Complex Workbook\n\nThis is a complex test workbook with markdown.""
+                    }
+                },
+                {
+                    ""type"": 3,
+                    ""content"": {
+                        ""version"": ""KqlItem/1.0"",
+                        ""query"": ""AzureActivity | summarize count() by ActivityStatus"",
+                        ""size"": 0,
+                        ""title"": ""Activity Summary"",
+                        ""timeContext"": {
+                            ""durationMs"": 86400000
+                        },
+                        ""queryType"": 0,
+                        ""resourceType"": ""microsoft.operationalinsights/workspaces"",
+                        ""visualization"": ""piechart""
+                    }
+                }
+            ],
+            ""styleSettings"": {},
+            ""$schema"": ""https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json""
+        }";
+
+        var complexTags = @"{
+            ""environment"": ""production"",
+            ""team"": ""data-analytics"",
+            ""version"": ""2.1"",
+            ""custom"": ""true""
+        }";
+
+        var expectedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Complex Analytics Dashboard",
+            Description: "A comprehensive dashboard with multiple KQL queries and visualizations",
+            Category: "workbook",
+            Location: "westus2",
+            Kind: "shared",
+            Tags: complexTags,
+            SerializedData: complexSerializedData,
+            Version: "2.1",
+            TimeModified: new DateTimeOffset(2024, 6, 15, 14, 30, 0, TimeSpan.Zero),
+            UserId: "complex-user-id-12345",
+            SourceId: "azure monitor"
+        );
+
+        _service.GetWorkbook(
+            Arg.Is(workbookId),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(expectedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<ShowWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Workbook);
+
+        var workbook = result.Workbook;
+        Assert.Equal("Complex Analytics Dashboard", workbook.DisplayName);
+        Assert.Equal("2.1", workbook.Version);
+        Assert.Equal("westus2", workbook.Location);
+        Assert.Contains("data-analytics", workbook.Tags);
+        Assert.Contains("KqlItem/1.0", workbook.SerializedData);
+        Assert.Contains("AzureActivity", workbook.SerializedData);
+        Assert.Contains("piechart", workbook.SerializedData);
+        Assert.Equal("complex-user-id-12345", workbook.UserId);
+    }
+
+    private class ShowWorkbooksCommandResult
+    {
+        public WorkbookInfo Workbook { get; set; } = null!;
+    }
+}

--- a/tests/Areas/Workbooks/UnitTests/UpdateWorkbooksCommandTests.cs
+++ b/tests/Areas/Workbooks/UnitTests/UpdateWorkbooksCommandTests.cs
@@ -1,0 +1,620 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Text.Json;
+using Azure.Core;
+using AzureMcp.Areas.Workbooks.Commands.Workbook;
+using AzureMcp.Areas.Workbooks.Models;
+using AzureMcp.Areas.Workbooks.Services;
+using AzureMcp.Models.Command;
+using AzureMcp.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.Workbooks.UnitTests;
+
+[Trait("Area", "Workbooks")]
+public class UpdateWorkbooksCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IWorkbooksService _service;
+    private readonly ILogger<UpdateWorkbooksCommand> _logger;
+    private readonly UpdateWorkbooksCommand _command;
+
+    public UpdateWorkbooksCommandTests()
+    {
+        _service = Substitute.For<IWorkbooksService>();
+        _logger = Substitute.For<ILogger<UpdateWorkbooksCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+    }
+
+    [Fact]
+    public void Constructor_InitializesCommandCorrectly()
+    {
+        var command = _command.GetCommand();
+        Assert.Equal("update", command.Name);
+        Assert.NotNull(command.Description);
+        Assert.NotEmpty(command.Description);
+        Assert.Contains("Updates properties", command.Description);
+        Assert.Contains("workbook", command.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Name_ReturnsCorrectValue()
+    {
+        Assert.Equal("update", _command.Name);
+    }
+
+    [Fact]
+    public void Title_ReturnsCorrectValue()
+    {
+        Assert.Equal("Update Workbook", _command.Title);
+    }
+
+    [Fact]
+    public void Description_ContainsRequiredInformation()
+    {
+        var description = _command.Description;
+        Assert.NotNull(description);
+        Assert.Contains("Updates properties", description);
+        Assert.Contains("workbook", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("display name", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("serialized content", description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UpdatesWorkbook_WhenValidParametersProvided()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var updatedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Updated Test Workbook",
+            Description: "Updated Description",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{\"version\":\"Notebook/1.0\",\"updated\":true}",
+            Version: "2.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.UpdateWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is("Updated Test Workbook"),
+            Arg.Is("{\"version\":\"Notebook/1.0\",\"updated\":true}"),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(updatedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "Updated Test Workbook",
+            "--serialized-content", "{\"version\":\"Notebook/1.0\",\"updated\":true}"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<UpdateWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal("Updated Test Workbook", result.Workbook.DisplayName);
+        Assert.Equal("2.0", result.Workbook.Version);
+        Assert.Contains("updated", result.Workbook.SerializedData);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UpdatesOnlyDisplayName_WhenOnlyDisplayNameProvided()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var updatedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "New Display Name Only",
+            Description: "Original Description",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{\"version\":\"Notebook/1.0\"}",
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.UpdateWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is("New Display Name Only"),
+            Arg.Is((string?)null),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(updatedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "New Display Name Only"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<UpdateWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal("New Display Name Only", result.Workbook.DisplayName);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UpdatesOnlySerializedContent_WhenOnlySerializedContentProvided()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var newSerializedContent = "{\"version\":\"Notebook/2.0\",\"content\":\"new\"}";
+        var updatedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Original Display Name",
+            Description: "Original Description",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: newSerializedContent,
+            Version: "2.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.UpdateWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is((string?)null),
+            Arg.Is(newSerializedContent),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(updatedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--serialized-content", newSerializedContent
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<UpdateWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Contains("Notebook/2.0", result.Workbook.SerializedData);
+        Assert.Contains("new", result.Workbook.SerializedData);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesCorrectParameters_ToService()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/test-sub/resourceGroups/test-rg/providers/microsoft.insights/workbooks/test-workbook";
+        var displayName = "Test Display Name";
+        var serializedContent = "{\"test\":\"content\"}";
+
+        var updatedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: displayName,
+            Description: "Test Description",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: serializedContent,
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.UpdateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(updatedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", displayName,
+            "--serialized-content", serializedContent
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).UpdateWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is(displayName),
+            Arg.Is(serializedContent),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Is((string?)null));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsError_WhenServiceReturnsNull()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        _service.UpdateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(Task.FromResult<WorkbookInfo?>(null));
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "Test Name"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Failed to update workbook", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceErrors()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        _service.UpdateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(Task.FromException<WorkbookInfo?>(new Exception("Service error")));
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "Test Name"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Service error", response.Message);
+        Assert.Contains("troubleshooting", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public async Task ExecuteAsync_WithInvalidWorkbookId_ReturnsValidationError(string? invalidWorkbookId)
+    {
+        // Arrange
+        var args = invalidWorkbookId == null
+            ? _command.GetCommand().Parse(["--display-name", "Test Name"])
+            : _command.GetCommand().Parse([
+                "--workbook-id", invalidWorkbookId,
+                "--display-name", "Test Name"
+            ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(400, response.Status);
+        Assert.Contains("workbook", response.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithComplexSerializedContent_HandlesCorrectly()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/complex";
+        var complexSerializedData = @"{
+            ""version"": ""Notebook/1.0"",
+            ""items"": [
+                {
+                    ""type"": 1,
+                    ""content"": {
+                        ""json"": ""# Updated Complex Workbook\n\nThis workbook has been updated with complex data.""
+                    }
+                },
+                {
+                    ""type"": 3,
+                    ""content"": {
+                        ""version"": ""KqlItem/1.0"",
+                        ""query"": ""requests | take 10"",
+                        ""size"": 1
+                    }
+                }
+            ],
+            ""styleSettings"": {
+                ""paddingStyle"": ""narrow""
+            }
+        }";
+
+        var updatedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Updated Complex Workbook",
+            Description: "A workbook with updated complex data",
+            Category: "workbook",
+            Location: "westus2",
+            Kind: "shared",
+            Tags: @"{""environment"": ""test"", ""updated"": ""true""}",
+            SerializedData: complexSerializedData,
+            Version: "3.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "complex-user-id",
+            SourceId: "azure monitor"
+        );
+
+        _service.UpdateWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is("Updated Complex Workbook"),
+            Arg.Is(complexSerializedData),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(updatedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "Updated Complex Workbook",
+            "--serialized-content", complexSerializedData
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        Assert.Equal(200, response.Status);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<UpdateWorkbooksCommandResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal("Updated Complex Workbook", result.Workbook.DisplayName);
+        Assert.Equal("3.0", result.Workbook.Version);
+        Assert.Contains("Updated Complex Workbook", result.Workbook.SerializedData);
+        Assert.Contains("KqlItem/1.0", result.Workbook.SerializedData);
+        Assert.Contains("requests | take 10", result.Workbook.SerializedData);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithTenant_PassesCorrectParameters()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var tenantId = "test-tenant-123";
+
+        var updatedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Test Workbook",
+            Description: "Test Description",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{\"version\":\"Notebook/1.0\"}",
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.UpdateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(updatedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "Test Workbook",
+            "--tenant", tenantId
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).UpdateWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is("Test Workbook"),
+            Arg.Is((string?)null),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Is(tenantId));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAuthMethod_PassesCorrectParameters()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        var updatedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Test Workbook",
+            Description: "Test Description",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{\"version\":\"Notebook/1.0\"}",
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.UpdateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(updatedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "Test Workbook",
+            "--auth-method", "1"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).UpdateWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is("Test Workbook"),
+            Arg.Is((string?)null),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithRetryOptions_PassesCorrectParameters()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+
+        var updatedWorkbook = new WorkbookInfo(
+            WorkbookId: workbookId,
+            DisplayName: "Test Workbook",
+            Description: "Test Description",
+            Category: "workbook",
+            Location: "eastus",
+            Kind: "shared",
+            Tags: "{}",
+            SerializedData: "{\"version\":\"Notebook/1.0\"}",
+            Version: "1.0",
+            TimeModified: DateTimeOffset.UtcNow,
+            UserId: "user1",
+            SourceId: "azure monitor"
+        );
+
+        _service.UpdateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(updatedWorkbook);
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "Test Workbook",
+            "--retry-max-retries", "5",
+            "--retry-delay", "2.5"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        await _command.ExecuteAsync(context, args);
+
+        // Assert
+        await _service.Received(1).UpdateWorkbook(
+            Arg.Is(workbookId),
+            Arg.Is("Test Workbook"),
+            Arg.Is((string?)null),
+            Arg.Is<RetryPolicyOptions>(x => x.MaxRetries == 5 && x.DelaySeconds == 2.5),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesExceptionCorrectly_WhenExceptionOccurs()
+    {
+        // Arrange
+        var workbookId = "/subscriptions/sub1/resourceGroups/rg1/providers/microsoft.insights/workbooks/workbook1";
+        var exception = new Exception("Test exception");
+
+        _service.UpdateWorkbook(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<RetryPolicyOptions>(),
+            Arg.Any<string?>())
+            .Returns(Task.FromException<WorkbookInfo?>(exception));
+
+        var args = _command.GetCommand().Parse([
+            "--workbook-id", workbookId,
+            "--display-name", "Test Name"
+        ]);
+
+        var context = new CommandContext(_serviceProvider);
+
+        // Act
+        var response = await _command.ExecuteAsync(context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Test exception", response.Message);
+    }
+
+    private class UpdateWorkbooksCommandResult
+    {
+        public WorkbookInfo Workbook { get; set; } = null!;
+    }
+}


### PR DESCRIPTION
Greetings from the Azure Monitor UX team 🌊

This PR adds support for basic CRUD operations around Azure Workbooks:

- Creating a workbook
- Listing available workbooks (with basic filters such as kind, type and linked resource)
- Updating a workbook
- Deleting a workbook

I've included **live tests** and **unit tests** for all commands, alongside Bicep configuration for the live tests. 

We're excited to contribute--we've had a multitude of internal demos showcasing models creating Workbooks dashboards after outage investigations, full end-to-end editing capabilities, and more. We think Workbooks is uniquely suited to take advantage of this.

## How querying works

Listing workbooks requires a subscription and resource group. Both are plumbed using best-practice patterns and services found around the repository. 

Operations over workbooks require a **workbook ID**. In our testing, we've found models will always seek the ID--even despite being told that searching by display name is an option. Hence, to simplify the internal implementation (display names are not unique for wbs!) we've standardized on `WorkbookId` for lookups.

## GitHub issue number?

N/A

## Pre-merge checklist
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) covering pull request process, code style, and testing**
- [x] PR title is clear and informative
- [x] Commit history is clean with informative messages (no previously merged commits appear in PR history). [See cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
- [x] Added comprehensive tests for core features
- [x] Added `CHANGELOG.md` entry for user-impacting changes (bug fixes, new features, UI/UX changes)
- [x] Spelling check passes with `.\eng\common\spelling\Invoke-Cspell.ps1`
- [x] For MCP tool changes, updated:
  - [x] Documentation in `README.md`
  - [x] Command list in `/docs/azmcp-commands.md` 
  - [x] End-to-end test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] **Team member live testing:**
  - [ ] **Security review:** Review PR for security vulnerabilities and malicious code before running tests (e.g., cryptocurrency mining, email spam, data exfiltration, or other harmful activities)
  - [x] **Test execution:** Add comment `/azp run azure - mcp` to trigger pipeline
