### PR TITLE
Cosmos: Replace JsonNode with lightweight JsonElement in QueryItems command

### DIFF
--- a/src/Areas/Cosmos/Commands/ItemQueryCommand.cs
+++ b/src/Areas/Cosmos/Commands/ItemQueryCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using AzureMcp.Areas.Cosmos.Options;
 using AzureMcp.Areas.Cosmos.Services;
@@ -83,5 +84,5 @@ public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger) : BaseCon
         return context.Response;
     }
 
-    internal record ItemQueryCommandResult(List<JsonNode> Items);
+    internal record ItemQueryCommandResult(List<JsonElement> Items);
 }

--- a/src/Areas/Cosmos/Services/ICosmosService.cs
+++ b/src/Areas/Cosmos/Services/ICosmosService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using AzureMcp.Options;
 
@@ -28,7 +29,7 @@ public interface ICosmosService : IDisposable
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null);
 
-    Task<List<JsonNode>> QueryItems(
+    Task<List<JsonElement>> QueryItems(
         string accountName,
         string databaseName,
         string containerName,


### PR DESCRIPTION
## What does this PR do?

Replace the use of JsonNode with JsonElement in cosmos query.

`JsonNode` is heavier than `JsonElement` because it's built for mutable scenarios, whereas `JsonElement` suits read-only operations like Cosmos queries. `JsonElement` also allocates less memory on the heap. While `JsonNode` requires its own converters (Json[Node|Object|Array|Value]Converter), `JsonElement` uses the core serialization engine's built-in converters.

## GitHub issue number?

## Pre-merge checklist
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) covering pull request process, code style, and testing**
- [ ] PR title is clear and informative
- [ ] Commit history is clean with informative messages (no previously merged commits appear in PR history). [See cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
- [ ] Added comprehensive tests for core features
- [ ] Added `CHANGELOG.md` entry for user-impacting changes (bug fixes, new features, UI/UX changes)
- [ ] Spelling check passes with `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes, updated:
  - [ ] Documentation in `README.md`
  - [ ] Command list in `/docs/azmcp-commands.md` 
  - [ ] End-to-end test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] **Team member live testing:**
  - [ ] **Security review:** Review PR for security vulnerabilities and malicious code before running tests (e.g., cryptocurrency mining, email spam, data exfiltration, or other harmful activities)
  - [ ] **Test execution:** Add comment `/azp run azure - mcp` to trigger pipeline
