### PR TITLE
Fixes tool call errors before tool listing

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -42,6 +42,7 @@
                 "petermarcu",
                 "rohit",
                 "vinay",
+                "wbreza",
                 "xiangyan"
             ]
         },
@@ -66,6 +67,7 @@
                 "batchfile",
                 "bestpractices",
                 "buildtransitive",
+                "cctor",
                 "centralus",
                 "classdef",
                 "classfilters",
@@ -220,6 +222,7 @@
         "ESRPRELPACMANTEST",
         "facetable",
         "hnsw",
+        "idempotency",
         "idtyp",
         "keyvault",
         "Kusto",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixes issue where tool call can fail if MCP host does not first list tools [[#556](https://github.com/Azure/azure-mcp/issues/556)]
+
 ### Other Changes
 
 ## 0.4.1 (2025-07-17)

--- a/src/Areas/Server/Commands/Discovery/CommandGroupDiscoveryStrategy.cs
+++ b/src/Areas/Server/Commands/Discovery/CommandGroupDiscoveryStrategy.cs
@@ -3,6 +3,7 @@
 
 using AzureMcp.Areas.Server.Options;
 using AzureMcp.Commands;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace AzureMcp.Areas.Server.Commands.Discovery;
@@ -13,7 +14,8 @@ namespace AzureMcp.Areas.Server.Commands.Discovery;
 /// </summary>
 /// <param name="commandFactory">The command factory used to access available command groups.</param>
 /// <param name="options">Options for configuring the service behavior.</param>
-public sealed class CommandGroupDiscoveryStrategy(CommandFactory commandFactory, IOptions<ServiceStartOptions> options) : BaseDiscoveryStrategy()
+/// <param name="logger">Logger instance for this discovery strategy.</param>
+public sealed class CommandGroupDiscoveryStrategy(CommandFactory commandFactory, IOptions<ServiceStartOptions> options, ILogger<CommandGroupDiscoveryStrategy> logger) : BaseDiscoveryStrategy(logger)
 {
     private readonly CommandFactory _commandFactory = commandFactory;
     private readonly IOptions<ServiceStartOptions> _options = options;

--- a/src/Areas/Server/Commands/Discovery/CompositeDiscoveryStrategy.cs
+++ b/src/Areas/Server/Commands/Discovery/CompositeDiscoveryStrategy.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
+
 namespace AzureMcp.Areas.Server.Commands.Discovery;
 
 /// <summary>
@@ -8,7 +10,8 @@ namespace AzureMcp.Areas.Server.Commands.Discovery;
 /// This allows discovering servers from multiple sources and aggregating the results.
 /// </summary>
 /// <param name="strategies">The collection of discovery strategies to combine.</param>
-public sealed class CompositeDiscoveryStrategy(IEnumerable<IMcpDiscoveryStrategy> strategies) : BaseDiscoveryStrategy()
+/// <param name="logger">Logger instance for this discovery strategy.</param>
+public sealed class CompositeDiscoveryStrategy(IEnumerable<IMcpDiscoveryStrategy> strategies, ILogger<CompositeDiscoveryStrategy> logger) : BaseDiscoveryStrategy(logger)
 {
     private readonly List<IMcpDiscoveryStrategy> _strategies = InitializeStrategies(strategies);
 
@@ -43,5 +46,18 @@ public sealed class CompositeDiscoveryStrategy(IEnumerable<IMcpDiscoveryStrategy
         var results = await Task.WhenAll(tasks);
 
         return results.SelectMany(result => result);
+    }
+
+    /// <summary>
+    /// Disposes all child discovery strategies and then calls the base dispose.
+    /// </summary>
+    public override async ValueTask DisposeAsync()
+    {
+        // Dispose all child strategies first
+        var childDisposalTasks = _strategies.Select(strategy => strategy.DisposeAsync().AsTask());
+        await Task.WhenAll(childDisposalTasks);
+
+        // Then dispose our own cached clients
+        await base.DisposeAsync();
     }
 }

--- a/src/Areas/Server/Commands/Discovery/IDiscoveryStrategy.cs
+++ b/src/Areas/Server/Commands/Discovery/IDiscoveryStrategy.cs
@@ -5,7 +5,7 @@ using ModelContextProtocol.Client;
 
 namespace AzureMcp.Areas.Server.Commands.Discovery;
 
-public interface IMcpDiscoveryStrategy
+public interface IMcpDiscoveryStrategy : IAsyncDisposable
 {
     /// <summary>
     /// Discovers available MCP servers via this strategy.

--- a/src/Areas/Server/Commands/Discovery/RegistryDiscoveryStrategy.cs
+++ b/src/Areas/Server/Commands/Discovery/RegistryDiscoveryStrategy.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text.Json;
 using AzureMcp.Areas.Server.Models;
 using AzureMcp.Areas.Server.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace AzureMcp.Areas.Server.Commands.Discovery;
@@ -14,7 +15,8 @@ namespace AzureMcp.Areas.Server.Commands.Discovery;
 /// This strategy loads server configurations from a JSON resource bundled with the assembly.
 /// </summary>
 /// <param name="options">Options for configuring the service behavior.</param>
-public sealed class RegistryDiscoveryStrategy(IOptions<ServiceStartOptions> options) : BaseDiscoveryStrategy()
+/// <param name="logger">Logger instance for this discovery strategy.</param>
+public sealed class RegistryDiscoveryStrategy(IOptions<ServiceStartOptions> options, ILogger<RegistryDiscoveryStrategy> logger) : BaseDiscoveryStrategy(logger)
 {
     private readonly IOptions<ServiceStartOptions> _options = options;
     /// <summary>

--- a/src/Areas/Server/Commands/Discovery/RegistryServerProvider.cs
+++ b/src/Areas/Server/Commands/Discovery/RegistryServerProvider.cs
@@ -39,14 +39,35 @@ public sealed class RegistryServerProvider(string id, RegistryServerInfo serverI
     /// <exception cref="InvalidOperationException">Thrown when the server configuration doesn't specify a valid transport mechanism.</exception>
     public async Task<IMcpClient> CreateClientAsync(McpClientOptions clientOptions)
     {
-        if (!string.IsNullOrWhiteSpace(_serverInfo.Type) && _serverInfo.Type.Equals("stdio", StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrWhiteSpace(_serverInfo.Url))
+        {
+            return await CreateSseClientAsync(clientOptions);
+        }
+        else if (!string.IsNullOrWhiteSpace(_serverInfo.Type) && _serverInfo.Type.Equals("stdio", StringComparison.OrdinalIgnoreCase))
         {
             return await CreateStdioClientAsync(clientOptions);
         }
         else
         {
-            throw new InvalidOperationException($"Registry server '{_id}' does not have a valid transport type. Only 'stdio' is supported.");
+            throw new InvalidOperationException($"Registry server '{_id}' does not have a valid url or type for transport.");
         }
+    }
+
+    /// <summary>
+    /// Creates an MCP client that communicates with the server using Server-Sent Events (SSE).
+    /// </summary>
+    /// <param name="clientOptions">Options to configure the client behavior.</param>
+    /// <returns>A configured MCP client using SSE transport.</returns>
+    private async Task<IMcpClient> CreateSseClientAsync(McpClientOptions clientOptions)
+    {
+        var transportOptions = new SseClientTransportOptions
+        {
+            Name = _id,
+            Endpoint = new Uri(_serverInfo.Url!),
+            TransportMode = HttpTransportMode.AutoDetect,
+        };
+        var clientTransport = new SseClientTransport(transportOptions);
+        return await McpClientFactory.CreateAsync(clientTransport, clientOptions);
     }
 
     /// <summary>

--- a/src/Areas/Server/Commands/Runtime/IMcpRuntime.cs
+++ b/src/Areas/Server/Commands/Runtime/IMcpRuntime.cs
@@ -9,7 +9,7 @@ namespace AzureMcp.Areas.Server.Commands.Runtime;
 /// Defines the core functionality for a Model Context Protocol (MCP) runtime.
 /// The runtime is responsible for handling tool discovery and invocation requests.
 /// </summary>
-public interface IMcpRuntime
+public interface IMcpRuntime : IAsyncDisposable
 {
     /// <summary>
     /// Handles requests to list all tools available in the MCP server.

--- a/src/Areas/Server/Commands/Runtime/McpRuntime.cs
+++ b/src/Areas/Server/Commands/Runtime/McpRuntime.cs
@@ -87,4 +87,12 @@ public sealed class McpRuntime : IMcpRuntime
         using var activity = _telemetry.StartActivity(nameof(ListToolsHandler), request?.Server?.ClientInfo);
         return await _toolLoader.ListToolsHandler(request!, cancellationToken);
     }
+
+    /// <summary>
+    /// Disposes the tool loader and releases associated resources.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        await _toolLoader.DisposeAsync();
+    }
 }

--- a/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
+++ b/src/Areas/Server/Commands/ServiceCollectionExtensions.cs
@@ -69,7 +69,8 @@ public static class AzureMcpServiceCollectionExtensions
                     sp.GetRequiredService<CommandGroupDiscoveryStrategy>(),
                 };
 
-                return new CompositeDiscoveryStrategy(discoveryStrategies);
+                var logger = sp.GetRequiredService<ILogger<CompositeDiscoveryStrategy>>();
+                return new CompositeDiscoveryStrategy(discoveryStrategies, logger);
             });
         }
 

--- a/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -216,4 +216,14 @@ public sealed class CommandFactoryToolLoader(
 
         return tool;
     }
+
+    /// <summary>
+    /// Disposes resources owned by this tool loader.
+    /// CommandFactoryToolLoader doesn't own external resources that need disposal.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        // CommandFactoryToolLoader doesn't create or manage disposable resources
+        await ValueTask.CompletedTask;
+    }
 }

--- a/src/Areas/Server/Commands/ToolLoading/CompositeToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/CompositeToolLoader.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
 
 namespace AzureMcp.Areas.Server.Commands.ToolLoading;
 
@@ -19,6 +20,8 @@ public sealed class CompositeToolLoader(IEnumerable<IToolLoader> toolLoaders, IL
     private readonly IEnumerable<IToolLoader> _toolLoaders = InitializeToolLoaders(toolLoaders);
     private readonly Dictionary<string, IToolLoader> _toolLoaderMap = new();
     private readonly SemaphoreSlim _initializationSemaphore = new(1, 1);
+    private bool _isInitialized = false;
+    private List<Tool>? _cachedTools;
 
     /// <summary>
     /// Initializes the list of tool loaders, validating that at least one is provided.
@@ -46,33 +49,37 @@ public sealed class CompositeToolLoader(IEnumerable<IToolLoader> toolLoaders, IL
     /// </summary>
     /// <param name="request">The request context containing metadata and parameters.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    /// <returns>A result containing the combined list of all available tools.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when a tool loader returns a null response.</exception>
+    /// <returns>A result containing the combined list of all available tools, or an empty list if initialization fails.</returns>
     public async ValueTask<ListToolsResult> ListToolsHandler(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
     {
-        var allToolsResponse = new ListToolsResult
+        try
         {
-            Tools = new List<Tool>()
-        };
-
-        foreach (var loader in _toolLoaders)
+            await InitializeAsync(request.Server, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
         {
-            var toolsResponse = await loader.ListToolsHandler(request, cancellationToken);
-            if (toolsResponse == null)
-            {
-                throw new InvalidOperationException("Tool loader returned null response.");
-            }
+            _logger.LogError(ex, "Tool loader initialization failed");
 
-            foreach (var tool in toolsResponse.Tools)
+            // Return empty result with error indication
+            return new ListToolsResult
             {
-                allToolsResponse.Tools.Add(tool);
-                _toolLoaderMap[tool.Name] = loader;
-            }
+                Tools = []
+            };
         }
 
-        return allToolsResponse;
+        // Return cached result after initialization
+        return new ListToolsResult
+        {
+            Tools = _cachedTools!
+        };
     }
 
+    /// <summary>
+    /// Calls a tool by its name using the appropriate tool loader.
+    /// </summary>
+    /// <param name="request">The request context containing the tool name and parameters.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A result containing the output of the tool invocation, or an error result if the tool is not found or initialization fails.</returns>
     public async ValueTask<CallToolResult> CallToolHandler(RequestContext<CallToolRequestParams> request, CancellationToken cancellationToken)
     {
         if (request.Params == null)
@@ -92,7 +99,25 @@ public sealed class CompositeToolLoader(IEnumerable<IToolLoader> toolLoaders, IL
         }
 
         // Ensure tool loader map is populated before attempting tool lookup
-        await EnsureToolLoaderMapInitializedAsync(request, cancellationToken);
+        try
+        {
+            await InitializeAsync(request.Server, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            var content = new TextContentBlock
+            {
+                Text = $"Failed to initialize tool loaders: {ex.Message}",
+            };
+
+            _logger.LogError(ex, "Tool loader initialization failed");
+
+            return new CallToolResult
+            {
+                Content = [content],
+                IsError = true,
+            };
+        }
 
         if (!_toolLoaderMap.TryGetValue(request.Params.Name, out var toolCaller))
         {
@@ -114,44 +139,75 @@ public sealed class CompositeToolLoader(IEnumerable<IToolLoader> toolLoaders, IL
     }
 
     /// <summary>
-    /// Ensures that the tool loader map is initialized by populating it if it's empty.
-    /// This provides lazy initialization to handle cases where tool calls occur before ListToolsHandler is called.
-    /// Thread-safe initialization using a semaphore to prevent race conditions.
+    /// Initializes the tool loader map by discovering all tools from child loaders.
+    /// This provides thread-safe initialization using the double-checked locking pattern.
     /// </summary>
-    /// <param name="request">The request context containing metadata and parameters.</param>
+    /// <param name="server">The server context for creating list tools requests.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-    private async ValueTask EnsureToolLoaderMapInitializedAsync(RequestContext<CallToolRequestParams> request, CancellationToken cancellationToken)
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private async Task InitializeAsync(IMcpServer server, CancellationToken cancellationToken)
     {
-        if (_toolLoaderMap.Count == 0)
+        if (_isInitialized)
         {
-            await _initializationSemaphore.WaitAsync(cancellationToken);
-            try
-            {
-                // Double-check pattern: verify the map is still empty after acquiring the lock
-                if (_toolLoaderMap.Count == 0)
-                {
-                    // Create a dummy request for listing tools to populate the tool loader map
-                    var listToolsRequest = new RequestContext<ListToolsRequestParams>(request.Server)
-                    {
-                        Params = new ListToolsRequestParams()
-                    };
+            return;
+        }
 
-                    // Populate the tool loader map by calling ListToolsHandler internally
-                    await ListToolsHandler(listToolsRequest, cancellationToken);
+        await _initializationSemaphore.WaitAsync(cancellationToken);
+        try
+        {
+            // Double-check pattern: verify we're still not initialized after acquiring the lock
+            if (_isInitialized)
+            {
+                return;
+            }
+
+            // Populate the tool loader map and cache the combined tools
+            var allTools = new List<Tool>();
+
+            // Create a request for listing tools to populate the tool loader map
+            var listToolsRequest = new RequestContext<ListToolsRequestParams>(server)
+            {
+                Params = new ListToolsRequestParams()
+            };
+
+            foreach (var loader in _toolLoaders)
+            {
+                var toolsResponse = await loader.ListToolsHandler(listToolsRequest, cancellationToken);
+                if (toolsResponse == null)
+                {
+                    throw new InvalidOperationException("Tool loader returned null response during initialization.");
+                }
+
+                foreach (var tool in toolsResponse.Tools)
+                {
+                    _toolLoaderMap[tool.Name] = loader;
+                    allTools.Add(tool);
                 }
             }
-            finally
-            {
-                _initializationSemaphore.Release();
-            }
+
+            _cachedTools = allTools;
+            _isInitialized = true;
+        }
+        finally
+        {
+            _initializationSemaphore.Release();
         }
     }
 
     /// <summary>
-    /// Disposes the semaphore used for thread-safe initialization.
+    /// Disposes the semaphore used for thread-safe initialization and disposes child tool loaders if they implement IDisposable.
     /// </summary>
     public void Dispose()
     {
         _initializationSemaphore?.Dispose();
+
+        // Dispose child loaders if they implement IDisposable
+        foreach (var loader in _toolLoaders)
+        {
+            if (loader is IDisposable disposableLoader)
+            {
+                disposableLoader.Dispose();
+            }
+        }
     }
 }

--- a/src/Areas/Server/Commands/ToolLoading/IToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/IToolLoader.cs
@@ -9,7 +9,7 @@ namespace AzureMcp.Areas.Server.Commands.ToolLoading;
 /// Defines the interface for tool loaders in the MCP server.
 /// Tool loaders are responsible for discovering, listing, and invoking tools.
 /// </summary>
-public interface IToolLoader
+public interface IToolLoader : IAsyncDisposable
 {
     /// <summary>
     /// Handles requests to list all tools available in the MCP server.

--- a/src/Areas/Server/Commands/ToolLoading/RegistryToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/RegistryToolLoader.cs
@@ -24,6 +24,8 @@ public sealed class RegistryToolLoader(
     private readonly IOptions<ServiceStartOptions> _options = options;
     private readonly ILogger<RegistryToolLoader> _logger = logger;
     private Dictionary<string, IMcpClient> _toolClientMap = new();
+    private readonly SemaphoreSlim _initializationSemaphore = new(1, 1);
+    private bool _isInitialized = false;
 
     /// <summary>
     /// Gets or sets the client options used when creating MCP clients.
@@ -43,11 +45,14 @@ public sealed class RegistryToolLoader(
     /// <returns>A result containing the list of available tools.</returns>
     public async ValueTask<ListToolsResult> ListToolsHandler(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
     {
-        var serverList = await _serverDiscoveryStrategy.DiscoverServersAsync();
+        await InitializeAsync(cancellationToken);
+
         var allToolsResponse = new ListToolsResult
         {
             Tools = new List<Tool>()
         };
+
+        var serverList = await _serverDiscoveryStrategy.DiscoverServersAsync();
 
         foreach (var server in serverList)
         {
@@ -77,7 +82,6 @@ public sealed class RegistryToolLoader(
             foreach (var tool in filteredTools)
             {
                 allToolsResponse.Tools.Add(tool);
-                _toolClientMap[tool.Name] = mcpClient;
             }
         }
 
@@ -108,8 +112,10 @@ public sealed class RegistryToolLoader(
             };
         }
 
-        var mcpClient = _toolClientMap[request.Params.Name];
-        if (mcpClient == null)
+        // Initialize the tool client map if not already done
+        await InitializeAsync(cancellationToken);
+
+        if (!_toolClientMap.TryGetValue(request.Params.Name, out var mcpClient) || mcpClient == null)
         {
             var content = new TextContentBlock
             {
@@ -160,5 +166,67 @@ public sealed class RegistryToolLoader(
         }
 
         return parameters;
+    }
+
+    /// <summary>
+    /// Initializes the tool client map by discovering servers and populating tools.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        if (_isInitialized)
+        {
+            return;
+        }
+
+        await _initializationSemaphore.WaitAsync(cancellationToken);
+        try
+        {
+            // Double-check pattern: verify we're still not initialized after acquiring the lock
+            if (_isInitialized)
+            {
+                return;
+            }
+
+            var serverList = await _serverDiscoveryStrategy.DiscoverServersAsync();
+
+            foreach (var server in serverList)
+            {
+                var serverMetadata = server.CreateMetadata();
+                IMcpClient? mcpClient;
+                try
+                {
+                    mcpClient = await _serverDiscoveryStrategy.GetOrCreateClientAsync(serverMetadata.Name, ClientOptions);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    _logger.LogWarning("Failed to create client for provider {ProviderName}: {Error}", serverMetadata.Name, ex.Message);
+                    continue;
+                }
+
+                if (mcpClient == null)
+                {
+                    _logger.LogWarning("Failed to get MCP client for provider {ProviderName}.", serverMetadata.Name);
+                    continue;
+                }
+
+                var toolsResponse = await mcpClient.ListToolsAsync(cancellationToken: cancellationToken);
+                var filteredTools = toolsResponse
+                    .Select(t => t.ProtocolTool)
+                    .Where(t => !ReadOnly || (t.Annotations?.ReadOnlyHint == true));
+
+                foreach (var tool in filteredTools)
+                {
+                    _toolClientMap[tool.Name] = mcpClient;
+                }
+            }
+
+            _isInitialized = true;
+        }
+        finally
+        {
+            _initializationSemaphore.Release();
+        }
     }
 }

--- a/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
@@ -126,28 +126,50 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
             learn = true;
         }
 
-        if (learn && string.IsNullOrEmpty(command))
+        try
         {
-            return await InvokeToolLearn(request, intent ?? "", tool, cancellationToken);
+            if (learn && string.IsNullOrEmpty(command))
+            {
+                return await InvokeToolLearn(request, intent ?? "", tool, cancellationToken);
+            }
+            else if (!string.IsNullOrEmpty(tool) && !string.IsNullOrEmpty(command))
+            {
+                var toolParams = GetParametersDictionary(args);
+                return await InvokeChildToolAsync(request, intent ?? "", tool, command, toolParams, cancellationToken);
+            }
         }
-        else if (!string.IsNullOrEmpty(tool) && !string.IsNullOrEmpty(command))
+        catch (KeyNotFoundException ex)
         {
-            var toolParams = GetParametersDictionary(args);
-            return await InvokeChildToolAsync(request, intent ?? "", tool, command, toolParams, cancellationToken);
+            _logger.LogError(ex, "Key not found while calling tool: {Tool}", tool);
+
+            return new CallToolResult
+            {
+                Content =
+                [
+                    new TextContentBlock {
+                        Text = $"""
+                            The tool '{tool}.{command}' was not found or does not support the specified command.
+                            Please ensure the tool name and command are correct.
+                            If you want to learn about available tools, run again with the "learn=true" argument.
+                        """
+                    }
+                ],
+                IsError = true
+            };
         }
 
         return new CallToolResult
         {
             Content =
-            [
-                new TextContentBlock {
+                [
+                    new TextContentBlock {
                     Text = """
                         The "command" parameters are required when not learning
                         Run again with the "learn" argument to get a list of available tools and their parameters.
                         To learn about a specific tool, use the "tool" argument with the name of the tool.
                     """
                 }
-            ]
+                ]
         };
     }
 

--- a/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
@@ -517,4 +517,15 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
 
         return clientOptions;
     }
+
+    /// <summary>
+    /// Disposes resources owned by this tool loader.
+    /// ServerToolLoader doesn't own clients directly - they're owned by the discovery strategy.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        // ServerToolLoader doesn't create or cache clients directly,
+        // it relies on the discovery strategy which handles disposal
+        await ValueTask.CompletedTask;
+    }
 }

--- a/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
@@ -486,4 +486,15 @@ public sealed class SingleProxyToolLoader : IToolLoader
 
         return clientOptions;
     }
+
+    /// <summary>
+    /// Disposes resources owned by this tool loader.
+    /// SingleProxyToolLoader doesn't own clients directly - they're owned by the discovery strategy.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        // SingleProxyToolLoader doesn't create or cache clients directly,
+        // it relies on the discovery strategy which handles disposal
+        await ValueTask.CompletedTask;
+    }
 }

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/BaseDiscoveryStrategyTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/BaseDiscoveryStrategyTests.cs
@@ -2,11 +2,31 @@
 // Licensed under the MIT License.
 
 using AzureMcp.Areas.Server.Commands.Discovery;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol.Client;
 using NSubstitute;
 using Xunit;
 
 namespace AzureMcp.Tests.Areas.Server.UnitTests.Commands.Discovery;
+
+/// <summary>
+/// Concrete test implementation of BaseDiscoveryStrategy for testing disposal behavior
+/// </summary>
+public class TestDiscoveryStrategy : BaseDiscoveryStrategy
+{
+    private readonly IEnumerable<IMcpServerProvider> _providers;
+
+    public TestDiscoveryStrategy(IEnumerable<IMcpServerProvider> providers, ILogger? logger = null) : base(logger ?? NullLogger.Instance)
+    {
+        _providers = providers;
+    }
+
+    public override Task<IEnumerable<IMcpServerProvider>> DiscoverServersAsync()
+    {
+        return Task.FromResult(_providers);
+    }
+}
 
 [Trait("Area", "Server")]
 public class BaseDiscoveryStrategyTests
@@ -26,9 +46,7 @@ public class BaseDiscoveryStrategyTests
 
     private static BaseDiscoveryStrategy CreateMockStrategy(params IMcpServerProvider[] providers)
     {
-        var strategy = Substitute.For<BaseDiscoveryStrategy>();
-        strategy.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(providers));
-        return strategy;
+        return new TestDiscoveryStrategy(providers);
     }
 
     [Fact]
@@ -303,5 +321,116 @@ public class BaseDiscoveryStrategyTests
 
         // Still only 1 call total (all calls use the cached entry regardless of casing)
         await provider.Received(1).CreateClientAsync(Arg.Any<McpClientOptions>());
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldDisposeAllCachedClients()
+    {
+        // Arrange
+        var mockClient1 = Substitute.For<IMcpClient>();
+        var mockClient2 = Substitute.For<IMcpClient>();
+        var provider1 = CreateMockServerProvider("Server1");
+        var provider2 = CreateMockServerProvider("Server2");
+
+        provider1.CreateClientAsync(Arg.Any<McpClientOptions>()).Returns(mockClient1);
+        provider2.CreateClientAsync(Arg.Any<McpClientOptions>()).Returns(mockClient2);
+
+        var strategy = CreateMockStrategy(provider1, provider2);
+
+        // Create and cache some clients
+        await strategy.GetOrCreateClientAsync("Server1");
+        await strategy.GetOrCreateClientAsync("Server2");
+
+        // Act
+        await strategy.DisposeAsync();
+
+        // Assert - All cached clients should be disposed
+        await mockClient1.Received(1).DisposeAsync();
+        await mockClient2.Received(1).DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithNoCachedClients_ShouldNotThrow()
+    {
+        // Arrange
+        var provider = CreateMockServerProvider("Server1");
+        var strategy = CreateMockStrategy(provider);
+
+        // Act & Assert - should not throw
+        await strategy.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldHandleClientDisposalExceptions()
+    {
+        // Arrange
+        var mockClient1 = Substitute.For<IMcpClient>();
+        var mockClient2 = Substitute.For<IMcpClient>();
+        var provider1 = CreateMockServerProvider("Server1");
+        var provider2 = CreateMockServerProvider("Server2");
+
+        provider1.CreateClientAsync(Arg.Any<McpClientOptions>()).Returns(mockClient1);
+        provider2.CreateClientAsync(Arg.Any<McpClientOptions>()).Returns(mockClient2);
+
+        // Setup first client to throw on disposal
+        mockClient1.DisposeAsync().Returns(ValueTask.FromException(new InvalidOperationException("Client 1 disposal failed")));
+        mockClient2.DisposeAsync().Returns(ValueTask.CompletedTask);
+
+        var strategy = CreateMockStrategy(provider1, provider2);
+
+        // Cache both clients
+        await strategy.GetOrCreateClientAsync("Server1");
+        await strategy.GetOrCreateClientAsync("Server2");
+
+        // Act - Should not throw (BaseDiscoveryStrategy catches and swallows disposal exceptions)
+        await strategy.DisposeAsync();
+
+        // Assert - Both clients should have been attempted to dispose
+        await mockClient1.Received(1).DisposeAsync();
+        await mockClient2.Received(1).DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldBeIdempotent()
+    {
+        // Arrange
+        var mockClient = Substitute.For<IMcpClient>();
+        var provider = CreateMockServerProvider("Server1");
+        provider.CreateClientAsync(Arg.Any<McpClientOptions>()).Returns(mockClient);
+
+        var strategy = CreateMockStrategy(provider);
+
+        // Cache a client
+        await strategy.GetOrCreateClientAsync("Server1");
+
+        // Act - dispose multiple times
+        await strategy.DisposeAsync();
+        await strategy.DisposeAsync();
+        await strategy.DisposeAsync();
+
+        // Assert - client should only be disposed once (idempotent)
+        await mockClient.Received(1).DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldClearClientCache()
+    {
+        // Arrange
+        var mockClient = Substitute.For<IMcpClient>();
+        var provider = CreateMockServerProvider("Server1");
+        provider.CreateClientAsync(Arg.Any<McpClientOptions>()).Returns(mockClient);
+
+        var strategy = CreateMockStrategy(provider);
+
+        // Cache a client
+        var client1 = await strategy.GetOrCreateClientAsync("Server1");
+        Assert.Same(mockClient, client1);
+
+        // Act
+        await strategy.DisposeAsync();
+
+        // Assert - After disposal, cache should be cleared
+        // This is verified by the fact that disposal was called and the cache is no longer accessible
+        await mockClient.Received(1).DisposeAsync();
     }
 }

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/BaseDiscoveryStrategyTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/BaseDiscoveryStrategyTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using AzureMcp.Areas.Server.Commands.Discovery;
 using ModelContextProtocol.Client;
 using NSubstitute;

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/CommandGroupDiscoveryStrategyTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/CommandGroupDiscoveryStrategyTests.cs
@@ -31,7 +31,8 @@ public class CommandGroupDiscoveryStrategyTests
     {
         var factory = commandFactory ?? CommandFactoryHelpers.CreateCommandFactory();
         var startOptions = Microsoft.Extensions.Options.Options.Create(options ?? new ServiceStartOptions());
-        var strategy = new CommandGroupDiscoveryStrategy(factory, startOptions);
+        var logger = NSubstitute.Substitute.For<Microsoft.Extensions.Logging.ILogger<CommandGroupDiscoveryStrategy>>();
+        var strategy = new CommandGroupDiscoveryStrategy(factory, startOptions, logger);
         if (entryPoint != null)
         {
             strategy.EntryPoint = entryPoint;
@@ -44,10 +45,11 @@ public class CommandGroupDiscoveryStrategyTests
     {
         // Arrange
         var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
+        var logger = NSubstitute.Substitute.For<Microsoft.Extensions.Logging.ILogger<CommandGroupDiscoveryStrategy>>();
 
         // Act & Assert
         // Primary constructor syntax doesn't automatically validate null parameters
-        var strategy = new CommandGroupDiscoveryStrategy(null!, options);
+        var strategy = new CommandGroupDiscoveryStrategy(null!, options, logger);
         Assert.NotNull(strategy);
     }
 
@@ -56,10 +58,11 @@ public class CommandGroupDiscoveryStrategyTests
     {
         // Arrange
         var commandFactory = CommandFactoryHelpers.CreateCommandFactory();
+        var logger = NSubstitute.Substitute.For<Microsoft.Extensions.Logging.ILogger<CommandGroupDiscoveryStrategy>>();
 
         // Act & Assert
         // Primary constructor syntax doesn't automatically validate null parameters
-        var strategy = new CommandGroupDiscoveryStrategy(commandFactory, null!);
+        var strategy = new CommandGroupDiscoveryStrategy(commandFactory, null!, logger);
         Assert.NotNull(strategy);
     }
 
@@ -69,9 +72,10 @@ public class CommandGroupDiscoveryStrategyTests
         // Arrange
         var commandFactory = CommandFactoryHelpers.CreateCommandFactory();
         var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
+        var logger = NSubstitute.Substitute.For<Microsoft.Extensions.Logging.ILogger<CommandGroupDiscoveryStrategy>>();
 
         // Act
-        var strategy = new CommandGroupDiscoveryStrategy(commandFactory, options);
+        var strategy = new CommandGroupDiscoveryStrategy(commandFactory, options, logger);
 
         // Assert
         Assert.NotNull(strategy);
@@ -458,7 +462,8 @@ public class CommandGroupDiscoveryStrategyTests
     {
         var commandFactory = CommandFactoryHelpers.CreateCommandFactory();
         var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
-        var strategy = new CommandGroupDiscoveryStrategy(commandFactory, options);
+        var logger = NSubstitute.Substitute.For<Microsoft.Extensions.Logging.ILogger<CommandGroupDiscoveryStrategy>>();
+        var strategy = new CommandGroupDiscoveryStrategy(commandFactory, options, logger);
         var result = await strategy.DiscoverServersAsync();
         Assert.NotNull(result);
     }
@@ -469,7 +474,8 @@ public class CommandGroupDiscoveryStrategyTests
         var commandFactory = CommandFactoryHelpers.CreateCommandFactory();
         var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions { ReadOnly = true });
         var azmcpEntryPoint = GetAzmcpExecutablePath();
-        var strategy = new CommandGroupDiscoveryStrategy(commandFactory, options)
+        var logger = NSubstitute.Substitute.For<Microsoft.Extensions.Logging.ILogger<CommandGroupDiscoveryStrategy>>();
+        var strategy = new CommandGroupDiscoveryStrategy(commandFactory, options, logger)
         {
             EntryPoint = azmcpEntryPoint
         };

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/CommandGroupDiscoveryStrategyTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/CommandGroupDiscoveryStrategyTests.cs
@@ -1,16 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using AzureMcp.Areas.Server.Commands.Discovery;
 using AzureMcp.Areas.Server.Options;
 using AzureMcp.Commands;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using NSubstitute;
 using Xunit;
 
 namespace AzureMcp.Tests.Areas.Server.UnitTests.Commands.Discovery;

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/CommandGroupServerProviderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/CommandGroupServerProviderTests.cs
@@ -3,7 +3,6 @@
 
 using AzureMcp.Areas.Server.Commands.Discovery;
 using AzureMcp.Commands;
-using AzureMcp.Services.Telemetry;
 using ModelContextProtocol.Client;
 using Xunit;
 

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/CompositeDiscoveryStrategyTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/CompositeDiscoveryStrategyTests.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using AzureMcp.Areas.Server.Commands.Discovery;
 using NSubstitute;
 using Xunit;

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/CompositeDiscoveryStrategyTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/CompositeDiscoveryStrategyTests.cs
@@ -29,6 +29,12 @@ public class CompositeDiscoveryStrategyTests
         return provider;
     }
 
+    private static CompositeDiscoveryStrategy CreateCompositeStrategy(IEnumerable<IMcpDiscoveryStrategy> strategies)
+    {
+        var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<CompositeDiscoveryStrategy>>();
+        return new CompositeDiscoveryStrategy(strategies, logger);
+    }
+
     [Fact]
     public void Constructor_WithValidStrategies_InitializesCorrectly()
     {
@@ -37,7 +43,7 @@ public class CompositeDiscoveryStrategyTests
         var strategy2 = Substitute.For<IMcpDiscoveryStrategy>();
 
         // Act
-        var composite = new CompositeDiscoveryStrategy(new[] { strategy1, strategy2 });
+        var composite = CreateCompositeStrategy(new[] { strategy1, strategy2 });
 
         // Assert
         Assert.NotNull(composite);
@@ -49,8 +55,9 @@ public class CompositeDiscoveryStrategyTests
     public void Constructor_WithNullStrategies_ThrowsArgumentNullException()
     {
         // Act & Assert
+        var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<CompositeDiscoveryStrategy>>();
         var exception = Assert.Throws<ArgumentNullException>(() =>
-            new CompositeDiscoveryStrategy(null!));
+            new CompositeDiscoveryStrategy(null!, logger));
         Assert.Equal("strategies", exception.ParamName);
     }
 
@@ -58,8 +65,9 @@ public class CompositeDiscoveryStrategyTests
     public void Constructor_WithEmptyStrategies_ThrowsArgumentException()
     {
         // Act & Assert
+        var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<CompositeDiscoveryStrategy>>();
         var exception = Assert.Throws<ArgumentException>(() =>
-            new CompositeDiscoveryStrategy(Array.Empty<IMcpDiscoveryStrategy>()));
+            new CompositeDiscoveryStrategy(Array.Empty<IMcpDiscoveryStrategy>(), logger));
         Assert.Equal("strategies", exception.ParamName);
         Assert.Contains("At least one discovery strategy must be provided", exception.Message);
     }
@@ -68,8 +76,9 @@ public class CompositeDiscoveryStrategyTests
     public void DiscoverServersAsync_WithEmptyStrategies_ThrowsArgumentException()
     {
         // Act & Assert
+        var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<CompositeDiscoveryStrategy>>();
         var exception = Assert.Throws<ArgumentException>(() =>
-            new CompositeDiscoveryStrategy(Array.Empty<IMcpDiscoveryStrategy>()));
+            new CompositeDiscoveryStrategy(Array.Empty<IMcpDiscoveryStrategy>(), logger));
         Assert.Equal("strategies", exception.ParamName);
         Assert.Contains("At least one discovery strategy must be provided", exception.Message);
     }
@@ -81,7 +90,7 @@ public class CompositeDiscoveryStrategyTests
         var provider1 = CreateMockProvider("test1");
         var provider2 = CreateMockProvider("test2");
         var strategy = CreateMockStrategy(provider1, provider2);
-        var composite = new CompositeDiscoveryStrategy(new[] { strategy });
+        var composite = CreateCompositeStrategy(new[] { strategy });
 
         // Act
         var result = (await composite.DiscoverServersAsync()).ToList();
@@ -103,7 +112,7 @@ public class CompositeDiscoveryStrategyTests
 
         var strategy1 = CreateMockStrategy(provider1, provider2);
         var strategy2 = CreateMockStrategy(provider3, provider4);
-        var composite = new CompositeDiscoveryStrategy(new[] { strategy1, strategy2 });
+        var composite = CreateCompositeStrategy(new[] { strategy1, strategy2 });
 
         // Act
         var result = (await composite.DiscoverServersAsync()).ToList();
@@ -125,7 +134,7 @@ public class CompositeDiscoveryStrategyTests
         var emptyStrategy1 = CreateMockStrategy(); // No providers
         var emptyStrategy2 = CreateMockStrategy(); // No providers
 
-        var composite = new CompositeDiscoveryStrategy(new[] { activeStrategy, emptyStrategy1, emptyStrategy2 });
+        var composite = CreateCompositeStrategy(new[] { activeStrategy, emptyStrategy1, emptyStrategy2 });
 
         // Act
         var result = (await composite.DiscoverServersAsync()).ToList();
@@ -141,7 +150,7 @@ public class CompositeDiscoveryStrategyTests
         // Arrange
         var emptyStrategy1 = CreateMockStrategy();
         var emptyStrategy2 = CreateMockStrategy();
-        var composite = new CompositeDiscoveryStrategy(new[] { emptyStrategy1, emptyStrategy2 });
+        var composite = CreateCompositeStrategy(new[] { emptyStrategy1, emptyStrategy2 });
 
         // Act
         var result = await composite.DiscoverServersAsync();
@@ -163,7 +172,7 @@ public class CompositeDiscoveryStrategyTests
         var strategy2 = CreateMockStrategy(provider2);
         var strategy3 = CreateMockStrategy(provider3);
 
-        var composite = new CompositeDiscoveryStrategy(new[] { strategy1, strategy2, strategy3 });
+        var composite = CreateCompositeStrategy(new[] { strategy1, strategy2, strategy3 });
 
         // Act
         var result = (await composite.DiscoverServersAsync()).ToList();
@@ -192,7 +201,7 @@ public class CompositeDiscoveryStrategyTests
         var strategy1 = CreateMockStrategy(provider1, provider2);
         var strategy2 = CreateMockStrategy(provider3, provider4);
 
-        var composite = new CompositeDiscoveryStrategy(new[] { strategy1, strategy2 });
+        var composite = CreateCompositeStrategy(new[] { strategy1, strategy2 });
 
         // Act
         var result = (await composite.DiscoverServersAsync()).ToList();
@@ -213,7 +222,7 @@ public class CompositeDiscoveryStrategyTests
         var provider1 = CreateMockProvider("provider1");
         var provider2 = CreateMockProvider("provider2");
         var strategy = CreateMockStrategy(provider1, provider2);
-        var composite = new CompositeDiscoveryStrategy(new[] { strategy });
+        var composite = CreateCompositeStrategy(new[] { strategy });
 
         // Act
         var result1 = (await composite.DiscoverServersAsync()).ToList();
@@ -238,7 +247,7 @@ public class CompositeDiscoveryStrategyTests
         var strategy1 = CreateMockStrategy(provider1);
         var strategy2 = CreateMockStrategy(provider2);
 
-        var composite = new CompositeDiscoveryStrategy(new[] { strategy1, strategy2 });
+        var composite = CreateCompositeStrategy(new[] { strategy1, strategy2 });
 
         // Act
         var result = (await composite.DiscoverServersAsync()).ToList();
@@ -255,7 +264,7 @@ public class CompositeDiscoveryStrategyTests
     {
         // Arrange
         var strategy = CreateMockStrategy();
-        var composite = new CompositeDiscoveryStrategy(new[] { strategy });
+        var composite = CreateCompositeStrategy(new[] { strategy });
 
         // Act & Assert
         Assert.IsAssignableFrom<BaseDiscoveryStrategy>(composite);
@@ -275,7 +284,7 @@ public class CompositeDiscoveryStrategyTests
         var provider2 = Substitute.For<IMcpServerProvider>();
         mockStrategy1.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider1 }));
         mockStrategy2.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider2 }));
-        var composite = new CompositeDiscoveryStrategy(new[] { mockStrategy1, mockStrategy2 });
+        var composite = CreateCompositeStrategy(new[] { mockStrategy1, mockStrategy2 });
         var result = await composite.DiscoverServersAsync();
         Assert.Contains(provider1, result);
         Assert.Contains(provider2, result);
@@ -292,7 +301,7 @@ public class CompositeDiscoveryStrategyTests
         provider2.CreateMetadata().Returns(new McpServerMetadata { Id = "two", Name = "two", Description = "desc2" });
         mockStrategy1.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider1 }));
         mockStrategy2.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(new[] { provider2 }));
-        var composite = new CompositeDiscoveryStrategy(new[] { mockStrategy1, mockStrategy2 });
+        var composite = CreateCompositeStrategy(new[] { mockStrategy1, mockStrategy2 });
         var result = (await composite.DiscoverServersAsync()).ToList();
         Assert.Equal(2, result.Count);
         Assert.Contains(result, p => p.CreateMetadata().Id == "one");
@@ -304,7 +313,7 @@ public class CompositeDiscoveryStrategyTests
     {
         // Arrange
         var emptyStrategy = CreateMockStrategy(); // No providers
-        var composite = new CompositeDiscoveryStrategy(new[] { emptyStrategy });
+        var composite = CreateCompositeStrategy(new[] { emptyStrategy });
 
         // Act
         var result = await composite.DiscoverServersAsync();

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryDiscoveryStrategyTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryDiscoveryStrategyTests.cs
@@ -1,12 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using AzureMcp.Areas.Server.Commands.Discovery;
 using AzureMcp.Areas.Server.Options;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace AzureMcp.Tests.Areas.Server.UnitTests.Commands.Discovery;

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryDiscoveryStrategyTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryDiscoveryStrategyTests.cs
@@ -3,6 +3,7 @@
 
 using AzureMcp.Areas.Server.Commands.Discovery;
 using AzureMcp.Areas.Server.Options;
+using NSubstitute;
 using Xunit;
 
 namespace AzureMcp.Tests.Areas.Server.UnitTests.Commands.Discovery;
@@ -13,7 +14,8 @@ public class RegistryDiscoveryStrategyTests
     private static RegistryDiscoveryStrategy CreateStrategy(ServiceStartOptions? options = null)
     {
         var serviceOptions = Microsoft.Extensions.Options.Options.Create(options ?? new ServiceStartOptions());
-        return new RegistryDiscoveryStrategy(serviceOptions);
+        var logger = NSubstitute.Substitute.For<Microsoft.Extensions.Logging.ILogger<RegistryDiscoveryStrategy>>();
+        return new RegistryDiscoveryStrategy(serviceOptions, logger);
     }
 
     [Fact]

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryServerProviderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryServerProviderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -79,7 +80,7 @@ public class RegistryServerProviderTests
     }
 
     [Fact]
-    public async Task CreateClientAsync_WithUrl_ThrowsInvalidOperationException()
+    public async Task CreateClientAsync_WithUrlReturning404_ThrowsHttpRequestException()
     {
         // Arrange
         string testId = "sseProvider";
@@ -92,11 +93,10 @@ public class RegistryServerProviderTests
         var provider = new RegistryServerProvider(testId, serverInfo);
 
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
             () => provider.CreateClientAsync(new McpClientOptions()));
 
-        Assert.Contains($"Registry server '{testId}' does not have a valid transport type. Only 'stdio' is supported.",
-            exception.Message);
+        Assert.Contains("404", exception.Message);
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class RegistryServerProviderTests
     }
 
     [Fact]
-    public async Task CreateClientAsync_NoValidTransport_ThrowsInvalidOperationException()
+    public async Task CreateClientAsync_NoUrlOrType_ThrowsInvalidOperationException()
     {
         // Arrange
         string testId = "invalidProvider";
@@ -167,7 +167,7 @@ public class RegistryServerProviderTests
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
             () => provider.CreateClientAsync(new McpClientOptions()));
 
-        Assert.Contains($"Registry server '{testId}' does not have a valid transport type. Only 'stdio' is supported.",
+        Assert.Contains($"Registry server '{testId}' does not have a valid url or type for transport.",
             exception.Message);
     }
 

--- a/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryServerProviderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/Discovery/RegistryServerProviderTests.cs
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 using AzureMcp.Areas.Server.Commands.Discovery;
 using AzureMcp.Areas.Server.Models;
 using ModelContextProtocol.Client;

--- a/tests/Areas/Server/UnitTests/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
 using System.Text.Json;
 using AzureMcp.Areas.Server.Commands.ToolLoading;
 using AzureMcp.Areas.Server.Options;
 using AzureMcp.Commands;
-using AzureMcp.Services.Telemetry;
-using AzureMcp.Tests.Areas.Server;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
@@ -307,13 +304,6 @@ public class CommandFactoryToolLoaderTests
 
         // Find the subscription list command
         var subscriptionListCommand = availableCommands.FirstOrDefault(cmd => cmd.Key.Contains("subscription") && cmd.Key.Contains("list"));
-
-        // Use the subscription list command - skip test if not available
-        if (subscriptionListCommand.Key == null)
-        {
-            // Skip this test if subscription list command is not available
-            return;
-        }
 
         var targetCommand = subscriptionListCommand;
 

--- a/tests/Areas/Server/UnitTests/Commands/ToolLoading/CompositeToolLoaderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/ToolLoading/CompositeToolLoaderTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using System.Threading.Tasks;
 using AzureMcp.Areas.Server.Commands.ToolLoading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/tests/Areas/Server/UnitTests/Commands/ToolLoading/RegistryToolLoaderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/ToolLoading/RegistryToolLoaderTests.cs
@@ -5,12 +5,12 @@ using System.Text.Json;
 using AzureMcp.Areas.Server.Commands.Discovery;
 using AzureMcp.Areas.Server.Commands.ToolLoading;
 using AzureMcp.Areas.Server.Options;
+using AzureMcp.Tests.Areas.Server.UnitTests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using NSubstitute;
 using Xunit;
-using AzureMcp.Tests.Areas.Server.UnitTests.Helpers;
 
 namespace AzureMcp.Tests.Areas.Server.UnitTests.Commands.ToolLoading;
 

--- a/tests/Areas/Server/UnitTests/Commands/ToolLoading/RegistryToolLoaderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/ToolLoading/RegistryToolLoaderTests.cs
@@ -7,10 +7,10 @@ using AzureMcp.Areas.Server.Commands.ToolLoading;
 using AzureMcp.Areas.Server.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using NSubstitute;
 using Xunit;
+using AzureMcp.Tests.Areas.Server.UnitTests.Helpers;
 
 namespace AzureMcp.Tests.Areas.Server.UnitTests.Commands.ToolLoading;
 
@@ -21,7 +21,7 @@ public class RegistryToolLoaderTests
     {
         var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-        var mockDiscoveryStrategy = Substitute.For<IMcpDiscoveryStrategy>();
+        var mockDiscoveryStrategy = new MockMcpDiscoveryStrategyBuilder().Build();
         var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
         var serviceOptions = Microsoft.Extensions.Options.Options.Create(options ?? new ServiceStartOptions());
 
@@ -29,7 +29,7 @@ public class RegistryToolLoaderTests
         return (toolLoader, mockDiscoveryStrategy);
     }
 
-    private static ModelContextProtocol.Server.RequestContext<ListToolsRequestParams> CreateRequest()
+    private static ModelContextProtocol.Server.RequestContext<ListToolsRequestParams> CreateListToolsRequest()
     {
         var mockServer = Substitute.For<ModelContextProtocol.Server.IMcpServer>();
         return new ModelContextProtocol.Server.RequestContext<ListToolsRequestParams>(mockServer)
@@ -56,7 +56,7 @@ public class RegistryToolLoaderTests
     {
         // Arrange
         var (toolLoader, mockDiscoveryStrategy) = CreateToolLoader();
-        var request = CreateRequest();
+        var request = CreateListToolsRequest();
 
         mockDiscoveryStrategy.DiscoverServersAsync()
             .Returns(Task.FromResult(Enumerable.Empty<IMcpServerProvider>()));
@@ -71,17 +71,24 @@ public class RegistryToolLoaderTests
     }
 
     [Fact]
-    public async Task ListToolsHandler_WithRealRegistryDiscovery_ReturnsExpectedStructure()
+    public async Task ListToolsHandler_WithMockServerProvider_ReturnsExpectedStructure()
     {
-        // Arrange - use real RegistryDiscoveryStrategy
+        // Arrange
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool("test-tool-1", "Test Tool 1 Description", "Test response 1")
+            .AddTool("test-tool-2", "Test Tool 2 Description", "Test response 2");
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
         var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
-        var discoveryStrategy = new RegistryDiscoveryStrategy(options);
         var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
 
-        var toolLoader = new RegistryToolLoader(discoveryStrategy, options, logger);
-        var request = CreateRequest();
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
+        var request = CreateListToolsRequest();
 
         // Act
         var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
@@ -89,32 +96,47 @@ public class RegistryToolLoaderTests
         // Assert
         Assert.NotNull(result);
         Assert.NotNull(result.Tools);
-        Assert.True(result.Tools.Count >= 0); // Should return at least an empty list
-
-        // The result should be consistent (either empty if no registry, or have tools)
-        // Each tool should have proper structure if any exist
-        foreach (var tool in result.Tools)
-        {
-            Assert.NotNull(tool.Name);
-            Assert.NotEmpty(tool.Name);
-            Assert.NotNull(tool.Description);
-            Assert.True(tool.InputSchema.ValueKind != JsonValueKind.Undefined, "InputSchema should be defined");
-        }
+        Assert.Equal(2, result.Tools.Count);
+        Assert.Contains(result.Tools, t => t.Name == "test-tool-1");
+        Assert.Contains(result.Tools, t => t.Name == "test-tool-2");
     }
 
     [Fact]
     public async Task ListToolsHandler_WithReadOnlyOption_FiltersProperly()
     {
         // Arrange
+        var readOnlyTool = new Tool
+        {
+            Name = "readonly-tool",
+            Description = "Read-only tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var writeTool = new Tool
+        {
+            Name = "write-tool",
+            Description = "Write tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Read-only result" }], IsError = false })
+            .AddTool(writeTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Write result" }], IsError = false });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
         var readOnlyOptions = new ServiceStartOptions { ReadOnly = true };
         var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-        var serviceOptions = Microsoft.Extensions.Options.Options.Create(readOnlyOptions);
-        var discoveryStrategy = new RegistryDiscoveryStrategy(serviceOptions);
         var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(readOnlyOptions);
 
         var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
-        var request = CreateRequest();
+        var request = CreateListToolsRequest();
 
         // Act
         var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
@@ -124,11 +146,69 @@ public class RegistryToolLoaderTests
         Assert.NotNull(result.Tools);
 
         // When ReadOnly is enabled, only tools with ReadOnlyHint = true should be returned
-        foreach (var tool in result.Tools)
+        Assert.Single(result.Tools);
+        var returnedTool = result.Tools.First();
+        Assert.Equal("readonly-tool", returnedTool.Name);
+        Assert.True(returnedTool.Annotations?.ReadOnlyHint == true, "Returned tool should have ReadOnlyHint = true");
+
+        // Verify that the write tool was filtered out
+        Assert.DoesNotContain(result.Tools, t => t.Name == "write-tool");
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_WithReadOnlyDisabled_ReturnsAllTools()
+    {
+        // Arrange
+        var readOnlyTool = new Tool
         {
-            Assert.True(tool.Annotations?.ReadOnlyHint == true,
-                $"Tool '{tool.Name}' should have ReadOnlyHint = true when ReadOnly mode is enabled");
-        }
+            Name = "readonly-tool",
+            Description = "Read-only tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var writeTool = new Tool
+        {
+            Name = "write-tool",
+            Description = "Write tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = false }
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Read-only result" }], IsError = false })
+            .AddTool(writeTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Write result" }], IsError = false });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
+        var defaultOptions = new ServiceStartOptions { ReadOnly = false };
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(defaultOptions);
+
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
+        var request = CreateListToolsRequest();
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+
+        // When ReadOnly is disabled, all tools should be returned regardless of ReadOnlyHint
+        Assert.Equal(2, result.Tools.Count);
+        Assert.Contains(result.Tools, t => t.Name == "readonly-tool");
+        Assert.Contains(result.Tools, t => t.Name == "write-tool");
+
+        // Verify annotations are preserved
+        var readOnlyToolResult = result.Tools.First(t => t.Name == "readonly-tool");
+        var writeToolResult = result.Tools.First(t => t.Name == "write-tool");
+        Assert.True(readOnlyToolResult.Annotations?.ReadOnlyHint == true);
+        Assert.True(writeToolResult.Annotations?.ReadOnlyHint == false);
     }
 
     [Fact]
@@ -161,16 +241,22 @@ public class RegistryToolLoaderTests
         var defaultOptions = new ServiceStartOptions();
         var readOnlyOptions = new ServiceStartOptions { ReadOnly = true };
 
-        var (defaultToolLoader, mockDiscoveryStrategy1) = CreateToolLoader(defaultOptions);
-        var (readOnlyToolLoader, mockDiscoveryStrategy2) = CreateToolLoader(readOnlyOptions);
+        // Create empty discovery strategies for both tests
+        var defaultDiscoveryStrategy = new MockMcpDiscoveryStrategyBuilder().Build();
+        var readOnlyDiscoveryStrategy = new MockMcpDiscoveryStrategyBuilder().Build();
 
-        // Setup both discovery strategies to return empty
-        mockDiscoveryStrategy1.DiscoverServersAsync()
-            .Returns(Task.FromResult(Enumerable.Empty<IMcpServerProvider>()));
-        mockDiscoveryStrategy2.DiscoverServersAsync()
-            .Returns(Task.FromResult(Enumerable.Empty<IMcpServerProvider>()));
+        // Create tool loaders with different options
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger1 = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var logger2 = loggerFactory.CreateLogger<RegistryToolLoader>();
 
-        var request = CreateRequest();
+        var defaultToolLoader = new RegistryToolLoader(defaultDiscoveryStrategy,
+            Microsoft.Extensions.Options.Options.Create(defaultOptions), logger1);
+        var readOnlyToolLoader = new RegistryToolLoader(readOnlyDiscoveryStrategy,
+            Microsoft.Extensions.Options.Options.Create(readOnlyOptions), logger2);
+
+        var request = CreateListToolsRequest();
 
         // Act
         var defaultResult = await defaultToolLoader.ListToolsHandler(request, CancellationToken.None);
@@ -189,22 +275,35 @@ public class RegistryToolLoaderTests
     [Fact]
     public async Task CallToolHandler_WithoutListToolsFirst_ShouldSucceed()
     {
-        // Arrange - use real RegistryDiscoveryStrategy
+        // Arrange
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool("microsoft_docs_search", "Search Microsoft documentation", args =>
+            {
+                var question = args?.GetValueOrDefault("question")?.ToString() ?? "";
+                return new CallToolResult
+                {
+                    Content = new List<ContentBlock> { new TextContentBlock { Text = "Tool executed successfully" } },
+                    IsError = false
+                };
+            });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
         var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
-        var discoveryStrategy = new RegistryDiscoveryStrategy(options);
         var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
 
-        var toolLoader = new RegistryToolLoader(discoveryStrategy, options, logger);
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
         var request = CreateCallToolRequest("microsoft_docs_search",
             new Dictionary<string, JsonElement>
             {
                 { "question", JsonDocument.Parse("\"how to implement mcp server in azure\"").RootElement }
             });
 
-        // Act - Call CallToolHandler WITHOUT calling ListToolsHandler first
-        // This should work but currently fails due to the bug
+        // Act - Call CallToolHandler, which should initialize tools first
         var result = await toolLoader.CallToolHandler(request, CancellationToken.None);
 
         // Assert - The tool call should succeed
@@ -212,5 +311,136 @@ public class RegistryToolLoaderTests
         Assert.False(result.IsError);
         Assert.NotNull(result.Content);
         Assert.NotEmpty(result.Content);
+
+        // Verify the content
+        var textContent = result.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(textContent);
+        Assert.Equal("Tool executed successfully", textContent.Text);
+    }
+
+    [Fact]
+    public async Task MockMcpClient_WithExtensionMethods_WorksCorrectly()
+    {
+        // Arrange
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool("docs-search", "Azure documentation", args =>
+            {
+                var query = args?.GetValueOrDefault("query")?.ToString() ?? "";
+                return new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = $"Azure documentation: here is some content about {query}" }],
+                    IsError = false
+                };
+            })
+            .AddTool("echo", "Echo tool", args =>
+            {
+                var message = args?.GetValueOrDefault("message")?.ToString() ?? "No message";
+                return new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = $"Echo: {message}" }],
+                    IsError = false
+                };
+            });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
+
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
+
+        // Act & Assert - List tools
+        var listRequest = CreateListToolsRequest();
+        var listResult = await toolLoader.ListToolsHandler(listRequest, CancellationToken.None);
+        Assert.NotNull(listResult);
+        Assert.Equal(2, listResult.Tools.Count);
+        Assert.Contains(listResult.Tools, t => t.Name == "docs-search");
+        Assert.Contains(listResult.Tools, t => t.Name == "echo");
+
+        // Act & Assert - Call search tool
+        var searchRequest = CreateCallToolRequest("docs-search", new Dictionary<string, JsonElement>
+        {
+            { "query", JsonDocument.Parse("\"MCP implementation\"").RootElement }
+        });
+
+        var searchResult = await toolLoader.CallToolHandler(searchRequest, CancellationToken.None);
+        Assert.NotNull(searchResult);
+        Assert.False(searchResult.IsError);
+
+        var searchContent = searchResult.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(searchContent);
+        Assert.Contains("MCP implementation", searchContent.Text);
+        Assert.Contains("Azure documentation", searchContent.Text);
+
+        // Act & Assert - Call echo tool
+        var echoRequest = CreateCallToolRequest("echo", new Dictionary<string, JsonElement>
+        {
+            { "message", JsonDocument.Parse("\"Hello MCP!\"").RootElement }
+        });
+        var echoResult = await toolLoader.CallToolHandler(echoRequest, CancellationToken.None);
+        Assert.NotNull(echoResult);
+        Assert.False(echoResult.IsError);
+        var echoContent = echoResult.Content.OfType<TextContentBlock>().FirstOrDefault();
+        Assert.NotNull(echoContent);
+        Assert.Equal("Echo: Hello MCP!", echoContent.Text);
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_WithReadOnlyOption_FilterToolsWithNullAnnotations()
+    {
+        // Arrange
+        var readOnlyTool = new Tool
+        {
+            Name = "readonly-tool",
+            Description = "Read-only tool",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = new ToolAnnotations { ReadOnlyHint = true }
+        };
+
+        var toolWithoutAnnotations = new Tool
+        {
+            Name = "tool-no-annotations",
+            Description = "Tool without annotations",
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement,
+            Annotations = null  // No annotations
+        };
+
+        var clientBuilder = new MockMcpClientBuilder()
+            .AddTool(readOnlyTool, _ => new CallToolResult { Content = [new TextContentBlock { Text = "Read-only result" }], IsError = false })
+            .AddTool(toolWithoutAnnotations, _ => new CallToolResult { Content = [new TextContentBlock { Text = "No annotations result" }], IsError = false });
+
+        var discoveryStrategy = new MockMcpDiscoveryStrategyBuilder()
+            .AddServer("test-server", "test-server", "Test Server Description", clientBuilder)
+            .Build();
+
+        var readOnlyOptions = new ServiceStartOptions { ReadOnly = true };
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<RegistryToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(readOnlyOptions);
+
+        var toolLoader = new RegistryToolLoader(discoveryStrategy, serviceOptions, logger);
+        var request = CreateListToolsRequest();
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+
+        // When ReadOnly is enabled, only tools with ReadOnlyHint = true should be returned
+        // Tools with null annotations should be filtered out
+        Assert.Single(result.Tools);
+        var returnedTool = result.Tools.First();
+        Assert.Equal("readonly-tool", returnedTool.Name);
+        Assert.True(returnedTool.Annotations?.ReadOnlyHint == true);
+
+        // Verify that the tool without annotations was filtered out
+        Assert.DoesNotContain(result.Tools, t => t.Name == "tool-no-annotations");
     }
 }

--- a/tests/Areas/Server/UnitTests/Commands/ToolLoading/ServerToolLoaderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/ToolLoading/ServerToolLoaderTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using AzureMcp.Areas.Server.Commands.Discovery;
+using AzureMcp.Areas.Server.Commands.ToolLoading;
+using AzureMcp.Areas.Server.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Tests.Areas.Server.UnitTests.Commands.ToolLoading;
+
+[Trait("Area", "Server")]
+public class ServerToolLoaderTests
+{
+    private static (ServerToolLoader toolLoader, IMcpDiscoveryStrategy mockDiscoveryStrategy) CreateToolLoader(ServiceStartOptions? options = null)
+    {
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var mockDiscoveryStrategy = Substitute.For<IMcpDiscoveryStrategy>();
+        var logger = loggerFactory.CreateLogger<ServerToolLoader>();
+        var serviceOptions = Microsoft.Extensions.Options.Options.Create(options ?? new ServiceStartOptions());
+
+        var toolLoader = new ServerToolLoader(mockDiscoveryStrategy, serviceOptions, logger);
+        return (toolLoader, mockDiscoveryStrategy);
+    }
+
+    private static ModelContextProtocol.Server.RequestContext<ListToolsRequestParams> CreateRequest()
+    {
+        var mockServer = Substitute.For<ModelContextProtocol.Server.IMcpServer>();
+        return new ModelContextProtocol.Server.RequestContext<ListToolsRequestParams>(mockServer)
+        {
+            Params = new ListToolsRequestParams()
+        };
+    }
+
+    private static ModelContextProtocol.Server.RequestContext<CallToolRequestParams> CreateCallToolRequest(string toolName, IReadOnlyDictionary<string, JsonElement>? arguments = null)
+    {
+        var mockServer = Substitute.For<ModelContextProtocol.Server.IMcpServer>();
+        return new ModelContextProtocol.Server.RequestContext<CallToolRequestParams>(mockServer)
+        {
+            Params = new CallToolRequestParams
+            {
+                Name = toolName,
+                Arguments = arguments ?? new Dictionary<string, JsonElement>()
+            }
+        };
+    }
+
+    [Fact]
+    public async Task CallToolHandler_WithoutListToolsFirst_ShouldSucceed()
+    {
+        // Arrange - use real RegistryDiscoveryStrategy since ServerToolLoader depends on it
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
+        var discoveryStrategy = new RegistryDiscoveryStrategy(options);
+        var logger = loggerFactory.CreateLogger<ServerToolLoader>();
+
+        var toolLoader = new ServerToolLoader(discoveryStrategy, options, logger);
+        var request = CreateCallToolRequest("documentation",
+            new Dictionary<string, JsonElement>
+            {
+                { "intent", JsonDocument.Parse("\"search for information about implementing MCP servers\"").RootElement },
+                { "command", JsonDocument.Parse("\"microsoft_docs_search\"").RootElement },
+                { "parameters", JsonDocument.Parse("""
+                    {
+                        "question": "how to implement mcp server in azure"
+                    }
+                    """).RootElement }
+            });
+
+        // Act - Call CallToolHandler WITHOUT calling ListToolsHandler first
+        // This should work without requiring ListToolsHandler to be called first
+        var result = await toolLoader.CallToolHandler(request, CancellationToken.None);
+
+        // Assert - The tool call should succeed
+        Assert.NotNull(result);
+        Assert.NotNull(result.Content);
+        Assert.NotEmpty(result.Content);
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_WithNoServers_ReturnsEmptyToolList()
+    {
+        // Arrange
+        var (toolLoader, mockDiscoveryStrategy) = CreateToolLoader();
+        var request = CreateRequest();
+
+        mockDiscoveryStrategy.DiscoverServersAsync()
+            .Returns(Task.FromResult(Enumerable.Empty<IMcpServerProvider>()));
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+        Assert.Empty(result.Tools);
+    }
+
+    [Fact]
+    public async Task ListToolsHandler_WithRealRegistryDiscovery_ReturnsExpectedStructure()
+    {
+        // Arrange - use real RegistryDiscoveryStrategy
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
+        var discoveryStrategy = new RegistryDiscoveryStrategy(options);
+        var logger = loggerFactory.CreateLogger<ServerToolLoader>();
+
+        var toolLoader = new ServerToolLoader(discoveryStrategy, options, logger);
+        var request = CreateRequest();
+
+        // Act
+        var result = await toolLoader.ListToolsHandler(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tools);
+        Assert.True(result.Tools.Count >= 0); // Should return at least an empty list
+
+        // Each tool should have proper structure if any exist
+        foreach (var tool in result.Tools)
+        {
+            Assert.NotNull(tool.Name);
+            Assert.NotEmpty(tool.Name);
+            Assert.NotNull(tool.Description);
+            Assert.True(tool.InputSchema.ValueKind != JsonValueKind.Undefined, "InputSchema should be defined");
+        }
+    }
+}

--- a/tests/Areas/Server/UnitTests/Commands/ToolLoading/ServerToolLoaderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/ToolLoading/ServerToolLoaderTests.cs
@@ -57,7 +57,8 @@ public class ServerToolLoaderTests
         var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
         var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
-        var discoveryStrategy = new RegistryDiscoveryStrategy(options);
+        var discoveryLogger = loggerFactory.CreateLogger<RegistryDiscoveryStrategy>();
+        var discoveryStrategy = new RegistryDiscoveryStrategy(options, discoveryLogger);
         var logger = loggerFactory.CreateLogger<ServerToolLoader>();
 
         var toolLoader = new ServerToolLoader(discoveryStrategy, options, logger);
@@ -109,7 +110,8 @@ public class ServerToolLoaderTests
         var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
         var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
-        var discoveryStrategy = new RegistryDiscoveryStrategy(options);
+        var discoveryLogger = loggerFactory.CreateLogger<RegistryDiscoveryStrategy>();
+        var discoveryStrategy = new RegistryDiscoveryStrategy(options, discoveryLogger);
         var logger = loggerFactory.CreateLogger<ServerToolLoader>();
 
         var toolLoader = new ServerToolLoader(discoveryStrategy, options, logger);

--- a/tests/Areas/Server/UnitTests/Commands/ToolLoading/SingleProxyToolLoaderTests.cs
+++ b/tests/Areas/Server/UnitTests/Commands/ToolLoading/SingleProxyToolLoaderTests.cs
@@ -25,15 +25,19 @@ public class SingleProxyToolLoaderTests
         if (useRealDiscovery)
         {
             var options = Microsoft.Extensions.Options.Options.Create(new ServiceStartOptions());
+            var commandGroupLogger = serviceProvider.GetRequiredService<ILogger<CommandGroupDiscoveryStrategy>>();
             var commandGroupDiscoveryStrategy = new CommandGroupDiscoveryStrategy(
                 CommandFactoryHelpers.CreateCommandFactory(serviceProvider),
-                options
+                options,
+                commandGroupLogger
             );
-            var registryDiscoveryStrategy = new RegistryDiscoveryStrategy(options);
+            var registryLogger = serviceProvider.GetRequiredService<ILogger<RegistryDiscoveryStrategy>>();
+            var registryDiscoveryStrategy = new RegistryDiscoveryStrategy(options, registryLogger);
+            var compositeLogger = serviceProvider.GetRequiredService<ILogger<CompositeDiscoveryStrategy>>();
             var compositeDiscoveryStrategy = new CompositeDiscoveryStrategy([
                 commandGroupDiscoveryStrategy,
                 registryDiscoveryStrategy
-            ]);
+            ], compositeLogger);
             var toolLoader = new SingleProxyToolLoader(compositeDiscoveryStrategy, logger);
             return (toolLoader, compositeDiscoveryStrategy);
         }

--- a/tests/Areas/Server/UnitTests/Helpers/MockMcpClientBuilder.cs
+++ b/tests/Areas/Server/UnitTests/Helpers/MockMcpClientBuilder.cs
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using AzureMcp.Areas.Server;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+
+namespace AzureMcp.Tests.Areas.Server.UnitTests.Helpers;
+
+/// <summary>
+/// A builder for creating mock <see cref="IMcpClient"/> instances for testing purposes.
+/// Provides a fluent API for registering mock tools with custom handlers.
+/// </summary>
+public sealed class MockMcpClientBuilder
+{
+    private readonly Dictionary<string, MockTool> _tools = new();
+
+    /// <summary>
+    /// Adds a mock tool with a custom Tool object and handler using fluent API.
+    /// </summary>
+    /// <param name="tool">The Tool object containing name, description, and schema.</param>
+    /// <param name="handler">The handler function to execute when the tool is called.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpClientBuilder AddTool(Tool tool, Func<IReadOnlyDictionary<string, object?>?, CallToolResult> handler)
+    {
+        var mockTool = new MockTool(tool, handler);
+        _tools[tool.Name] = mockTool;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a mock tool with a custom handler using fluent API.
+    /// </summary>
+    /// <param name="name">The name of the tool.</param>
+    /// <param name="description">The description of the tool.</param>
+    /// <param name="handler">The handler function to execute when the tool is called.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpClientBuilder AddTool(string name, string description, Func<IReadOnlyDictionary<string, object?>?, CallToolResult> handler)
+    {
+        var tool = new Tool
+        {
+            Name = name,
+            Description = description,
+            InputSchema = JsonDocument.Parse("""{"type": "object", "properties": {}}""").RootElement
+        };
+        return AddTool(tool, handler);
+    }
+
+    /// <summary>
+    /// Adds a mock tool with a custom handler using fluent API.
+    /// </summary>
+    /// <param name="name">The name of the tool.</param>
+    /// <param name="description">The description of the tool.</param>
+    /// <param name="handler">The handler function to execute when the tool is called.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpClientBuilder AddTool(string name, string description, Func<CallToolResult> handler)
+    {
+        return AddTool(name, description, _ => handler());
+    }
+
+    /// <summary>
+    /// Adds a mock tool with a simple text response.
+    /// </summary>
+    /// <param name="name">The name of the tool.</param>
+    /// <param name="description">The description of the tool.</param>
+    /// <param name="response">The text response to return.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpClientBuilder AddTool(string name, string description, string response)
+    {
+        return AddTool(name, description, () => new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = response }],
+            IsError = false
+        });
+    }
+
+    /// <summary>
+    /// Adds a mock tool that returns an error response.
+    /// </summary>
+    /// <param name="name">The name of the tool.</param>
+    /// <param name="description">The description of the tool.</param>
+    /// <param name="errorMessage">The error message to return.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpClientBuilder AddErrorTool(string name, string description, string errorMessage)
+    {
+        return AddTool(name, description, () => new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = errorMessage }],
+            IsError = true
+        });
+    }
+
+    /// <summary>
+    /// Removes a tool from the mock client.
+    /// </summary>
+    /// <param name="name">The name of the tool to remove.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpClientBuilder RemoveTool(string name)
+    {
+        _tools.Remove(name);
+        return this;
+    }
+
+    /// <summary>
+    /// Clears all registered tools.
+    /// </summary>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpClientBuilder ClearTools()
+    {
+        _tools.Clear();
+        return this;
+    }
+
+    /// <summary>
+    /// Builds and returns a mock <see cref="IMcpClient"/> instance configured with the registered tools.
+    /// </summary>
+    /// <returns>A mock <see cref="IMcpClient"/> instance.</returns>
+    public IMcpClient Build()
+    {
+        var mockClient = Substitute.For<IMcpClient>();
+
+        // Setup tools/list response
+        mockClient.SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(req => req.Method == "tools/list"),
+            Arg.Any<CancellationToken>())
+            .Returns(callInfo => HandleListToolsRequest(callInfo.Arg<JsonRpcRequest>()));
+
+        // Setup tools/call response
+        mockClient.SendRequestAsync(
+            Arg.Is<JsonRpcRequest>(req => req.Method == "tools/call"),
+            Arg.Any<CancellationToken>())
+            .Returns(callInfo => HandleCallToolRequest(callInfo.Arg<JsonRpcRequest>()));
+
+        return mockClient;
+    }
+
+    /// <summary>
+    /// Handles the tools/list request and returns registered tools.
+    /// </summary>
+    private Task<JsonRpcResponse> HandleListToolsRequest(JsonRpcRequest request)
+    {
+        var tools = _tools.Values.Select(mockTool => mockTool.Tool).ToList();
+
+        var result = new ListToolsResult { Tools = tools };
+        var json = JsonSerializer.SerializeToNode(result, ServerJsonContext.Default.ListToolsResult);
+
+        return Task.FromResult(new JsonRpcResponse
+        {
+            Id = request.Id,
+            Result = json
+        });
+    }
+
+    /// <summary>
+    /// Handles the tools/call request and executes the registered tool.
+    /// </summary>
+    private Task<JsonRpcResponse> HandleCallToolRequest(JsonRpcRequest request)
+    {
+        try
+        {
+            var callParams = JsonSerializer.Deserialize<CallToolRequestParams>(request.Params!);
+
+            if (callParams?.Name == null || !_tools.TryGetValue(callParams.Name, out var mockTool))
+            {
+                var errorResult = new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = $"Tool '{callParams?.Name ?? "null"}' not found" }],
+                    IsError = true
+                };
+
+                var errorJson = JsonSerializer.SerializeToNode(errorResult);
+                return Task.FromResult(new JsonRpcResponse
+                {
+                    Id = request.Id,
+                    Result = errorJson
+                });
+            }
+
+            // Convert JsonElement arguments to dictionary
+            var arguments = callParams.Arguments?.ToDictionary(
+                kvp => kvp.Key,
+                kvp => ConvertJsonElementToObject(kvp.Value)
+            );
+
+            var result = mockTool.Handler(arguments);
+            var resultJson = JsonSerializer.SerializeToNode(result);
+
+            return Task.FromResult(new JsonRpcResponse
+            {
+                Id = request.Id,
+                Result = resultJson
+            });
+        }
+        catch (Exception ex)
+        {
+            var errorResult = new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = $"Error calling tool: {ex.Message}" }],
+                IsError = true
+            };
+
+            var errorJson = JsonSerializer.SerializeToNode(errorResult);
+            return Task.FromResult(new JsonRpcResponse
+            {
+                Id = request.Id,
+                Result = errorJson
+            });
+        }
+    }
+
+    /// <summary>
+    /// Converts a JsonElement to an appropriate object type.
+    /// </summary>
+    private static object? ConvertJsonElementToObject(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number when element.TryGetInt32(out var intValue) => intValue,
+            JsonValueKind.Number when element.TryGetInt64(out var longValue) => longValue,
+            JsonValueKind.Number when element.TryGetDouble(out var doubleValue) => doubleValue,
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            _ => element // Keep as JsonElement for complex types
+        };
+    }
+}
+
+/// <summary>
+/// Internal representation of a mock tool.
+/// </summary>
+internal sealed class MockTool(
+    Tool tool,
+    Func<IReadOnlyDictionary<string, object?>?, CallToolResult> handler)
+{
+    public Tool Tool { get; } = tool;
+    public Func<IReadOnlyDictionary<string, object?>?, CallToolResult> Handler { get; } = handler;
+}

--- a/tests/Areas/Server/UnitTests/Helpers/MockMcpDiscoveryStrategyBuilder.cs
+++ b/tests/Areas/Server/UnitTests/Helpers/MockMcpDiscoveryStrategyBuilder.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Areas.Server.Commands.Discovery;
+using ModelContextProtocol.Client;
+using NSubstitute;
+
+namespace AzureMcp.Tests.Areas.Server.UnitTests.Helpers;
+
+/// <summary>
+/// A builder for creating mock implementations of <see cref="IMcpDiscoveryStrategy"/> for testing purposes.
+/// Provides a fluent API for adding servers and configuring mock behavior.
+/// </summary>
+public sealed class MockMcpDiscoveryStrategyBuilder
+{
+    private readonly List<IMcpServerProvider> _providers = new();
+
+    /// <summary>
+    /// Initializes a new instance of the MockMcpDiscoveryStrategyBuilder.
+    /// </summary>
+    public MockMcpDiscoveryStrategyBuilder()
+    {
+    }
+
+    /// <summary>
+    /// Adds a new server with the specified client to the mock discovery strategy.
+    /// </summary>
+    /// <param name="serverId">The unique identifier for the server.</param>
+    /// <param name="serverName">The display name of the server. If null, uses the serverId.</param>
+    /// <param name="description">The description of the server. If null, uses a default description.</param>
+    /// <param name="client">The mock client to return for this server.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpDiscoveryStrategyBuilder AddServer(string serverId, string? serverName = null, string? description = null, IMcpClient? client = null)
+    {
+        var mockProvider = Substitute.For<IMcpServerProvider>();
+        var metadata = new McpServerMetadata
+        {
+            Id = serverId,
+            Name = serverName ?? serverId,
+            Description = description ?? $"Mock server for {serverId}"
+        };
+
+        mockProvider.CreateMetadata().Returns(metadata);
+
+        if (client != null)
+        {
+            mockProvider.CreateClientAsync(Arg.Any<McpClientOptions>()).Returns(Task.FromResult(client));
+        }
+        else
+        {
+            // If no client is provided, create a basic substitute
+            var defaultClient = Substitute.For<IMcpClient>();
+            mockProvider.CreateClientAsync(Arg.Any<McpClientOptions>()).Returns(Task.FromResult(defaultClient));
+        }
+
+        _providers.Add(mockProvider);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a new server using a MockMcpClientBuilder for the client.
+    /// </summary>
+    /// <param name="serverId">The unique identifier for the server.</param>
+    /// <param name="serverName">The display name of the server. If null, uses the serverId.</param>
+    /// <param name="description">The description of the server. If null, uses a default description.</param>
+    /// <param name="clientBuilder">The MockMcpClientBuilder to use for creating the client.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpDiscoveryStrategyBuilder AddServer(string serverId, string? serverName, string? description, MockMcpClientBuilder clientBuilder)
+    {
+        var client = clientBuilder.Build();
+        return AddServer(serverId, serverName, description, client);
+    }
+
+    /// <summary>
+    /// Adds a new server using a MockMcpClientBuilder for the client.
+    /// </summary>
+    /// <param name="serverId">The unique identifier for the server.</param>
+    /// <param name="clientBuilder">The MockMcpClientBuilder to use for creating the client.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpDiscoveryStrategyBuilder AddServer(string serverId, MockMcpClientBuilder clientBuilder)
+    {
+        return AddServer(serverId, null, null, clientBuilder);
+    }
+
+    /// <summary>
+    /// Removes a server from the mock discovery strategy.
+    /// </summary>
+    /// <param name="serverId">The unique identifier of the server to remove.</param>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpDiscoveryStrategyBuilder RemoveServer(string serverId)
+    {
+        var providerToRemove = _providers.FirstOrDefault(p =>
+            p.CreateMetadata().Id.Equals(serverId, StringComparison.OrdinalIgnoreCase));
+
+        if (providerToRemove != null)
+        {
+            _providers.Remove(providerToRemove);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Clears all servers from the mock discovery strategy.
+    /// </summary>
+    /// <returns>The current instance for method chaining.</returns>
+    public MockMcpDiscoveryStrategyBuilder ClearServers()
+    {
+        _providers.Clear();
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Builds and returns the configured mock discovery strategy.
+    /// </summary>
+    /// <returns>The configured mock discovery strategy.</returns>
+    public IMcpDiscoveryStrategy Build()
+    {
+        var mockStrategy = Substitute.For<IMcpDiscoveryStrategy>();
+
+        // Configure DiscoverServersAsync to return the current providers
+        mockStrategy.DiscoverServersAsync().Returns(Task.FromResult<IEnumerable<IMcpServerProvider>>(_providers));
+
+        // Configure FindServerProviderAsync to find providers by name (case-insensitive)
+        mockStrategy.FindServerProviderAsync(Arg.Any<string>()).Returns(callInfo =>
+        {
+            var serverName = callInfo.Arg<string>();
+            var provider = _providers.FirstOrDefault(p =>
+                p.CreateMetadata().Name.Equals(serverName, StringComparison.OrdinalIgnoreCase));
+
+            if (provider == null)
+            {
+                throw new KeyNotFoundException($"No MCP server found with the name '{serverName}'.");
+            }
+
+            return Task.FromResult(provider);
+        });
+
+        // Configure GetOrCreateClientAsync to return the appropriate client
+        mockStrategy.GetOrCreateClientAsync(Arg.Any<string>(), Arg.Any<McpClientOptions>()).Returns(callInfo =>
+        {
+            var serverName = callInfo.Arg<string>();
+            var clientOptions = callInfo.ArgAt<McpClientOptions>(1) ?? new McpClientOptions();
+
+            var provider = _providers.FirstOrDefault(p =>
+                p.CreateMetadata().Name.Equals(serverName, StringComparison.OrdinalIgnoreCase));
+
+            if (provider == null)
+            {
+                throw new KeyNotFoundException($"No MCP server found with the name '{serverName}'.");
+            }
+
+            // Return the client from the provider
+            return provider.CreateClientAsync(clientOptions);
+        });
+
+        return mockStrategy;
+    }
+}

--- a/tests/Client/Helpers/LiveTestFixture.cs
+++ b/tests/Client/Helpers/LiveTestFixture.cs
@@ -34,6 +34,5 @@ public class LiveTestFixture : LiveTestSettingsFixture
         var clientTransport = new StdioClientTransport(transportOptions);
 
         Client = await McpClientFactory.CreateAsync(clientTransport);
-        await Client.ListToolsAsync();
     }
 }


### PR DESCRIPTION
## What does this PR do?

- [x] Fixes the issue where a tool call can fail if called before tool list call was performed.
- [x] Implements `IAsyncDisposable` for tool loaders and discovery strategies.

## GitHub issue number?

Fixes #556 

## Pre-merge checklist
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) covering pull request process, code style, and testing**
- [x] PR title is clear and informative
- [x] Commit history is clean with informative messages (no previously merged commits appear in PR history). [See cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
- [x] Added comprehensive tests for core features
- [x] Added `CHANGELOG.md` entry for user-impacting changes (bug fixes, new features, UI/UX changes)
- [x] Spelling check passes with `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] **Team member live testing:**
  - [ ] **Security review:** Review PR for security vulnerabilities and malicious code before running tests (e.g., cryptocurrency mining, email spam, data exfiltration, or other harmful activities)
  - [x] **Test execution:** Add comment `/azp run azure - mcp` to trigger pipeline
