### PR TITLE
Fix Release Pipeline + Update Azure MCP VSIX ext ID 

### DIFF
--- a/eng/pipelines/templates/jobs/docker.yml
+++ b/eng/pipelines/templates/jobs/docker.yml
@@ -33,7 +33,7 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)
       artifact: docker_drops
 
-- job: Publish
+- job: PublishACR
   displayName: "Publish to ACR"
   condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
   dependsOn: CreateDockerArtifact

--- a/eng/vscode/package.json
+++ b/eng/vscode/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "azure-mcp-extension",
-    "displayName": "Azure MCP Server Extension",
+    "name": "vscode-azure-mcp-server",
+    "displayName": "Azure MCP Server",
     "description": "Provides Model Context Protocol (MCP) integration and tooling for Azure in Visual Studio Code.",
     "version": "0.1.0-alpha.1",
     "license": "MIT",


### PR DESCRIPTION
Fixes the release pipeline by renaming the conflicting Publish job in docker.yml to PublishACR
Updates the VSIX extension ID