### PR TITLE
Foundry: Use a defined type for deployment result, correct command file namespace

### DIFF
--- a/infra/test-resources.bicep
+++ b/infra/test-resources.bicep
@@ -174,7 +174,7 @@ module storage 'services/storage.bicep' = if (empty(areas) || contains(areas, 'S
   }
 }
 
-module loadtesting 'services/loadtesting.bicep' = {
+module loadtesting 'services/loadtesting.bicep' = if (empty(areas) || contains(areas, 'Loadtesting')) {
   name: '${deploymentName}-loadtesting'
   params: {
     baseName: baseName

--- a/src/Areas/Foundry/Commands/DeploymentsListCommand.cs
+++ b/src/Areas/Foundry/Commands/DeploymentsListCommand.cs
@@ -7,7 +7,7 @@ using AzureMcp.Areas.Foundry.Options.Models;
 using AzureMcp.Areas.Foundry.Services;
 using AzureMcp.Commands;
 
-namespace AzureMcp.Areas.Foundry.Commands.Models;
+namespace AzureMcp.Areas.Foundry.Commands;
 
 public sealed class DeploymentsListCommand : GlobalCommand<DeploymentsListOptions>
 {

--- a/src/Areas/Foundry/Commands/FoundryJsonContext.cs
+++ b/src/Areas/Foundry/Commands/FoundryJsonContext.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json.Serialization;
 using Azure.ResourceManager.CognitiveServices.Models;
-using AzureMcp.Areas.Foundry.Commands.Models;
 using AzureMcp.Areas.Foundry.Models;
 
 namespace AzureMcp.Areas.Foundry.Commands;
@@ -17,6 +16,7 @@ namespace AzureMcp.Areas.Foundry.Commands;
 [JsonSerializable(typeof(ModelCatalogResponse))]
 [JsonSerializable(typeof(ModelDeploymentInformation))]
 [JsonSerializable(typeof(ModelInformation))]
+[JsonSerializable(typeof(ModelDeploymentResult))]
 [JsonSerializable(typeof(CognitiveServicesAccountSku))]
 [JsonSerializable(typeof(CognitiveServicesAccountDeploymentProperties))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/src/Areas/Foundry/Commands/ModelDeploymentCommand.cs
+++ b/src/Areas/Foundry/Commands/ModelDeploymentCommand.cs
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Areas.Foundry.Models;
 using AzureMcp.Areas.Foundry.Options;
 using AzureMcp.Areas.Foundry.Options.Models;
 using AzureMcp.Areas.Foundry.Services;
 using AzureMcp.Commands.Subscription;
 using AzureMcp.Services.Telemetry;
 
-namespace AzureMcp.Areas.Foundry.Commands.Models;
+namespace AzureMcp.Areas.Foundry.Commands;
 
 public sealed class ModelDeploymentCommand : SubscriptionCommand<ModelDeploymentOptions>
 {
@@ -111,5 +112,5 @@ public sealed class ModelDeploymentCommand : SubscriptionCommand<ModelDeployment
         return context.Response;
     }
 
-    internal record ModelDeploymentCommandResult(Dictionary<string, object> DeploymentData);
+    internal record ModelDeploymentCommandResult(ModelDeploymentResult DeploymentData);
 }

--- a/src/Areas/Foundry/Commands/ModelsListCommand.cs
+++ b/src/Areas/Foundry/Commands/ModelsListCommand.cs
@@ -7,7 +7,7 @@ using AzureMcp.Areas.Foundry.Options.Models;
 using AzureMcp.Areas.Foundry.Services;
 using AzureMcp.Commands;
 
-namespace AzureMcp.Areas.Foundry.Commands.Models;
+namespace AzureMcp.Areas.Foundry.Commands;
 
 public sealed class ModelsListCommand : GlobalCommand<ModelsListOptions>
 {

--- a/src/Areas/Foundry/FoundrySetup.cs
+++ b/src/Areas/Foundry/FoundrySetup.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using AzureMcp.Areas.Foundry.Commands.Models;
+using AzureMcp.Areas.Foundry.Commands;
 using AzureMcp.Areas.Foundry.Services;
 using AzureMcp.Commands;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Areas/Foundry/Models/ModelDeploymentResult.cs
+++ b/src/Areas/Foundry/Models/ModelDeploymentResult.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.ResourceManager.CognitiveServices.Models;
+
+namespace AzureMcp.Areas.Foundry.Models;
+
+public record ModelDeploymentResult
+{
+    [JsonPropertyName("hasData")]
+    public bool HasData { get; init; }
+
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("sku")]
+    public CognitiveServicesSku? Sku { get; init; }
+
+    [JsonPropertyName("tags")]
+    public IDictionary<string, string>? Tags { get; init; }
+
+    [JsonPropertyName("properties")]
+    public CognitiveServicesAccountDeploymentProperties? Properties { get; init; }
+}

--- a/src/Areas/Foundry/Services/FoundryService.cs
+++ b/src/Areas/Foundry/Services/FoundryService.cs
@@ -153,7 +153,7 @@ public class FoundryService : BaseAzureService, IFoundryService
         }
     }
 
-    public async Task<Dictionary<string, object>> DeployModel(string deploymentName, string modelName, string modelFormat,
+    public async Task<ModelDeploymentResult> DeployModel(string deploymentName, string modelName, string modelFormat,
         string azureAiServicesName, string resourceGroup, string subscriptionId, string? modelVersion = null, string? modelSource = null,
         string? skuName = null, int? skuCapacity = null, string? scaleType = null, int? scaleCapacity = null, RetryPolicyOptions? retryPolicy = null)
     {
@@ -213,22 +213,21 @@ public class FoundryService : BaseAzureService, IFoundryService
 
             if (!deployment.HasData)
             {
-                return new Dictionary<string, object>
+                return new ModelDeploymentResult
                 {
-                    { "has_data", false },
+                    HasData = false
                 };
             }
 
-            // Manually converting system data to a dictionary due to lack of available JsonSerializer support
-            return new Dictionary<string, object>
+            return new ModelDeploymentResult
             {
-                { "has_data", true },
-                { "id", deployment.Data.Id.ToString() },
-                { "name", deployment.Data.Name },
-                { "type", deployment.Data.ResourceType.ToString() },
-                { "sku", deployment.Data.Sku },
-                { "tags", deployment.Data.Tags },
-                { "properties", deployment.Data.Properties },
+                HasData = true,
+                Id = deployment.Data.Id.ToString(),
+                Name = deployment.Data.Name,
+                Type = deployment.Data.ResourceType.ToString(),
+                Sku = deployment.Data.Sku,
+                Tags = deployment.Data.Tags,
+                Properties = deployment.Data.Properties
             };
         }
         catch (Exception ex)

--- a/src/Areas/Foundry/Services/IFoundryService.cs
+++ b/src/Areas/Foundry/Services/IFoundryService.cs
@@ -24,7 +24,7 @@ public interface IFoundryService
         RetryPolicyOptions? retryPolicy = null
     );
 
-    Task<Dictionary<string, object>> DeployModel(string deploymentName,
+    Task<ModelDeploymentResult> DeployModel(string deploymentName,
         string modelName,
         string modelFormat,
         string azureAiServicesName,

--- a/tests/Areas/Foundry/UnitTests/DeploymentsListCommandTests.cs
+++ b/tests/Areas/Foundry/UnitTests/DeploymentsListCommandTests.cs
@@ -3,7 +3,7 @@
 
 using System.CommandLine;
 using Azure.AI.Projects;
-using AzureMcp.Areas.Foundry.Commands.Models;
+using AzureMcp.Areas.Foundry.Commands;
 using AzureMcp.Areas.Foundry.Services;
 using AzureMcp.Models.Command;
 using AzureMcp.Options;

--- a/tests/Areas/Foundry/UnitTests/ModelDeploymentCommandTests.cs
+++ b/tests/Areas/Foundry/UnitTests/ModelDeploymentCommandTests.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
-using AzureMcp.Areas.Foundry.Commands.Models;
+using AzureMcp.Areas.Foundry.Commands;
+using AzureMcp.Areas.Foundry.Models;
 using AzureMcp.Areas.Foundry.Services;
 using AzureMcp.Models.Command;
 using AzureMcp.Options;
@@ -39,9 +40,9 @@ public class ModelDeploymentCommandTests
         var resourceGroup = "test-resource-group";
         var subscriptionId = "test-subscription-id";
 
-        var expectedResponse = new Dictionary<string, object>
+        var expectedResponse = new ModelDeploymentResult
         {
-            { "has_data", true },
+            HasData = true
         };
 
         _foundryService.DeployModel(
@@ -85,9 +86,9 @@ public class ModelDeploymentCommandTests
         var scaleType = "Standard";
         var scaleCapacity = 2;
 
-        var expectedResponse = new Dictionary<string, object>
+        var expectedResponse = new ModelDeploymentResult
         {
-            { "has_data", true },
+            HasData = true
         };
 
         _foundryService.DeployModel(

--- a/tests/Areas/Foundry/UnitTests/ModelsListCommandTests.cs
+++ b/tests/Areas/Foundry/UnitTests/ModelsListCommandTests.cs
@@ -4,7 +4,7 @@
 using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using AzureMcp.Areas.Foundry.Commands.Models;
+using AzureMcp.Areas.Foundry.Commands;
 using AzureMcp.Areas.Foundry.Models;
 using AzureMcp.Areas.Foundry.Services;
 using AzureMcp.Models.Command;


### PR DESCRIPTION

## What does this PR do?

1. Minor cleanup for foundry service -
   1.  Avoid using Dictionary_string_object for deployment result.
   2. Correcting the command files location (files were in models namespace/dir)

2. respect --area for loadtesting bicep deployment.

## GitHub issue number?

## Pre-merge checklist
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) covering pull request process, code style, and testing**
- [ ] PR title is clear and informative
- [ ] Commit history is clean with informative messages (no previously merged commits appear in PR history). [See cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
- [ ] Added comprehensive tests for core features
- [ ] Added `CHANGELOG.md` entry for user-impacting changes (bug fixes, new features, UI/UX changes)
- [ ] Spelling check passes with `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes, updated:
  - [ ] Documentation in `README.md`
  - [ ] Command list in `/docs/azmcp-commands.md` 
  - [ ] End-to-end test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] **Team member live testing:**
  - [ ] **Security review:** Review PR for security vulnerabilities and malicious code before running tests (e.g., cryptocurrency mining, email spam, data exfiltration, or other harmful activities)
  - [ ] **Test execution:** Add comment `/azp run azure - mcp` to trigger pipeline
