### PR TITLE
Remove the use of ModelContextProtocol.Server.McpServerTool decorator

### DIFF
--- a/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterGetCommand.cs
+++ b/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterGetCommand.cs
@@ -6,6 +6,7 @@ using AzureMcp.Aks.Models;
 using AzureMcp.Aks.Options;
 using AzureMcp.Aks.Options.Cluster;
 using AzureMcp.Aks.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -29,6 +30,8 @@ public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : BaseA
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -44,7 +47,6 @@ public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : BaseA
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterGetCommand.cs
+++ b/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterGetCommand.cs
@@ -30,7 +30,7 @@ public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : BaseA
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterListCommand.cs
+++ b/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterListCommand.cs
@@ -5,6 +5,7 @@ using AzureMcp.Aks.Commands;
 using AzureMcp.Aks.Models;
 using AzureMcp.Aks.Options.Cluster;
 using AzureMcp.Aks.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -24,8 +25,9 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Bas
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterListCommand.cs
+++ b/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterListCommand.cs
@@ -25,7 +25,7 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Bas
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)

--- a/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterListCommand.cs
+++ b/areas/aks/src/AzureMcp.Aks/Commands/Cluster/ClusterListCommand.cs
@@ -26,7 +26,7 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Bas
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/Account/AccountListCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/Account/AccountListCommand.cs
@@ -27,7 +27,7 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/Account/AccountListCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/Account/AccountListCommand.cs
@@ -5,6 +5,7 @@ using AzureMcp.AppConfig.Commands;
 using AzureMcp.AppConfig.Models;
 using AzureMcp.AppConfig.Options.Account;
 using AzureMcp.AppConfig.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -26,7 +27,8 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueDeleteCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueDeleteCommand.cs
@@ -26,7 +26,7 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger)
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = true, ReadOnly = false };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueDeleteCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueDeleteCommand.cs
@@ -4,6 +4,7 @@
 using AzureMcp.AppConfig.Commands;
 using AzureMcp.AppConfig.Options.KeyValue;
 using AzureMcp.AppConfig.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -25,7 +26,8 @@ public sealed class KeyValueDeleteCommand(ILogger<KeyValueDeleteCommand> logger)
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueListCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueListCommand.cs
@@ -32,7 +32,7 @@ public sealed class KeyValueListCommand(ILogger<KeyValueListCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueListCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueListCommand.cs
@@ -6,6 +6,7 @@ using AzureMcp.AppConfig.Models;
 using AzureMcp.AppConfig.Options;
 using AzureMcp.AppConfig.Options.KeyValue;
 using AzureMcp.AppConfig.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -31,6 +32,8 @@ public sealed class KeyValueListCommand(ILogger<KeyValueListCommand> logger) : B
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -46,7 +49,6 @@ public sealed class KeyValueListCommand(ILogger<KeyValueListCommand> logger) : B
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueLockCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueLockCommand.cs
@@ -26,7 +26,7 @@ public sealed class KeyValueLockCommand(ILogger<KeyValueLockCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueLockCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueLockCommand.cs
@@ -4,6 +4,7 @@
 using AzureMcp.AppConfig.Commands;
 using AzureMcp.AppConfig.Options.KeyValue;
 using AzureMcp.AppConfig.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -25,7 +26,8 @@ public sealed class KeyValueLockCommand(ILogger<KeyValueLockCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueSetCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueSetCommand.cs
@@ -5,6 +5,7 @@ using AzureMcp.AppConfig.Commands;
 using AzureMcp.AppConfig.Options;
 using AzureMcp.AppConfig.Options.KeyValue;
 using AzureMcp.AppConfig.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -27,6 +28,8 @@ public sealed class KeyValueSetCommand(ILogger<KeyValueSetCommand> logger) : Bas
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -40,7 +43,6 @@ public sealed class KeyValueSetCommand(ILogger<KeyValueSetCommand> logger) : Bas
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueSetCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueSetCommand.cs
@@ -28,7 +28,7 @@ public sealed class KeyValueSetCommand(ILogger<KeyValueSetCommand> logger) : Bas
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueShowCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueShowCommand.cs
@@ -5,6 +5,7 @@ using AzureMcp.AppConfig.Commands;
 using AzureMcp.AppConfig.Models;
 using AzureMcp.AppConfig.Options.KeyValue;
 using AzureMcp.AppConfig.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -26,7 +27,8 @@ public sealed class KeyValueShowCommand(ILogger<KeyValueShowCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueShowCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueShowCommand.cs
@@ -27,7 +27,7 @@ public sealed class KeyValueShowCommand(ILogger<KeyValueShowCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueUnlockCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueUnlockCommand.cs
@@ -4,6 +4,7 @@
 using AzureMcp.AppConfig.Commands;
 using AzureMcp.AppConfig.Options.KeyValue;
 using AzureMcp.AppConfig.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -26,7 +27,8 @@ public sealed class KeyValueUnlockCommand(ILogger<KeyValueUnlockCommand> logger)
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueUnlockCommand.cs
+++ b/areas/appconfig/src/AzureMcp.AppConfig/Commands/KeyValue/KeyValueUnlockCommand.cs
@@ -27,7 +27,7 @@ public sealed class KeyValueUnlockCommand(ILogger<KeyValueUnlockCommand> logger)
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/authorization/src/AzureMcp.Authorization/Commands/RoleAssignmentListCommand.cs
+++ b/areas/authorization/src/AzureMcp.Authorization/Commands/RoleAssignmentListCommand.cs
@@ -28,7 +28,7 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
 
     public override string Title => _commandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     private readonly Option<string> _scopeOption = OptionDefinitions.Authorization.Scope;
 

--- a/areas/authorization/src/AzureMcp.Authorization/Commands/RoleAssignmentListCommand.cs
+++ b/areas/authorization/src/AzureMcp.Authorization/Commands/RoleAssignmentListCommand.cs
@@ -27,7 +27,7 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
         """;
 
     public override string Title => _commandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     private readonly Option<string> _scopeOption = OptionDefinitions.Authorization.Scope;

--- a/areas/authorization/src/AzureMcp.Authorization/Commands/RoleAssignmentListCommand.cs
+++ b/areas/authorization/src/AzureMcp.Authorization/Commands/RoleAssignmentListCommand.cs
@@ -5,6 +5,7 @@ using AzureMcp.Authorization.Commands;
 using AzureMcp.Authorization.Models;
 using AzureMcp.Authorization.Options;
 using AzureMcp.Authorization.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.Core.Services.Telemetry;
@@ -26,6 +27,8 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
         """;
 
     public override string Title => _commandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     private readonly Option<string> _scopeOption = OptionDefinitions.Authorization.Scope;
 
@@ -42,7 +45,6 @@ public sealed class RoleAssignmentListCommand(ILogger<RoleAssignmentListCommand>
         return args;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/azurebestpractices/src/AzureMcp.AzureBestPractices/Commands/BestPracticesCommand.cs
+++ b/areas/azurebestpractices/src/AzureMcp.AzureBestPractices/Commands/BestPracticesCommand.cs
@@ -26,6 +26,8 @@ public sealed class BestPracticesCommand(ILogger<BestPracticesCommand> logger) :
         "This command returns the content of the best practices file as a string array.";
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -33,7 +35,6 @@ public sealed class BestPracticesCommand(ILogger<BestPracticesCommand> logger) :
         command.AddOption(_actionOption);
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/azurebestpractices/src/AzureMcp.AzureBestPractices/Commands/BestPracticesCommand.cs
+++ b/areas/azurebestpractices/src/AzureMcp.AzureBestPractices/Commands/BestPracticesCommand.cs
@@ -26,7 +26,7 @@ public sealed class BestPracticesCommand(ILogger<BestPracticesCommand> logger) :
         "This command returns the content of the best practices file as a string array.";
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/azurebestpractices/src/AzureMcp.AzureBestPractices/Commands/BestPracticesCommand.cs
+++ b/areas/azurebestpractices/src/AzureMcp.AzureBestPractices/Commands/BestPracticesCommand.cs
@@ -27,7 +27,7 @@ public sealed class BestPracticesCommand(ILogger<BestPracticesCommand> logger) :
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/azureisv/src/AzureMcp.AzureIsv/Commands/Datadog/MonitoredResourcesListCommand.cs
+++ b/areas/azureisv/src/AzureMcp.AzureIsv/Commands/Datadog/MonitoredResourcesListCommand.cs
@@ -29,7 +29,7 @@ public sealed class MonitoredResourcesListCommand(ILogger<MonitoredResourcesList
         """;
 
     public override string Title => _commandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/azureisv/src/AzureMcp.AzureIsv/Commands/Datadog/MonitoredResourcesListCommand.cs
+++ b/areas/azureisv/src/AzureMcp.AzureIsv/Commands/Datadog/MonitoredResourcesListCommand.cs
@@ -5,6 +5,7 @@ using AzureMcp.AzureIsv.Commands.Datadog;
 using AzureMcp.AzureIsv.Options;
 using AzureMcp.AzureIsv.Options.Datadog;
 using AzureMcp.AzureIsv.Services;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -28,6 +29,8 @@ public sealed class MonitoredResourcesListCommand(ILogger<MonitoredResourcesList
         """;
 
     public override string Title => _commandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -44,7 +47,6 @@ public sealed class MonitoredResourcesListCommand(ILogger<MonitoredResourcesList
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/azureisv/src/AzureMcp.AzureIsv/Commands/Datadog/MonitoredResourcesListCommand.cs
+++ b/areas/azureisv/src/AzureMcp.AzureIsv/Commands/Datadog/MonitoredResourcesListCommand.cs
@@ -30,7 +30,7 @@ public sealed class MonitoredResourcesListCommand(ILogger<MonitoredResourcesList
 
     public override string Title => _commandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/azureterraformbestpractices/src/AzureMcp.AzureTerraformBestPractices/Commands/AzureTerraformBestPracticesGetCommand.cs
+++ b/areas/azureterraformbestpractices/src/AzureMcp.AzureTerraformBestPractices/Commands/AzureTerraformBestPracticesGetCommand.cs
@@ -31,7 +31,7 @@ public sealed class AzureTerraformBestPracticesGetCommand(ILogger<AzureTerraform
         "This command returns the content of the markdown file as a string array.";
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)

--- a/areas/azureterraformbestpractices/src/AzureMcp.AzureTerraformBestPractices/Commands/AzureTerraformBestPracticesGetCommand.cs
+++ b/areas/azureterraformbestpractices/src/AzureMcp.AzureTerraformBestPractices/Commands/AzureTerraformBestPracticesGetCommand.cs
@@ -32,7 +32,7 @@ public sealed class AzureTerraformBestPracticesGetCommand(ILogger<AzureTerraform
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/azureterraformbestpractices/src/AzureMcp.AzureTerraformBestPractices/Commands/AzureTerraformBestPracticesGetCommand.cs
+++ b/areas/azureterraformbestpractices/src/AzureMcp.AzureTerraformBestPractices/Commands/AzureTerraformBestPracticesGetCommand.cs
@@ -31,8 +31,9 @@ public sealed class AzureTerraformBestPracticesGetCommand(ILogger<AzureTerraform
         "This command returns the content of the markdown file as a string array.";
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var bestPractices = GetBestPracticesText();

--- a/areas/bicepschema/src/AzureMcp.BicepSchema/Commands/BicepSchemaGetCommand.cs
+++ b/areas/bicepschema/src/AzureMcp.BicepSchema/Commands/BicepSchemaGetCommand.cs
@@ -32,7 +32,7 @@ namespace AzureMcp.BicepSchema.Commands
 
         public override string Title => CommandTitle;
 
-        public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+        public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
         private static readonly Lazy<IServiceProvider> s_serviceProvider;
 

--- a/areas/bicepschema/src/AzureMcp.BicepSchema/Commands/BicepSchemaGetCommand.cs
+++ b/areas/bicepschema/src/AzureMcp.BicepSchema/Commands/BicepSchemaGetCommand.cs
@@ -5,6 +5,7 @@ using AzureMcp.BicepSchema.Commands;
 using AzureMcp.BicepSchema.Options;
 using AzureMcp.BicepSchema.Services;
 using AzureMcp.BicepSchema.Services.ResourceProperties.Entities;
+using AzureMcp.Core.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -31,6 +32,8 @@ namespace AzureMcp.BicepSchema.Commands
 
         public override string Title => CommandTitle;
 
+        public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
         private static readonly Lazy<IServiceProvider> s_serviceProvider;
 
         static BicepSchemaGetCommand()
@@ -43,7 +46,6 @@ namespace AzureMcp.BicepSchema.Commands
             });
         }
 
-        [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
         public override Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
         {
             BicepSchemaOptions options = BindOptions(parseResult);

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/AccountListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/AccountListCommand.cs
@@ -26,7 +26,7 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/AccountListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/AccountListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Cosmos.Commands;
@@ -25,7 +26,8 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/ContainerListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/ContainerListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Cosmos.Commands;
 using AzureMcp.Cosmos.Options;
@@ -25,7 +26,8 @@ public sealed class ContainerListCommand(ILogger<ContainerListCommand> logger) :
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/ContainerListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/ContainerListCommand.cs
@@ -26,7 +26,7 @@ public sealed class ContainerListCommand(ILogger<ContainerListCommand> logger) :
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/DatabaseListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/DatabaseListCommand.cs
@@ -25,7 +25,7 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/DatabaseListCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/DatabaseListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Cosmos.Commands;
 using AzureMcp.Cosmos.Options;
@@ -24,7 +25,8 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/ItemQueryCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/ItemQueryCommand.cs
@@ -30,7 +30,7 @@ public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger) : BaseCon
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/cosmos/src/AzureMcp.Cosmos/Commands/ItemQueryCommand.cs
+++ b/areas/cosmos/src/AzureMcp.Cosmos/Commands/ItemQueryCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Cosmos.Commands;
 using AzureMcp.Cosmos.Options;
@@ -29,6 +30,8 @@ public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger) : BaseCon
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -42,7 +45,6 @@ public sealed class ItemQueryCommand(ILogger<ItemQueryCommand> logger) : BaseCon
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzCommand.cs
@@ -46,7 +46,7 @@ Your job is to answer questions about an Azure environment by executing Azure CL
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = true, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzCommand.cs
@@ -45,6 +45,8 @@ Your job is to answer questions about an Azure environment by executing Azure CL
 """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
 
     protected override void RegisterOptions(Command command)
     {
@@ -157,7 +159,6 @@ Your job is to answer questions about an Azure environment by executing Azure CL
         }
     }
 
-    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzCommand.cs
@@ -45,7 +45,7 @@ Your job is to answer questions about an Azure environment by executing Azure CL
 """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = true, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzdCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzdCommand.cs
@@ -76,7 +76,7 @@ public sealed class AzdCommand(ILogger<AzdCommand> logger, int processTimeoutSec
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = true, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzdCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzdCommand.cs
@@ -75,6 +75,8 @@ public sealed class AzdCommand(ILogger<AzdCommand> logger, int processTimeoutSec
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
 
     protected override void RegisterOptions(Command command)
     {
@@ -96,7 +98,6 @@ public sealed class AzdCommand(ILogger<AzdCommand> logger, int processTimeoutSec
         return options;
     }
 
-    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzdCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzdCommand.cs
@@ -75,7 +75,7 @@ public sealed class AzdCommand(ILogger<AzdCommand> logger, int processTimeoutSec
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = true, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzqrCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzqrCommand.cs
@@ -30,7 +30,7 @@ public sealed class AzqrCommand(ILogger<AzqrCommand> logger, int processTimeoutS
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzqrCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzqrCommand.cs
@@ -31,7 +31,7 @@ public sealed class AzqrCommand(ILogger<AzqrCommand> logger, int processTimeoutS
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/extension/src/AzureMcp.Extension/Commands/AzqrCommand.cs
+++ b/areas/extension/src/AzureMcp.Extension/Commands/AzqrCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Runtime.InteropServices;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Azure.Subscription;
 using AzureMcp.Core.Services.ProcessExecution;
@@ -29,6 +30,8 @@ public sealed class AzqrCommand(ILogger<AzqrCommand> logger, int processTimeoutS
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -36,7 +39,6 @@ public sealed class AzqrCommand(ILogger<AzqrCommand> logger, int processTimeoutS
         command.AddOption(ExtensionOptionDefinitions.Azqr.OptionalResourceGroup);
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/DeploymentsListCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/DeploymentsListCommand.cs
@@ -32,7 +32,7 @@ public sealed class DeploymentsListCommand : GlobalCommand<DeploymentsListOption
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/DeploymentsListCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/DeploymentsListCommand.cs
@@ -31,7 +31,7 @@ public sealed class DeploymentsListCommand : GlobalCommand<DeploymentsListOption
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/DeploymentsListCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/DeploymentsListCommand.cs
@@ -31,6 +31,8 @@ public sealed class DeploymentsListCommand : GlobalCommand<DeploymentsListOption
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -46,7 +48,6 @@ public sealed class DeploymentsListCommand : GlobalCommand<DeploymentsListOption
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/ModelDeploymentCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/ModelDeploymentCommand.cs
@@ -36,7 +36,7 @@ public sealed class ModelDeploymentCommand : SubscriptionCommand<ModelDeployment
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/ModelDeploymentCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/ModelDeploymentCommand.cs
@@ -35,7 +35,7 @@ public sealed class ModelDeploymentCommand : SubscriptionCommand<ModelDeployment
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/ModelDeploymentCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/ModelDeploymentCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Foundry.Models;
@@ -34,6 +35,8 @@ public sealed class ModelDeploymentCommand : SubscriptionCommand<ModelDeployment
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
 
     protected override void RegisterOptions(Command command)
     {
@@ -69,7 +72,6 @@ public sealed class ModelDeploymentCommand : SubscriptionCommand<ModelDeployment
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/ModelsListCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/ModelsListCommand.cs
@@ -33,6 +33,8 @@ public sealed class ModelsListCommand : GlobalCommand<ModelsListOptions>
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -54,7 +56,6 @@ public sealed class ModelsListCommand : GlobalCommand<ModelsListOptions>
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/ModelsListCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/ModelsListCommand.cs
@@ -34,7 +34,7 @@ public sealed class ModelsListCommand : GlobalCommand<ModelsListOptions>
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/foundry/src/AzureMcp.Foundry/Commands/ModelsListCommand.cs
+++ b/areas/foundry/src/AzureMcp.Foundry/Commands/ModelsListCommand.cs
@@ -33,7 +33,7 @@ public sealed class ModelsListCommand : GlobalCommand<ModelsListOptions>
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/grafana/src/AzureMcp.Grafana/Commands/Workspace/WorkspaceListCommand.cs
+++ b/areas/grafana/src/AzureMcp.Grafana/Commands/Workspace/WorkspaceListCommand.cs
@@ -30,7 +30,7 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger) :
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/grafana/src/AzureMcp.Grafana/Commands/Workspace/WorkspaceListCommand.cs
+++ b/areas/grafana/src/AzureMcp.Grafana/Commands/Workspace/WorkspaceListCommand.cs
@@ -29,7 +29,7 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger) :
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)

--- a/areas/grafana/src/AzureMcp.Grafana/Commands/Workspace/WorkspaceListCommand.cs
+++ b/areas/grafana/src/AzureMcp.Grafana/Commands/Workspace/WorkspaceListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Grafana.Commands;
@@ -28,8 +29,9 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger) :
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateCreateCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateCreateCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -21,6 +22,8 @@ public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> l
     public override string Name => "create";
 
     public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
 
     public override string Description =>
         """
@@ -43,7 +46,6 @@ public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> l
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateCreateCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateCreateCommand.cs
@@ -23,7 +23,7 @@ public sealed class CertificateCreateCommand(ILogger<CertificateCreateCommand> l
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     public override string Description =>
         """

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateGetCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateGetCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -21,6 +22,8 @@ public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger)
     public override string Name => "get";
 
     public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     public override string Description =>
         """
@@ -43,7 +46,6 @@ public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger)
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateGetCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateGetCommand.cs
@@ -23,7 +23,7 @@ public sealed class CertificateGetCommand(ILogger<CertificateGetCommand> logger)
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override string Description =>
         """

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateListCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -21,6 +22,8 @@ public sealed class CertificateListCommand(ILogger<CertificateListCommand> logge
 
     public override string Title => _commandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override string Description =>
         """
         List all certificates in an Azure Key Vault. This command retrieves and displays the names of all certificates
@@ -40,7 +43,6 @@ public sealed class CertificateListCommand(ILogger<CertificateListCommand> logge
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateListCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Certificate/CertificateListCommand.cs
@@ -22,7 +22,7 @@ public sealed class CertificateListCommand(ILogger<CertificateListCommand> logge
 
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override string Description =>
         """

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyCreateCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyCreateCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -22,6 +23,8 @@ public sealed class KeyCreateCommand(ILogger<KeyCreateCommand> logger) : Subscri
     public override string Name => "create";
 
     public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
 
     public override string Description =>
         """
@@ -46,7 +49,6 @@ public sealed class KeyCreateCommand(ILogger<KeyCreateCommand> logger) : Subscri
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyCreateCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyCreateCommand.cs
@@ -24,7 +24,7 @@ public sealed class KeyCreateCommand(ILogger<KeyCreateCommand> logger) : Subscri
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     public override string Description =>
         """

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyGetCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyGetCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -21,6 +22,8 @@ public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger) : SubscriptionC
     public override string Name => "get";
 
     public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     public override string Description =>
         """
@@ -43,7 +46,6 @@ public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger) : SubscriptionC
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyGetCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyGetCommand.cs
@@ -23,7 +23,7 @@ public sealed class KeyGetCommand(ILogger<KeyGetCommand> logger) : SubscriptionC
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override string Description =>
         """

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyListCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyListCommand.cs
@@ -23,7 +23,7 @@ public sealed class KeyListCommand(ILogger<KeyListCommand> logger) : Subscriptio
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override string Description =>
         """

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyListCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Key/KeyListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -21,6 +22,8 @@ public sealed class KeyListCommand(ILogger<KeyListCommand> logger) : Subscriptio
     public override string Name => "list";
 
     public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     public override string Description =>
         """
@@ -43,7 +46,6 @@ public sealed class KeyListCommand(ILogger<KeyListCommand> logger) : Subscriptio
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretCreateCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretCreateCommand.cs
@@ -24,7 +24,7 @@ public sealed class SecretCreateCommand(ILogger<SecretCreateCommand> logger) : S
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     public override string Description =>
         """

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretCreateCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretCreateCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -22,6 +23,8 @@ public sealed class SecretCreateCommand(ILogger<SecretCreateCommand> logger) : S
     public override string Name => "create";
 
     public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
 
     public override string Description =>
         """
@@ -46,7 +49,6 @@ public sealed class SecretCreateCommand(ILogger<SecretCreateCommand> logger) : S
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretGetCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretGetCommand.cs
@@ -23,7 +23,7 @@ public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger) : Subscri
 
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override string Description =>
         """

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretGetCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretGetCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -21,6 +22,8 @@ public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger) : Subscri
     public override string Name => "get";
 
     public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     public override string Description =>
         """
@@ -43,7 +46,6 @@ public sealed class SecretGetCommand(ILogger<SecretGetCommand> logger) : Subscri
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretListCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.KeyVault.Commands;
@@ -21,6 +22,8 @@ public sealed class SecretListCommand(ILogger<SecretListCommand> logger) : Subsc
 
     public override string Title => _commandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override string Description =>
         """
         List all secrets in an Azure Key Vault. This command retrieves and displays the names of all secrets
@@ -40,7 +43,6 @@ public sealed class SecretListCommand(ILogger<SecretListCommand> logger) : Subsc
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretListCommand.cs
+++ b/areas/keyvault/src/AzureMcp.KeyVault/Commands/Secret/SecretListCommand.cs
@@ -22,7 +22,7 @@ public sealed class SecretListCommand(ILogger<SecretListCommand> logger) : Subsc
 
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override string Description =>
         """

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterGetCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterGetCommand.cs
@@ -25,7 +25,7 @@ public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : BaseC
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterGetCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterGetCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Kusto.Commands;
 using AzureMcp.Kusto.Options;
@@ -24,7 +25,8 @@ public sealed class ClusterGetCommand(ILogger<ClusterGetCommand> logger) : BaseC
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Kusto.Commands;
@@ -26,7 +27,8 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/ClusterListCommand.cs
@@ -27,7 +27,7 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/DatabaseListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/DatabaseListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Kusto.Commands;
 using AzureMcp.Kusto.Options;
@@ -25,7 +26,8 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/DatabaseListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/DatabaseListCommand.cs
@@ -26,7 +26,7 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/QueryCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/QueryCommand.cs
@@ -40,7 +40,7 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger) : BaseDatabaseCom
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/QueryCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/QueryCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Kusto.Commands;
 using AzureMcp.Kusto.Options;
@@ -39,7 +40,8 @@ public sealed class QueryCommand(ILogger<QueryCommand> logger) : BaseDatabaseCom
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/SampleCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/SampleCommand.cs
@@ -41,7 +41,7 @@ public sealed class SampleCommand(ILogger<SampleCommand> logger) : BaseTableComm
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/SampleCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/SampleCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Kusto.Commands;
 using AzureMcp.Kusto.Options;
@@ -40,7 +41,8 @@ public sealed class SampleCommand(ILogger<SampleCommand> logger) : BaseTableComm
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/TableListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/TableListCommand.cs
@@ -26,7 +26,7 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseDat
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/TableListCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/TableListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Kusto.Commands;
 using AzureMcp.Kusto.Options;
@@ -25,7 +26,8 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseDat
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/TableSchemaCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/TableSchemaCommand.cs
@@ -25,7 +25,7 @@ public sealed class TableSchemaCommand(ILogger<TableSchemaCommand> logger) : Bas
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/kusto/src/AzureMcp.Kusto/Commands/TableSchemaCommand.cs
+++ b/areas/kusto/src/AzureMcp.Kusto/Commands/TableSchemaCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Kusto.Commands;
 using AzureMcp.Kusto.Options;
@@ -24,7 +25,8 @@ public sealed class TableSchemaCommand(ILogger<TableSchemaCommand> logger) : Bas
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestCreateCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.LoadTesting.Models.LoadTest;
 using AzureMcp.LoadTesting.Options.LoadTest;
@@ -27,6 +28,9 @@ public sealed class TestCreateCommand(ILogger<TestCreateCommand> logger)
         and scalability of web applications and APIs. The test configuration defines the target endpoint, load parameters, and test duration. Once we create a test configuration plan, we can use that to trigger test runs to test the endpoints set.
         """;
     public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -52,10 +56,6 @@ public sealed class TestCreateCommand(ILogger<TestCreateCommand> logger)
         return options;
     }
 
-    [McpServerTool(
-    Destructive = false,
-    ReadOnly = true,
-    Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestCreateCommand.cs
@@ -29,7 +29,7 @@ public sealed class TestCreateCommand(ILogger<TestCreateCommand> logger)
         """;
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestGetCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestGetCommand.cs
@@ -23,7 +23,7 @@ public sealed class TestGetCommand(ILogger<TestGetCommand> logger)
         """;
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestGetCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestGetCommand.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.LoadTesting.Models.LoadTest;
 using AzureMcp.LoadTesting.Options.LoadTest;
@@ -21,6 +22,9 @@ public sealed class TestGetCommand(ILogger<TestGetCommand> logger)
         This command retrieves the details of a specific load test configuration, including its parameters and settings. Based on this we can see what all parameters were set for the test configuration.
         """;
     public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -34,10 +38,6 @@ public sealed class TestGetCommand(ILogger<TestGetCommand> logger)
         return options;
     }
 
-    [McpServerTool(
-    Destructive = false,
-    ReadOnly = true,
-    Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceCreateCommand.cs
@@ -21,7 +21,7 @@ public sealed class TestResourceCreateCommand(ILogger<TestResourceCreateCommand>
         """;
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceCreateCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.LoadTesting.Models.LoadTestResource;
 using AzureMcp.LoadTesting.Options.LoadTestResource;
 using AzureMcp.LoadTesting.Services;
@@ -20,10 +21,8 @@ public sealed class TestResourceCreateCommand(ILogger<TestResourceCreateCommand>
         """;
     public override string Title => _commandTitle;
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = _commandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceListCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.LoadTesting.Models.LoadTestResource;
 using AzureMcp.LoadTesting.Options.LoadTestResource;
 using AzureMcp.LoadTesting.Services;
@@ -20,10 +21,8 @@ public sealed class TestResourceListCommand(ILogger<TestResourceListCommand> log
         """;
     public override string Title => _commandTitle;
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = _commandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceListCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceListCommand.cs
@@ -21,7 +21,7 @@ public sealed class TestResourceListCommand(ILogger<TestResourceListCommand> log
         """;
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunCreateCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.LoadTesting.Models.LoadTestRun;
 using AzureMcp.LoadTesting.Options.LoadTestRun;
@@ -26,6 +27,9 @@ public sealed class TestRunCreateCommand(ILogger<TestRunCreateCommand> logger)
         the same test multiple times to validate performance improvements, compare results across different deployments, or establish performance baselines for your application.
         """;
     public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -47,10 +51,6 @@ public sealed class TestRunCreateCommand(ILogger<TestRunCreateCommand> logger)
         return options;
     }
 
-    [McpServerTool(
-    Destructive = false,
-    ReadOnly = true,
-    Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunCreateCommand.cs
@@ -28,7 +28,7 @@ public sealed class TestRunCreateCommand(ILogger<TestRunCreateCommand> logger)
         """;
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunGetCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunGetCommand.cs
@@ -24,7 +24,7 @@ public sealed class TestRunGetCommand(ILogger<TestRunGetCommand> logger)
         """;
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunGetCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunGetCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.LoadTesting.Models.LoadTestRun;
 using AzureMcp.LoadTesting.Options.LoadTestRun;
@@ -22,6 +23,9 @@ public sealed class TestRunGetCommand(ILogger<TestRunGetCommand> logger)
         and final results to help you analyze your application's behavior under load.
         """;
     public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -35,10 +39,6 @@ public sealed class TestRunGetCommand(ILogger<TestRunGetCommand> logger)
         return options;
     }
 
-    [McpServerTool(
-    Destructive = false,
-    ReadOnly = true,
-    Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunListCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunListCommand.cs
@@ -24,7 +24,7 @@ public sealed class TestRunListCommand(ILogger<TestRunListCommand> logger)
         """;
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunListCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.LoadTesting.Models.LoadTestRun;
 using AzureMcp.LoadTesting.Options.LoadTestRun;
@@ -22,6 +23,9 @@ public sealed class TestRunListCommand(ILogger<TestRunListCommand> logger)
         trends, compare results across multiple runs, and analyze testing patterns over time.
         """;
     public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -35,10 +39,6 @@ public sealed class TestRunListCommand(ILogger<TestRunListCommand> logger)
         return options;
     }
 
-    [McpServerTool(
-    Destructive = false,
-    ReadOnly = true,
-    Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunUpdateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunUpdateCommand.cs
@@ -27,7 +27,7 @@ public sealed class TestRunUpdateCommand(ILogger<TestRunUpdateCommand> logger)
         """;
     public override string Title => _commandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunUpdateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunUpdateCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.LoadTesting.Models.LoadTestRun;
 using AzureMcp.LoadTesting.Options.LoadTestRun;
@@ -25,6 +26,9 @@ public sealed class TestRunUpdateCommand(ILogger<TestRunUpdateCommand> logger)
         and identification of test runs without affecting the actual test execution or results.
         """;
     public override string Title => _commandTitle;
+
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -44,10 +48,6 @@ public sealed class TestRunUpdateCommand(ILogger<TestRunUpdateCommand> logger)
         return options;
     }
 
-    [McpServerTool(
-    Destructive = false,
-    ReadOnly = true,
-    Title = _commandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/marketplace/src/AzureMcp.Marketplace/Commands/Product/ProductGetCommand.cs
+++ b/areas/marketplace/src/AzureMcp.Marketplace/Commands/Product/ProductGetCommand.cs
@@ -58,7 +58,7 @@ public sealed class ProductGetCommand(ILogger<ProductGetCommand> logger) : Subsc
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/marketplace/src/AzureMcp.Marketplace/Commands/Product/ProductGetCommand.cs
+++ b/areas/marketplace/src/AzureMcp.Marketplace/Commands/Product/ProductGetCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.Marketplace.Models;
@@ -57,6 +58,8 @@ public sealed class ProductGetCommand(ILogger<ProductGetCommand> logger) : Subsc
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -88,10 +91,6 @@ public sealed class ProductGetCommand(ILogger<ProductGetCommand> logger) : Subsc
         return options;
     }
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/HealthModels/Entity/EntityGetHealthCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/HealthModels/Entity/EntityGetHealthCommand.cs
@@ -28,7 +28,7 @@ public sealed class EntityGetHealthCommand(ILogger<EntityGetHealthCommand> logge
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     private readonly ILogger<EntityGetHealthCommand> _logger = logger;
 

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/HealthModels/Entity/EntityGetHealthCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/HealthModels/Entity/EntityGetHealthCommand.cs
@@ -27,7 +27,7 @@ public sealed class EntityGetHealthCommand(ILogger<EntityGetHealthCommand> logge
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     private readonly ILogger<EntityGetHealthCommand> _logger = logger;

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/HealthModels/Entity/EntityGetHealthCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/HealthModels/Entity/EntityGetHealthCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Monitor.Options;
 using AzureMcp.Monitor.Options.HealthModels.Entity;
@@ -26,6 +27,8 @@ public sealed class EntityGetHealthCommand(ILogger<EntityGetHealthCommand> logge
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     private readonly ILogger<EntityGetHealthCommand> _logger = logger;
 
@@ -46,7 +49,6 @@ public sealed class EntityGetHealthCommand(ILogger<EntityGetHealthCommand> logge
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle, Name = CommandName)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Log/ResourceLogQueryCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Log/ResourceLogQueryCommand.cs
@@ -37,7 +37,7 @@ public sealed class ResourceLogQueryCommand(ILogger<ResourceLogQueryCommand> log
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Log/ResourceLogQueryCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Log/ResourceLogQueryCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Monitor.Options;
 using AzureMcp.Monitor.Services;
@@ -36,6 +37,8 @@ public sealed class ResourceLogQueryCommand(ILogger<ResourceLogQueryCommand> log
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -46,7 +49,6 @@ public sealed class ResourceLogQueryCommand(ILogger<ResourceLogQueryCommand> log
         command.AddOption(_limitOption);
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Log/WorkspaceLogQueryCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Log/WorkspaceLogQueryCommand.cs
@@ -31,7 +31,7 @@ public sealed class WorkspaceLogQueryCommand(ILogger<WorkspaceLogQueryCommand> l
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Log/WorkspaceLogQueryCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Log/WorkspaceLogQueryCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Monitor.Options;
 using AzureMcp.Monitor.Services;
@@ -30,6 +31,8 @@ public sealed class WorkspaceLogQueryCommand(ILogger<WorkspaceLogQueryCommand> l
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -40,7 +43,6 @@ public sealed class WorkspaceLogQueryCommand(ILogger<WorkspaceLogQueryCommand> l
         command.AddOption(_resourceGroupOption);
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsDefinitionsCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsDefinitionsCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Monitor.Commands;
 using AzureMcp.Monitor.Models;
 using AzureMcp.Monitor.Options;
@@ -39,6 +40,8 @@ public sealed class MetricsDefinitionsCommand(ILogger<MetricsDefinitionsCommand>
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -57,10 +60,6 @@ public sealed class MetricsDefinitionsCommand(ILogger<MetricsDefinitionsCommand>
         return options;
     }
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsDefinitionsCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsDefinitionsCommand.cs
@@ -41,7 +41,7 @@ public sealed class MetricsDefinitionsCommand(ILogger<MetricsDefinitionsCommand>
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsDefinitionsCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsDefinitionsCommand.cs
@@ -40,7 +40,7 @@ public sealed class MetricsDefinitionsCommand(ILogger<MetricsDefinitionsCommand>
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsQueryCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsQueryCommand.cs
@@ -51,6 +51,8 @@ public sealed class MetricsQueryCommand(ILogger<MetricsQueryCommand> logger)
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -105,10 +107,6 @@ public sealed class MetricsQueryCommand(ILogger<MetricsQueryCommand> logger)
         return result;
     }
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsQueryCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsQueryCommand.cs
@@ -51,7 +51,7 @@ public sealed class MetricsQueryCommand(ILogger<MetricsQueryCommand> logger)
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsQueryCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Metrics/MetricsQueryCommand.cs
@@ -52,7 +52,7 @@ public sealed class MetricsQueryCommand(ILogger<MetricsQueryCommand> logger)
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Table/TableListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Table/TableListCommand.cs
@@ -27,7 +27,7 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseMon
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Table/TableListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Table/TableListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Monitor.Commands;
@@ -26,6 +27,8 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseMon
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -33,7 +36,6 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseMon
         command.AddOption(_resourceGroupOption);
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/TableType/TableTypeListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/TableType/TableTypeListCommand.cs
@@ -22,7 +22,7 @@ public sealed class TableTypeListCommand(ILogger<TableTypeListCommand> logger) :
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/TableType/TableTypeListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/TableType/TableTypeListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Monitor.Commands;
 using AzureMcp.Monitor.Options.TableType;
@@ -21,6 +22,8 @@ public sealed class TableTypeListCommand(ILogger<TableTypeListCommand> logger) :
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -34,7 +37,6 @@ public sealed class TableTypeListCommand(ILogger<TableTypeListCommand> logger) :
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Workspace/WorkspaceListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Workspace/WorkspaceListCommand.cs
@@ -27,7 +27,7 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger) :
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Workspace/WorkspaceListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Workspace/WorkspaceListCommand.cs
@@ -28,7 +28,7 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger) :
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Workspace/WorkspaceListCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Workspace/WorkspaceListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Monitor.Commands;
@@ -26,8 +27,9 @@ public sealed class WorkspaceListCommand(ILogger<WorkspaceListCommand> logger) :
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Postgres.Commands;
 using AzureMcp.Postgres.Options.Database;
@@ -19,7 +20,8 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseListCommand.cs
@@ -20,7 +20,7 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseQueryCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseQueryCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Postgres.Commands;
 using AzureMcp.Postgres.Options;
@@ -20,6 +21,8 @@ public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) :
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -33,8 +36,6 @@ public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) :
         return options;
     }
 
-
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseQueryCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Database/DatabaseQueryCommand.cs
@@ -21,7 +21,7 @@ public sealed class DatabaseQueryCommand(ILogger<DatabaseQueryCommand> logger) :
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/GetConfigCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/GetConfigCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Postgres.Commands;
 using AzureMcp.Postgres.Options.Server;
@@ -18,7 +19,8 @@ public sealed class GetConfigCommand(ILogger<GetConfigCommand> logger) : BaseSer
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/GetConfigCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/GetConfigCommand.cs
@@ -19,7 +19,7 @@ public sealed class GetConfigCommand(ILogger<GetConfigCommand> logger) : BaseSer
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/GetParamCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/GetParamCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Postgres.Commands;
 using AzureMcp.Postgres.Options;
@@ -21,6 +22,8 @@ public sealed class GetParamCommand(ILogger<GetParamCommand> logger) : BaseServe
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -34,7 +37,6 @@ public sealed class GetParamCommand(ILogger<GetParamCommand> logger) : BaseServe
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/GetParamCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/GetParamCommand.cs
@@ -22,7 +22,7 @@ public sealed class GetParamCommand(ILogger<GetParamCommand> logger) : BaseServe
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/ServerListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/ServerListCommand.cs
@@ -21,7 +21,7 @@ public sealed class ServerListCommand(ILogger<ServerListCommand> logger) : BaseP
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/ServerListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/ServerListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Postgres.Commands;
 using AzureMcp.Postgres.Options.Server;
@@ -20,7 +21,8 @@ public sealed class ServerListCommand(ILogger<ServerListCommand> logger) : BaseP
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/SetParamCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/SetParamCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Postgres.Commands;
 using AzureMcp.Postgres.Options;
@@ -22,6 +23,8 @@ public sealed class SetParamCommand(ILogger<SetParamCommand> logger) : BaseServe
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -37,7 +40,6 @@ public sealed class SetParamCommand(ILogger<SetParamCommand> logger) : BaseServe
         return options;
     }
 
-    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Server/SetParamCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Server/SetParamCommand.cs
@@ -23,7 +23,7 @@ public sealed class SetParamCommand(ILogger<SetParamCommand> logger) : BaseServe
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = true, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Table/GetSchemaCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Table/GetSchemaCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Postgres.Commands;
 using AzureMcp.Postgres.Options;
@@ -19,6 +20,8 @@ public sealed class GetSchemaCommand(ILogger<GetSchemaCommand> logger) : BaseDat
     public override string Description => "Retrieves the schema of a specified table in a PostgreSQL database.";
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -32,7 +35,6 @@ public sealed class GetSchemaCommand(ILogger<GetSchemaCommand> logger) : BaseDat
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Table/GetSchemaCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Table/GetSchemaCommand.cs
@@ -20,7 +20,7 @@ public sealed class GetSchemaCommand(ILogger<GetSchemaCommand> logger) : BaseDat
     public override string Description => "Retrieves the schema of a specified table in a PostgreSQL database.";
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Table/TableListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Table/TableListCommand.cs
@@ -19,7 +19,7 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseDat
     public override string Description => "Lists all tables in the PostgreSQL database.";
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/postgres/src/AzureMcp.Postgres/Commands/Table/TableListCommand.cs
+++ b/areas/postgres/src/AzureMcp.Postgres/Commands/Table/TableListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Postgres.Commands;
 using AzureMcp.Postgres.Options.Table;
@@ -18,7 +19,8 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseDat
     public override string Description => "Lists all tables in the PostgreSQL database.";
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/AccessPolicyListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/AccessPolicyListCommand.cs
@@ -28,7 +28,7 @@ public sealed class AccessPolicyListCommand(ILogger<AccessPolicyListCommand> log
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/AccessPolicyListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/AccessPolicyListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Redis.Commands;
 using AzureMcp.Redis.Models.CacheForRedis;
@@ -27,7 +28,8 @@ public sealed class AccessPolicyListCommand(ILogger<AccessPolicyListCommand> log
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/CacheListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/CacheListCommand.cs
@@ -30,7 +30,7 @@ public sealed class CacheListCommand(ILogger<CacheListCommand> logger) : Subscri
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/CacheListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/CacheForRedis/CacheListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Redis.Commands;
@@ -29,7 +30,8 @@ public sealed class CacheListCommand(ILogger<CacheListCommand> logger) : Subscri
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/ClusterListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/ClusterListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Redis.Commands;
@@ -28,7 +29,8 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Sub
         """;
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/ClusterListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/ClusterListCommand.cs
@@ -29,7 +29,7 @@ public sealed class ClusterListCommand(ILogger<ClusterListCommand> logger) : Sub
         """;
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/DatabaseListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/DatabaseListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Redis.Commands;
 using AzureMcp.Redis.Models.ManagedRedis;
@@ -27,7 +28,8 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
         """;
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/DatabaseListCommand.cs
+++ b/areas/redis/src/AzureMcp.Redis/Commands/ManagedRedis/DatabaseListCommand.cs
@@ -28,7 +28,7 @@ public sealed class DatabaseListCommand(ILogger<DatabaseListCommand> logger) : B
         """;
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexDescribeCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexDescribeCommand.cs
@@ -32,7 +32,7 @@ public sealed class IndexDescribeCommand(ILogger<IndexDescribeCommand> logger) :
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexDescribeCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexDescribeCommand.cs
@@ -31,7 +31,7 @@ public sealed class IndexDescribeCommand(ILogger<IndexDescribeCommand> logger) :
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexDescribeCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexDescribeCommand.cs
@@ -31,6 +31,8 @@ public sealed class IndexDescribeCommand(ILogger<IndexDescribeCommand> logger) :
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -47,7 +49,6 @@ public sealed class IndexDescribeCommand(ILogger<IndexDescribeCommand> logger) :
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexListCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexListCommand.cs
@@ -26,7 +26,7 @@ public sealed class IndexListCommand(ILogger<IndexListCommand> logger) : GlobalC
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexListCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexListCommand.cs
@@ -26,6 +26,8 @@ public sealed class IndexListCommand(ILogger<IndexListCommand> logger) : GlobalC
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -40,7 +42,6 @@ public sealed class IndexListCommand(ILogger<IndexListCommand> logger) : GlobalC
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexListCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexListCommand.cs
@@ -27,7 +27,7 @@ public sealed class IndexListCommand(ILogger<IndexListCommand> logger) : GlobalC
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexQueryCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexQueryCommand.cs
@@ -30,7 +30,7 @@ public sealed class IndexQueryCommand(ILogger<IndexQueryCommand> logger) : Globa
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexQueryCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexQueryCommand.cs
@@ -30,6 +30,8 @@ public sealed class IndexQueryCommand(ILogger<IndexQueryCommand> logger) : Globa
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
     protected override void RegisterOptions(Command command)
     {
@@ -48,7 +50,6 @@ public sealed class IndexQueryCommand(ILogger<IndexQueryCommand> logger) : Globa
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/search/src/AzureMcp.Search/Commands/Index/IndexQueryCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Index/IndexQueryCommand.cs
@@ -31,7 +31,7 @@ public sealed class IndexQueryCommand(ILogger<IndexQueryCommand> logger) : Globa
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/search/src/AzureMcp.Search/Commands/Service/ServiceListCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Service/ServiceListCommand.cs
@@ -26,7 +26,7 @@ public sealed class ServiceListCommand(ILogger<ServiceListCommand> logger) : Sub
         """;
 
     public override string Title => CommandTitle;
-    
+
     public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)

--- a/areas/search/src/AzureMcp.Search/Commands/Service/ServiceListCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Service/ServiceListCommand.cs
@@ -27,7 +27,7 @@ public sealed class ServiceListCommand(ILogger<ServiceListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
     
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/search/src/AzureMcp.Search/Commands/Service/ServiceListCommand.cs
+++ b/areas/search/src/AzureMcp.Search/Commands/Service/ServiceListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Search.Options.Service;
@@ -25,8 +26,9 @@ public sealed class ServiceListCommand(ILogger<ServiceListCommand> logger) : Sub
         """;
 
     public override string Title => CommandTitle;
+    
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueueDetailsCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueueDetailsCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Messaging.ServiceBus;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.ServiceBus.Commands;
@@ -32,6 +33,8 @@ public sealed class QueueDetailsCommand : SubscriptionCommand<BaseQueueOptions>
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -47,7 +50,6 @@ public sealed class QueueDetailsCommand : SubscriptionCommand<BaseQueueOptions>
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueueDetailsCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueueDetailsCommand.cs
@@ -33,7 +33,7 @@ public sealed class QueueDetailsCommand : SubscriptionCommand<BaseQueueOptions>
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueuePeekCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueuePeekCommand.cs
@@ -36,7 +36,7 @@ public sealed class QueuePeekCommand : SubscriptionCommand<QueuePeekOptions>
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueuePeekCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueuePeekCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Messaging.ServiceBus;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.ServiceBus.Commands;
@@ -35,6 +36,8 @@ public sealed class QueuePeekCommand : SubscriptionCommand<QueuePeekOptions>
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -53,7 +56,6 @@ public sealed class QueuePeekCommand : SubscriptionCommand<QueuePeekOptions>
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionDetailsCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionDetailsCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Messaging.ServiceBus;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.ServiceBus.Commands;
@@ -33,6 +34,8 @@ public sealed class SubscriptionDetailsCommand : SubscriptionCommand<Subscriptio
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -52,7 +55,6 @@ public sealed class SubscriptionDetailsCommand : SubscriptionCommand<Subscriptio
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionDetailsCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionDetailsCommand.cs
@@ -34,7 +34,7 @@ public sealed class SubscriptionDetailsCommand : SubscriptionCommand<Subscriptio
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionPeekCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionPeekCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Messaging.ServiceBus;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.ServiceBus.Commands;
@@ -37,6 +38,8 @@ public sealed class SubscriptionPeekCommand : SubscriptionCommand<SubscriptionPe
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -56,7 +59,6 @@ public sealed class SubscriptionPeekCommand : SubscriptionCommand<SubscriptionPe
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionPeekCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionPeekCommand.cs
@@ -38,7 +38,7 @@ public sealed class SubscriptionPeekCommand : SubscriptionCommand<SubscriptionPe
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/TopicDetailsCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/TopicDetailsCommand.cs
@@ -33,7 +33,7 @@ public sealed class TopicDetailsCommand : SubscriptionCommand<BaseTopicOptions>
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/TopicDetailsCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/TopicDetailsCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Messaging.ServiceBus;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.ServiceBus.Commands;
@@ -32,6 +33,8 @@ public sealed class TopicDetailsCommand : SubscriptionCommand<BaseTopicOptions>
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -49,7 +52,6 @@ public sealed class TopicDetailsCommand : SubscriptionCommand<BaseTopicOptions>
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/sql/src/AzureMcp.Sql/Commands/Database/DatabaseShowCommand.cs
+++ b/areas/sql/src/AzureMcp.Sql/Commands/Database/DatabaseShowCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Sql.Models;
 using AzureMcp.Sql.Options.Database;
@@ -30,10 +31,8 @@ public sealed class DatabaseShowCommand(ILogger<DatabaseShowCommand> logger)
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/sql/src/AzureMcp.Sql/Commands/Database/DatabaseShowCommand.cs
+++ b/areas/sql/src/AzureMcp.Sql/Commands/Database/DatabaseShowCommand.cs
@@ -31,7 +31,7 @@ public sealed class DatabaseShowCommand(ILogger<DatabaseShowCommand> logger)
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/sql/src/AzureMcp.Sql/Commands/ElasticPool/ElasticPoolListCommand.cs
+++ b/areas/sql/src/AzureMcp.Sql/Commands/ElasticPool/ElasticPoolListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Sql.Models;
 using AzureMcp.Sql.Options.ElasticPool;
@@ -28,10 +29,8 @@ public sealed class ElasticPoolListCommand(ILogger<ElasticPoolListCommand> logge
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/sql/src/AzureMcp.Sql/Commands/ElasticPool/ElasticPoolListCommand.cs
+++ b/areas/sql/src/AzureMcp.Sql/Commands/ElasticPool/ElasticPoolListCommand.cs
@@ -29,7 +29,7 @@ public sealed class ElasticPoolListCommand(ILogger<ElasticPoolListCommand> logge
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/sql/src/AzureMcp.Sql/Commands/EntraAdmin/EntraAdminListCommand.cs
+++ b/areas/sql/src/AzureMcp.Sql/Commands/EntraAdmin/EntraAdminListCommand.cs
@@ -26,7 +26,7 @@ public sealed class EntraAdminListCommand(ILogger<EntraAdminListCommand> logger)
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/sql/src/AzureMcp.Sql/Commands/EntraAdmin/EntraAdminListCommand.cs
+++ b/areas/sql/src/AzureMcp.Sql/Commands/EntraAdmin/EntraAdminListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Sql.Models;
 using AzureMcp.Sql.Options.EntraAdmin;
@@ -25,10 +26,8 @@ public sealed class EntraAdminListCommand(ILogger<EntraAdminListCommand> logger)
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/sql/src/AzureMcp.Sql/Commands/FirewallRule/FirewallRuleListCommand.cs
+++ b/areas/sql/src/AzureMcp.Sql/Commands/FirewallRule/FirewallRuleListCommand.cs
@@ -26,7 +26,7 @@ public sealed class FirewallRuleListCommand(ILogger<FirewallRuleListCommand> log
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/sql/src/AzureMcp.Sql/Commands/FirewallRule/FirewallRuleListCommand.cs
+++ b/areas/sql/src/AzureMcp.Sql/Commands/FirewallRule/FirewallRuleListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Sql.Models;
 using AzureMcp.Sql.Options.FirewallRule;
@@ -25,10 +26,8 @@ public sealed class FirewallRuleListCommand(ILogger<FirewallRuleListCommand> log
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(
-        Destructive = false,
-        ReadOnly = true,
-        Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/storage/src/AzureMcp.Storage/Commands/Account/AccountListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Account/AccountListCommand.cs
@@ -28,7 +28,7 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Account/AccountListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Account/AccountListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.Core.Services.Telemetry;
@@ -27,7 +28,8 @@ public sealed class AccountListCommand(ILogger<AccountListCommand> logger) : Sub
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/BlobListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/BlobListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Storage.Commands;
 using AzureMcp.Storage.Commands.Blob.Container;
@@ -28,7 +29,8 @@ public sealed class BlobListCommand(ILogger<BlobListCommand> logger) : BaseConta
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/BlobListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/BlobListCommand.cs
@@ -29,7 +29,7 @@ public sealed class BlobListCommand(ILogger<BlobListCommand> logger) : BaseConta
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerDetailsCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerDetailsCommand.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization;
 using Azure.Storage.Blobs.Models;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Storage.Commands;
 using AzureMcp.Storage.Options;
@@ -27,7 +28,8 @@ public sealed class ContainerDetailsCommand(ILogger<ContainerDetailsCommand> log
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerDetailsCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerDetailsCommand.cs
@@ -28,7 +28,7 @@ public sealed class ContainerDetailsCommand(ILogger<ContainerDetailsCommand> log
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerListCommand.cs
@@ -27,7 +27,7 @@ public sealed class ContainerListCommand(ILogger<ContainerListCommand> logger) :
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/Container/ContainerListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Storage.Commands;
 using AzureMcp.Storage.Options;
@@ -26,7 +27,8 @@ public sealed class ContainerListCommand(ILogger<ContainerListCommand> logger) :
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/storage/src/AzureMcp.Storage/Commands/DataLake/Directory/DirectoryCreateCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/DataLake/Directory/DirectoryCreateCommand.cs
@@ -31,7 +31,7 @@ public sealed class DirectoryCreateCommand(ILogger<DirectoryCreateCommand> logge
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/storage/src/AzureMcp.Storage/Commands/DataLake/Directory/DirectoryCreateCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/DataLake/Directory/DirectoryCreateCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Storage.Models;
 using AzureMcp.Storage.Options;
@@ -30,6 +31,8 @@ public sealed class DirectoryCreateCommand(ILogger<DirectoryCreateCommand> logge
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -43,7 +46,6 @@ public sealed class DirectoryCreateCommand(ILogger<DirectoryCreateCommand> logge
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/storage/src/AzureMcp.Storage/Commands/DataLake/FileSystem/FileSystemListPathsCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/DataLake/FileSystem/FileSystemListPathsCommand.cs
@@ -27,7 +27,7 @@ public sealed class FileSystemListPathsCommand(ILogger<FileSystemListPathsComman
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/storage/src/AzureMcp.Storage/Commands/DataLake/FileSystem/FileSystemListPathsCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/DataLake/FileSystem/FileSystemListPathsCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Storage.Commands;
 using AzureMcp.Storage.Models;
@@ -26,7 +27,8 @@ public sealed class FileSystemListPathsCommand(ILogger<FileSystemListPathsComman
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/storage/src/AzureMcp.Storage/Commands/Table/TableListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Table/TableListCommand.cs
@@ -26,7 +26,7 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseSto
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/areas/storage/src/AzureMcp.Storage/Commands/Table/TableListCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Table/TableListCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Telemetry;
 using AzureMcp.Storage.Commands;
 using AzureMcp.Storage.Options.Table;
@@ -25,7 +26,8 @@ public sealed class TableListCommand(ILogger<TableListCommand> logger) : BaseSto
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/CreateWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/CreateWorkbooksCommand.cs
@@ -31,7 +31,7 @@ public sealed class CreateWorkbooksCommand(ILogger<CreateWorkbooksCommand> logge
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/CreateWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/CreateWorkbooksCommand.cs
@@ -31,6 +31,8 @@ public sealed class CreateWorkbooksCommand(ILogger<CreateWorkbooksCommand> logge
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -50,7 +52,6 @@ public sealed class CreateWorkbooksCommand(ILogger<CreateWorkbooksCommand> logge
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/DeleteWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/DeleteWorkbooksCommand.cs
@@ -29,6 +29,8 @@ public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logge
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -42,7 +44,6 @@ public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logge
         return options;
     }
 
-    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/DeleteWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/DeleteWorkbooksCommand.cs
@@ -29,7 +29,7 @@ public sealed class DeleteWorkbooksCommand(ILogger<DeleteWorkbooksCommand> logge
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = true, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/ListWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/ListWorkbooksCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Workbooks.Models;
 using AzureMcp.Workbooks.Options;
@@ -30,6 +31,8 @@ public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger) :
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -49,7 +52,6 @@ public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger) :
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/ListWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/ListWorkbooksCommand.cs
@@ -31,7 +31,7 @@ public sealed class ListWorkbooksCommand(ILogger<ListWorkbooksCommand> logger) :
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/ShowWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/ShowWorkbooksCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Workbooks.Models;
 using AzureMcp.Workbooks.Options;
 using AzureMcp.Workbooks.Options.Workbook;
@@ -26,6 +27,8 @@ public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger) :
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -39,7 +42,6 @@ public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger) :
         return options;
     }
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/ShowWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/ShowWorkbooksCommand.cs
@@ -27,7 +27,7 @@ public sealed class ShowWorkbooksCommand(ILogger<ShowWorkbooksCommand> logger) :
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     protected override void RegisterOptions(Command command)
     {

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/UpdateWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/UpdateWorkbooksCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AzureMcp.Core.Commands;
 using AzureMcp.Workbooks.Models;
 using AzureMcp.Workbooks.Options;
 using AzureMcp.Workbooks.Options.Workbook;
@@ -28,6 +29,8 @@ public sealed class UpdateWorkbooksCommand(ILogger<UpdateWorkbooksCommand> logge
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -45,7 +48,6 @@ public sealed class UpdateWorkbooksCommand(ILogger<UpdateWorkbooksCommand> logge
         return options;
     }
 
-    [McpServerTool(Destructive = true, ReadOnly = false, Title = CommandTitle)]
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/UpdateWorkbooksCommand.cs
+++ b/areas/workbooks/src/AzureMcp.Workbooks/Commands/Workbooks/UpdateWorkbooksCommand.cs
@@ -29,7 +29,7 @@ public sealed class UpdateWorkbooksCommand(ILogger<UpdateWorkbooksCommand> logge
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: true, readOnly: false);
+    public override ToolMetadata Metadata => new() { Destructive = true, ReadOnly = false };
 
     protected override void RegisterOptions(Command command)
     {

--- a/core/src/AzureMcp.Core/Areas/Group/Commands/GroupListCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Group/Commands/GroupListCommand.cs
@@ -28,7 +28,7 @@ public sealed class GroupListCommand(ILogger<GroupListCommand> logger) : Subscri
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/core/src/AzureMcp.Core/Areas/Group/Commands/GroupListCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Group/Commands/GroupListCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using AzureMcp.Core.Areas.Group.Options;
+using AzureMcp.Core.Commands;
 using AzureMcp.Core.Commands.Subscription;
 using AzureMcp.Core.Models.Option;
 using AzureMcp.Core.Models.ResourceGroup;
@@ -27,7 +28,8 @@ public sealed class GroupListCommand(ILogger<GroupListCommand> logger) : Subscri
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/core/src/AzureMcp.Core/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Server/Commands/ServiceStartCommand.cs
@@ -40,6 +40,11 @@ public sealed class ServiceStartCommand : BaseCommand
     /// </summary>
     public override string Title => CommandTitle;
 
+    /// <summary>
+    /// Gets the metadata for this command.
+    /// </summary>
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public static Action<IServiceCollection> ConfigureServices { get; set; } = _ => { };
 
     /// <summary>

--- a/core/src/AzureMcp.Core/Areas/Server/Commands/ServiceStartCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Server/Commands/ServiceStartCommand.cs
@@ -43,7 +43,7 @@ public sealed class ServiceStartCommand : BaseCommand
     /// <summary>
     /// Gets the metadata for this command.
     /// </summary>
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public static Action<IServiceCollection> ConfigureServices { get; set; } = _ => { };
 

--- a/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
-using System.Reflection;
 using AzureMcp.Core.Areas.Server;
 using AzureMcp.Core.Areas.Server.Models;
 using AzureMcp.Core.Areas.Server.Options;
@@ -153,19 +152,16 @@ public sealed class CommandFactoryToolLoader(
             Description = underlyingCommand.Description,
         };
 
-        // Get the ExecuteAsync method info to check for McpServerToolAttribute
-        var executeAsyncMethod = command.GetType().GetMethod(nameof(IBaseCommand.ExecuteAsync));
-        if (executeAsyncMethod?.GetCustomAttribute<McpServerToolAttribute>() is { } mcpServerToolAttr)
+        // Get tool metadata from the command's Metadata property
+        var metadata = command.Metadata;
+        tool.Annotations = new ToolAnnotations()
         {
-            tool.Annotations = new ToolAnnotations()
-            {
-                DestructiveHint = mcpServerToolAttr.Destructive,
-                IdempotentHint = mcpServerToolAttr.Idempotent,
-                OpenWorldHint = mcpServerToolAttr.OpenWorld,
-                ReadOnlyHint = mcpServerToolAttr.ReadOnly,
-                Title = mcpServerToolAttr.Title,
-            };
-        }
+            DestructiveHint = metadata.Destructive,
+            IdempotentHint = metadata.Idempotent,
+            OpenWorldHint = metadata.OpenWorld,
+            ReadOnlyHint = metadata.ReadOnly,
+            Title = command.Title,
+        };
 
         var options = command.GetCommand().Options;
 

--- a/core/src/AzureMcp.Core/Areas/Subscription/Commands/SubscriptionListCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Subscription/Commands/SubscriptionListCommand.cs
@@ -25,7 +25,7 @@ public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> log
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/core/src/AzureMcp.Core/Areas/Subscription/Commands/SubscriptionListCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Subscription/Commands/SubscriptionListCommand.cs
@@ -25,7 +25,8 @@ public sealed class SubscriptionListCommand(ILogger<SubscriptionListCommand> log
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);

--- a/core/src/AzureMcp.Core/Areas/Tools/Commands/ToolsListCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Tools/Commands/ToolsListCommand.cs
@@ -23,7 +23,7 @@ public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger) : BaseCom
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
 
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {

--- a/core/src/AzureMcp.Core/Areas/Tools/Commands/ToolsListCommand.cs
+++ b/core/src/AzureMcp.Core/Areas/Tools/Commands/ToolsListCommand.cs
@@ -23,7 +23,8 @@ public sealed class ToolsListCommand(ILogger<ToolsListCommand> logger) : BaseCom
 
     public override string Title => CommandTitle;
 
-    [McpServerTool(Destructive = false, ReadOnly = true, Title = CommandTitle)]
+    public override ToolMetadata Metadata => new(destructive: false, readOnly: true);
+
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         try

--- a/core/src/AzureMcp.Core/Commands/BaseCommand.cs
+++ b/core/src/AzureMcp.Core/Commands/BaseCommand.cs
@@ -22,6 +22,7 @@ public abstract class BaseCommand : IBaseCommand
     public abstract string Name { get; }
     public abstract string Description { get; }
     public abstract string Title { get; }
+    public abstract ToolMetadata Metadata { get; }
 
     protected virtual void RegisterOptions(Command command)
     {

--- a/core/src/AzureMcp.Core/Commands/IBaseCommand.cs
+++ b/core/src/AzureMcp.Core/Commands/IBaseCommand.cs
@@ -27,6 +27,12 @@ public interface IBaseCommand
     string Title { get; }
 
     /// <summary>
+    /// Gets metadata about an MCP tool describing its behavioral characteristics.
+    /// This metadata helps MCP clients understand how the tool operates and its potential effects.
+    /// </summary>
+    ToolMetadata Metadata { get; }
+
+    /// <summary>
     /// Gets the command definition
     /// </summary>
     Command GetCommand();

--- a/core/src/AzureMcp.Core/Commands/ToolMetadata.cs
+++ b/core/src/AzureMcp.Core/Commands/ToolMetadata.cs
@@ -77,19 +77,4 @@ public sealed class ToolMetadata
     public ToolMetadata()
     {
     }
-
-    /// <summary>
-    /// Creates a new instance of <see cref="ToolMetadata"/> with the specified values.
-    /// </summary>
-    /// <param name="destructive">Whether the command performs destructive operations.</param>
-    /// <param name="readOnly">Whether the command only performs read operations.</param>
-    /// <param name="idempotent">Whether the command is idempotent.</param>
-    /// <param name="openWorld">Whether the command operates in an open world context.</param>
-    public ToolMetadata(bool destructive = true, bool readOnly = false, bool idempotent = false, bool openWorld = true)
-    {
-        Destructive = destructive;
-        ReadOnly = readOnly;
-        Idempotent = idempotent;
-        OpenWorld = openWorld;
-    }
 }

--- a/core/src/AzureMcp.Core/Commands/ToolMetadata.cs
+++ b/core/src/AzureMcp.Core/Commands/ToolMetadata.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Core.Commands;
+
+/// <summary>
+/// Provides metadata about an MCP tool describing its behavioral characteristics.
+/// This metadata helps MCP clients understand how the tool operates and its potential effects.
+/// </summary>
+public sealed class ToolMetadata
+{
+    /// <summary>
+    /// Gets or sets whether the tool may perform destructive updates to its environment.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If <see langword="true"/>, the tool may perform destructive updates to its environment.
+    /// If <see langword="false"/>, the tool performs only additive updates.
+    /// This property is most relevant when the tool modifies its environment (ReadOnly = false).
+    /// </para>
+    /// <para>
+    /// The default is <see langword="true"/>.
+    /// </para>
+    /// </remarks>
+    public bool Destructive { get; init; } = true;
+
+    /// <summary>
+    /// Gets or sets whether calling the tool repeatedly with the same arguments 
+    /// will have no additional effect on its environment.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property is most relevant when the tool modifies its environment (ReadOnly = false).
+    /// </para>
+    /// <para>
+    /// The default is <see langword="false"/>.
+    /// </para>
+    /// </remarks>
+    public bool Idempotent { get; init; } = false;
+
+    /// <summary>
+    /// Gets or sets whether this tool may interact with an "open world" of external entities.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If <see langword="true"/>, the tool may interact with an unpredictable or dynamic set of entities (like web search).
+    /// If <see langword="false"/>, the tool's domain of interaction is closed and well-defined (like memory access).
+    /// </para>
+    /// <para>
+    /// The default is <see langword="true"/>.
+    /// </para>
+    /// </remarks>
+    public bool OpenWorld { get; init; } = true;
+
+    /// <summary>
+    /// Gets or sets whether this tool does not modify its environment.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If <see langword="true"/>, the tool only performs read operations without changing state.
+    /// If <see langword="false"/>, the tool may make modifications to its environment.
+    /// </para>
+    /// <para>
+    /// Read-only tools do not have side effects beyond computational resource usage.
+    /// They don't create, update, or delete data in any system.
+    /// </para>
+    /// <para>
+    /// The default is <see langword="false"/>.
+    /// </para>
+    /// </remarks>
+    public bool ReadOnly { get; init; } = false;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ToolMetadata"/> with default values.
+    /// All properties default to their MCP specification defaults.
+    /// </summary>
+    public ToolMetadata()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ToolMetadata"/> with the specified values.
+    /// </summary>
+    /// <param name="destructive">Whether the command performs destructive operations.</param>
+    /// <param name="readOnly">Whether the command only performs read operations.</param>
+    /// <param name="idempotent">Whether the command is idempotent.</param>
+    /// <param name="openWorld">Whether the command operates in an open world context.</param>
+    public ToolMetadata(bool destructive = true, bool readOnly = false, bool idempotent = false, bool openWorld = true)
+    {
+        Destructive = destructive;
+        ReadOnly = readOnly;
+        Idempotent = idempotent;
+        OpenWorld = openWorld;
+    }
+}

--- a/docs/new-command.md
+++ b/docs/new-command.md
@@ -210,11 +210,11 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
 
     public override string Title => CommandTitle;
 
-    public override ToolMetadata Metadata => new(
-        destructive: false,     // Set to true for commands that modify resources
-        readOnly: true,         // Set to false for commands that modify resources  
-        idempotent: false,      // Set to true if calling repeatedly has no additional effect
-        openWorld: true);       // Set to false for closed/well-defined interactions
+    public override ToolMetadata Metadata => new()
+    {
+        Destructive = false,    // Set to true for commands that modify resources
+        ReadOnly = true         // Set to false for commands that modify resources  
+    };
 
     protected override void RegisterOptions(Command command)
     {

--- a/docs/new-command.md
+++ b/docs/new-command.md
@@ -45,7 +45,7 @@ This keeps all code, options, models, and tests for an area together. See `areas
    - Classes are always sealed unless explicitly intended for inheritance
    - Commands inheriting from SubscriptionCommand must handle subscription parameters
    - Service-specific base commands should add service-wide options
-   - Commands are marked with [McpServerTool] attribute to define their characteristics
+   - Commands return `ToolMetadata` property to define their behavioral characteristics
 
 3. **Command Pattern**
    Commands follow the Model-Context-Protocol (MCP) pattern with this naming convention:
@@ -210,6 +210,12 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
 
     public override string Title => CommandTitle;
 
+    public override ToolMetadata Metadata => new(
+        destructive: false,     // Set to true for commands that modify resources
+        readOnly: true,         // Set to false for commands that modify resources  
+        idempotent: false,      // Set to true if calling repeatedly has no additional effect
+        openWorld: true);       // Set to false for closed/well-defined interactions
+
     protected override void RegisterOptions(Command command)
     {
         base.RegisterOptions(command);
@@ -223,10 +229,6 @@ public sealed class {Resource}{Operation}Command(ILogger<{Resource}{Operation}Co
         return options;
     }
 
-    [McpServerTool(
-        Destructive = false,     // Set to true for commands that modify resources
-        ReadOnly = true,        // Set to false for commands that modify resources
-        Title = CommandTitle)]  // Display name shown in UI
     public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
     {
         var options = BindOptions(parseResult);


### PR DESCRIPTION
## What does this PR do?

This PR replaces the use `McpServerTool` decorator from `ModelContextProtocol.Server` with a new `ToolMetadata` type in AzureMcp.

1. the `McpServerTool` instances are inspected by the MCP C# SDK only if the SDK is instructed to discover tools from the Assembly with `WithToolsFromAssembly()` API ([documentation](https://devblogs.microsoft.com/dotnet/build-a-model-context-protocol-mcp-server-in-csharp/)).
2. Instead of `WithToolsFromAssembly()` approach, the Azure MCP server uses handler approach, where it registers `ToolListHandler` and `ToolCallHandler` with C# MCP SDK so tools are discoverable and callable from the MCP SDK.
3. Without `WithToolsFromAssembly()`, the use of `McpServerTool` decorator is noise.
4. The Azure MCP server’s `ToolListHandler` currently uses reflection to obtain tool characteristics from this decorator. However, this process can be streamlined, and reflection can be removed, by defining an appropriate metadata type, `ToolMetadata ` within the azmcp namespace and using it in command classes.
5. Soon, we need to define certain internal only attributes for the tool for categorization and filtering purposes. Using `ToolMetadata` local to azmcp namespace will make this process easier.

## GitHub issue number?

## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes, updated:
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
