### PR TITLE
Fix Azure MCP Server from sending unrecognizable json to MCP clients in STDIO mode

### DIFF
--- a/src/Commands/CommandFactory.cs
+++ b/src/Commands/CommandFactory.cs
@@ -167,7 +167,11 @@ public class CommandFactory
                     response.Results = ResponseResult.Create(new List<string>(), JsonSourceGenerationContext.Default.ListString);
                 }
 
-                Console.WriteLine(JsonSerializer.Serialize(response, _srcGenWithOptions.CommandResponse));
+                var isServiceStartCommand = implementation is AzureMcp.Areas.Server.Commands.ServiceStartCommand;
+                if (!isServiceStartCommand)
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(response, _srcGenWithOptions.CommandResponse));
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## What does this PR do?

With support now limited to STDIO mode, the `Azure MCP Server` and `MCP Client`s always communicate using STDIO. When the MCP client starts the MCP server with the "server start" like below,

```
  "command": "npx",
  "args": ["-y", "@azure/mcp@latest", "server", "start"],
  "env": None,
   "transport": "stdio"
```

the `CommandFactory` runs the `ServiceStartCommand` to start host enabling the STDIO. The `CommandFactory` then writes the following output to `stdout`. This JSON is not MCP-compliant as it does not represents a valid response for any MCP requests.

```json
{
  "status": 200,
  "message": "Success", 
  "results": [],
  "duration": 1189
}
```

since this is not valid MCP response payload, and strict clients may reject it. Using the official Python MCP SDK, the issue can be reproduced: after the initial handshake and tools list response, the Azure MCP Server sends above payload, which fails.

In MCP Python SDK, in mcp stdio mode, `\n` serves as the delimiter between JSON lines (though I'm not sure if this is standard). The stdin stream is split by `\n` ([source](https://github.com/modelcontextprotocol/python-sdk/blob/99c4f3c906a130ab7f4a03e5f255280e0cdce395/src/mcp/client/stdio/__init__.py#L149)), and each part is checked for valid JSON. When Azure MCP Server `CommandFactory` sends `{` followed by  `\n`, the `{` fails JSON validation, which leads to "unhandled errors in a TaskGroup".

We can use the below code to reproduce this. The `await client.get_tools()` fails as the internal loop gets invalid MCP response after the valid tool list response.

```py
#!/usr/bin/env python3

import sys
import asyncio
import os
from dotenv import load_dotenv

from langchain_mcp_adapters.client import MultiServerMCPClient
from langgraph.prebuilt import create_react_agent
from langchain.chat_models import init_chat_model
from langchain_core.messages import SystemMessage, HumanMessage

load_dotenv()

async def main():

    client = MultiServerMCPClient(
        connections={
            "azure": {
                "command": "npx",
                "args": ["-y", "@azure/mcp@latest", "server", "start"],
                "env": None,
                "transport": "stdio"
            }
        }
    )
    

    try:
        tools = await client.get_tools()
        print(f"Loaded {len(tools)} tools")
    except Exception as e:
        print(f"Error: {e}")
        return
    

    from azure.identity import DefaultAzureCredential, get_bearer_token_provider
    
    credential = DefaultAzureCredential()
    token_provider = get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default")
    
    llm = init_chat_model(
        "gpt-4o",
        model_provider="azure_openai",
        azure_ad_token_provider=token_provider,
        azure_endpoint="https://<open-ai-namespace>.openai.azure.com/",
        api_version="2024-02-15-preview"
    )
    

    agent = create_react_agent(llm, tools)
    
    messages = [
        SystemMessage(content="You are an Azure assistant with access to Azure tools."),
        HumanMessage(content="Hello, can you help with Azure?"),
    ]
    
    response = await agent.ainvoke({"messages": messages})
    print(response["messages"][-1].content)
    
    # Test resource group listing
    messages.append(response["messages"][-1])
    messages.append(HumanMessage(content="List resource groups in subscription 70a036f6-8e4d-4615-bad6-149c02e7720d"))
    
    response = await agent.ainvoke({"messages": messages})
    print(response["messages"][-1].content)

if __name__ == "__main__":
    asyncio.run(main())
```

output (with this pr changes):
```
Loaded 85 tools
Of course! Please let me know what you need assistance with in Azure, whether it's managing resources, querying data, or understanding specific services, and I'll help you right away.
Here are the resource groups in the subscription `4d042dc6-fe17-4698-a23f-ec6a8d1e98f4`:

1. **<rg1>** (Location: eastus2)
2. **<rg2>** (Location: eastus2)
....
10. **<rg3>** (Location: eastus2)

There are many more resource groups. Let me know if you want the complete list or details of a specific group!
```

## GitHub issue number?

## Pre-merge checklist
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) covering pull request process, code style, and testing**
- [ ] PR title is clear and informative
- [ ] Commit history is clean with informative messages (no previously merged commits appear in PR history). [See cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
- [ ] Added comprehensive tests for core features
- [ ] Added `CHANGELOG.md` entry for user-impacting changes (bug fixes, new features, UI/UX changes)
- [ ] Spelling check passes with `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes, updated:
  - [ ] Documentation in `README.md`
  - [ ] Command list in `/docs/azmcp-commands.md` 
  - [ ] End-to-end test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] **Team member live testing:**
  - [ ] **Security review:** Review PR for security vulnerabilities and malicious code before running tests (e.g., cryptocurrency mining, email spam, data exfiltration, or other harmful activities)
  - [ ] **Test execution:** Add comment `/azp run azure - mcp` to trigger pipeline
