### PR TITLE
Optimize serializer usage in tools discovery and loading code path

### DIFF
--- a/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/ServerToolLoader.cs
@@ -15,7 +15,6 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
 {
     private readonly IMcpDiscoveryStrategy _serverDiscoveryStrategy = serverDiscoveryStrategy ?? throw new ArgumentNullException(nameof(serverDiscoveryStrategy));
     private readonly Dictionary<string, List<Tool>> _cachedToolLists = new(StringComparer.OrdinalIgnoreCase);
-    private static readonly JsonElement s_emptyJsonObject = JsonDocument.Parse("{}").RootElement;
     private const string ToolCallProxySchema = """
         {
           "type": "object",
@@ -495,39 +494,6 @@ public sealed class ServerToolLoader(IMcpDiscoveryStrategy serverDiscoveryStrate
         }
 
         return (null, new Dictionary<string, object?>());
-    }
-
-    /// <summary>
-    /// Extracts the "parameters" object from the tool call request arguments and converts it to a dictionary.
-    /// </summary>
-    /// <param name="request">The request context containing the tool call parameters.</param>
-    /// <returns>
-    /// A dictionary containing the parameter names and values if the "parameters" object exists and is valid;
-    /// otherwise, returns an empty dictionary.
-    /// </returns>
-    private static Dictionary<string, object?> GetParametersDictionary(RequestContext<CallToolRequestParams> request)
-    {
-        JsonElement parametersElem = GetParametersJsonElement(request);
-        return parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value);
-    }
-
-    /// <summary>
-    /// Extracts the "parameters" JsonElement from the tool call request arguments.
-    /// </summary>
-    /// <param name="request">The request context containing the tool call parameters.</param>
-    /// <returns>
-    /// The "parameters" JsonElement if it exists and is a valid JSON object;
-    /// otherwise, returns an empty JSON object.
-    /// </returns>
-    private static JsonElement GetParametersJsonElement(RequestContext<CallToolRequestParams> request)
-    {
-        IReadOnlyDictionary<string, JsonElement>? args = request.Params?.Arguments;
-        if (args != null && args.TryGetValue("parameters", out var parametersElem) && parametersElem.ValueKind == JsonValueKind.Object)
-        {
-            return parametersElem;
-        }
-
-        return s_emptyJsonObject;
     }
 
     private McpClientOptions CreateClientOptions(IMcpServer server)

--- a/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
+++ b/src/Areas/Server/Commands/ToolLoading/SingleProxyToolLoader.cs
@@ -14,6 +14,7 @@ public sealed class SingleProxyToolLoader : BaseToolLoader
     private readonly IMcpDiscoveryStrategy _discoveryStrategy;
     private string? _cachedRootToolsJson;
     private readonly Dictionary<string, string> _cachedToolListsJson = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly JsonElement s_emptyJsonObject = JsonDocument.Parse("{}").RootElement;
 
     private const string ToolCallProxySchema = """
         {
@@ -395,8 +396,8 @@ public sealed class SingleProxyToolLoader : BaseToolLoader
     {
         await NotifyProgressAsync(request, $"Learning about {tool} capabilities...", cancellationToken);
 
-        var toolParams = GetParametersDictionary(request.Params?.Arguments);
-        var toolParamsJson = JsonSerializer.Serialize(toolParams, ServerJsonContext.Default.DictionaryStringObject);
+        JsonElement toolParams = GetParametersJsonElement(request.Params?.Arguments);
+        var toolParamsJson = toolParams.GetRawText();
 
         var samplingRequest = new CreateMessageRequestParams
         {
@@ -449,7 +450,7 @@ public sealed class SingleProxyToolLoader : BaseToolLoader
                 }
                 if (root.TryGetProperty("parameters", out var paramsProp) && paramsProp.ValueKind == JsonValueKind.Object)
                 {
-                    parameters = JsonSerializer.Deserialize(paramsProp.GetRawText(), ServerJsonContext.Default.DictionaryStringObject) ?? [];
+                    parameters = paramsProp.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value);
                 }
             }
             if (commandName != null && commandName != "Unknown")
@@ -465,14 +466,36 @@ public sealed class SingleProxyToolLoader : BaseToolLoader
         return (null, new Dictionary<string, object?>());
     }
 
-    private static Dictionary<string, object?> GetParametersDictionary(IReadOnlyDictionary<string, JsonElement>? args)
+    /// <summary>
+    /// Extracts the "parameters" JsonElement from the tool call request arguments.
+    /// </summary>
+    /// <param name="args">The request arguments dictionary.</param>
+    /// <returns>
+    /// The "parameters" JsonElement if it exists and is a valid JSON object; 
+    /// otherwise, returns an empty JSON object.
+    /// </returns>
+    private static JsonElement GetParametersJsonElement(IReadOnlyDictionary<string, JsonElement>? args)
     {
         if (args != null && args.TryGetValue("parameters", out var parametersElem) && parametersElem.ValueKind == JsonValueKind.Object)
         {
-            return JsonSerializer.Deserialize(parametersElem.GetRawText(), ServerJsonContext.Default.DictionaryStringObject) ?? [];
+            return parametersElem;
         }
 
-        return [];
+        return s_emptyJsonObject;
+    }
+
+    /// <summary>
+    /// Extracts the "parameters" object from the tool call request arguments and converts it to a dictionary.
+    /// </summary>
+    /// <param name="args">The request arguments dictionary.</param>
+    /// <returns>
+    /// A dictionary containing the parameter names and values if the "parameters" object exists and is valid;
+    /// otherwise, returns an empty dictionary.
+    /// </returns>
+    private static Dictionary<string, object?> GetParametersDictionary(IReadOnlyDictionary<string, JsonElement>? args)
+    {
+        JsonElement parametersElem = GetParametersJsonElement(args);
+        return parametersElem.EnumerateObject().ToDictionary(prop => prop.Name, prop => (object?)prop.Value);
     }
 
     private McpClientOptions CreateClientOptions(IMcpServer server)

--- a/src/Areas/Server/Models/ToolInputSchema.cs
+++ b/src/Areas/Server/Models/ToolInputSchema.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace AzureMcp.Areas.Server.Models;
+
+/// <summary>
+/// Represents the JSON schema for a tool's input parameters.
+/// </summary>
+public sealed class ToolInputSchema
+{
+    /// <summary>
+    /// The type of the schema object (always "object" for tool schemas).
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "object";
+
+    /// <summary>
+    /// The properties defined for this schema.
+    /// </summary>
+    [JsonPropertyName("properties")]
+    public Dictionary<string, ToolPropertySchema> Properties { get; init; } = new();
+
+    /// <summary>
+    /// The list of required property names.
+    /// </summary>
+    [JsonPropertyName("required")]
+    public string[]? Required { get; set; } = [];
+}

--- a/src/Areas/Server/Models/ToolPropertySchema.cs
+++ b/src/Areas/Server/Models/ToolPropertySchema.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace AzureMcp.Areas.Server.Models;
+
+/// <summary>
+/// Represents a property definition within a tool's input schema.
+/// </summary>
+public sealed class ToolPropertySchema
+{
+    /// <summary>
+    /// The JSON type of the property (e.g., "string", "integer", "boolean", "array", "object").
+    /// The type mapping is handled by <see cref="AzureMcp.Areas.Server.Commands.TypeToJsonTypeMapper"/>.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// A description of what this property represents.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; init; }
+}

--- a/src/Areas/Server/ServerJsonContext.cs
+++ b/src/Areas/Server/ServerJsonContext.cs
@@ -18,6 +18,8 @@ namespace AzureMcp.Areas.Server;
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(Tool))]
 [JsonSerializable(typeof(List<Tool>))]
+[JsonSerializable(typeof(ToolInputSchema))]
+[JsonSerializable(typeof(ToolPropertySchema))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,


### PR DESCRIPTION
## What does this PR do?

The PR optimizes the use of serializer -

* In `RegistryToolLoader`, we don’t have to special handle `JsonElement` holding primitive values. The `McpExtensions::CallToolAsync` Api in MCP SDK can handle any type of `JsonElement` (primitive, object, array).  By doing so, we can avoid MCP SDK from serializing primitives back to JsonElement for every tool call, which is a hot path.
* In ` CommandFactoryToolLoader`, we can define and use class for Tool InputSchema, this avoid using `JsonObject` which incur generally more allocations and serialization overhead as it is a very generic data structure.
* Similar to `RegistryToolLoader`,  in ` ServerToolLoader` also we can avoid serialization and de-serialization calls in few places, and also removes the need for dealing with `dictionary_string_object` in serde context (`object` means, the STJ in AOT needs to retain additional converters). 

## GitHub issue number?
N/A

## Pre-merge checklist
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md) covering pull request process, code style, and testing**
- [x] PR title is clear and informative
- [x] Commit history is clean with informative messages (no previously merged commits appear in PR history). [See cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md)
- [x] Added comprehensive tests for core features
- [x] Added `CHANGELOG.md` entry for user-impacting changes (bug fixes, new features, UI/UX changes)
- [x] Spelling check passes with `.\eng\common\spelling\Invoke-Cspell.ps1`
- [x] For MCP tool changes, updated:
  - [x] Documentation in `README.md`
  - [x] Command list in `/docs/azmcp-commands.md` 
  - [x] End-to-end test prompts in `/e2eTests/e2eTestPrompts.md`
- [x] **Team member live testing:**
  - [ ] **Security review:** Review PR for security vulnerabilities and malicious code before running tests (e.g., cryptocurrency mining, email spam, data exfiltration, or other harmful activities)
  - [ ] **Test execution:** Add comment `/azp run azure - mcp` to trigger pipeline

