### PR TITLE
Telemetry fixes for ToolName and passing context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Bugs Fixed
 
+- Fixed `ToolExecuted` telemetry activity being created twice. [[#741](https://github.com/Azure/azure-mcp/pull/741)]
+
 ### Other Changes
 
 ## 0.5.3 (2025-08-05)

--- a/core/src/AzureMcp.Cli/Program.cs
+++ b/core/src/AzureMcp.Cli/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.CommandLine.Builder;
+using System.Diagnostics;
 using AzureMcp.Core.Areas;
 using AzureMcp.Core.Commands;
 using AzureMcp.Core.Services.Azure.ResourceGroup;
@@ -95,7 +96,7 @@ internal class Program
 
         builder.AddMiddleware(async (context, next) =>
         {
-            var commandContext = new CommandContext(serviceProvider);
+            var commandContext = new CommandContext(serviceProvider, Activity.Current);
             var command = context.ParseResult.CommandResult.Command;
             if (command.Handler is IBaseCommand baseCommand)
             {

--- a/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using AzureMcp.Core.Areas.Server.Models;
 using AzureMcp.Core.Commands;
 using Microsoft.Extensions.Logging;
@@ -84,7 +85,7 @@ public sealed class CommandFactoryToolLoader(
                 IsError = true,
             };
         }
-        var commandContext = new CommandContext(_serviceProvider);
+        var commandContext = new CommandContext(_serviceProvider, Activity.Current);
 
         var realCommand = command.GetCommand();
         var commandOptions = realCommand.ParseFromDictionary(request.Params.Arguments);

--- a/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
+++ b/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoader.cs
@@ -1,18 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
-using System.Text.Json.Serialization.Metadata;
-using AzureMcp.Core.Areas.Server;
 using AzureMcp.Core.Areas.Server.Models;
-using AzureMcp.Core.Areas.Server.Options;
 using AzureMcp.Core.Commands;
-using AzureMcp.Core.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
-using static AzureMcp.Core.Services.Telemetry.TelemetryConstants;
 
 namespace AzureMcp.Core.Areas.Server.Commands.ToolLoading;
 
@@ -24,13 +17,10 @@ public sealed class CommandFactoryToolLoader(
     IServiceProvider serviceProvider,
     CommandFactory commandFactory,
     IOptions<ToolLoaderOptions> options,
-    ITelemetryService telemetry,
     ILogger<CommandFactoryToolLoader> logger) : IToolLoader
 {
     private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-    private readonly CommandFactory _commandFactory = commandFactory ?? throw new ArgumentNullException(nameof(commandFactory));
     private readonly IOptions<ToolLoaderOptions> _options = options;
-    private readonly ITelemetryService _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
     private IReadOnlyDictionary<string, IBaseCommand> _toolCommands =
         (options.Value.Namespace == null || options.Value.Namespace.Length == 0)
             ? commandFactory.AllCommands
@@ -65,16 +55,12 @@ public sealed class CommandFactoryToolLoader(
     /// <returns>The result of the tool call operation.</returns>
     public async ValueTask<CallToolResult> CallToolHandler(RequestContext<CallToolRequestParams> request, CancellationToken cancellationToken)
     {
-        using var activity = await _telemetry.StartActivity(ActivityName.ToolExecuted, request.Server.ClientInfo);
-
         if (request.Params == null)
         {
             var content = new TextContentBlock
             {
                 Text = "Cannot call tools with null parameters.",
             };
-
-            activity?.SetStatus(ActivityStatusCode.Error)?.AddTag(TagName.ErrorDetails, content.Text);
 
             return new CallToolResult
             {
@@ -84,8 +70,6 @@ public sealed class CommandFactoryToolLoader(
         }
 
         var toolName = request.Params.Name;
-        activity?.AddTag(TagName.ToolName, toolName);
-
         var command = _toolCommands.GetValueOrDefault(toolName);
         if (command == null)
         {
@@ -93,8 +77,6 @@ public sealed class CommandFactoryToolLoader(
             {
                 Text = $"Could not find command: {request.Params.Name}",
             };
-
-            activity?.SetStatus(ActivityStatusCode.Error)?.AddTag(TagName.ErrorDetails, content.Text);
 
             return new CallToolResult
             {
@@ -128,7 +110,6 @@ public sealed class CommandFactoryToolLoader(
         catch (Exception ex)
         {
             _logger.LogError(ex, "An exception occurred running '{Tool}'. ", realCommand.Name);
-            activity?.SetStatus(ActivityStatusCode.Error)?.AddTag(TagName.ErrorDetails, ex.Message);
 
             throw;
         }

--- a/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/CompositeToolLoader.cs
+++ b/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/CompositeToolLoader.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Threading;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
 
 namespace AzureMcp.Core.Areas.Server.Commands.ToolLoading;
 

--- a/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/IToolLoader.cs
+++ b/core/src/AzureMcp.Core/Areas/Server/Commands/ToolLoading/IToolLoader.cs
@@ -20,8 +20,9 @@ public interface IToolLoader : IAsyncDisposable
     ValueTask<ListToolsResult> ListToolsHandler(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Handles requests to call a specific tool with the provided parameters.
-    /// </summary>
+    /// Handles requests to call a specific tool with the provided parameters.  If an error occurs while calling the
+    /// tool, loaders should return a <see cref="TextContentBlock"/> where the contents are details of the exception.
+    ///
     /// <param name="request">The request context containing the tool name and parameters.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A result containing the output of the tool invocation.</returns>

--- a/core/src/AzureMcp.Core/Services/Telemetry/TelemetryConstants.cs
+++ b/core/src/AzureMcp.Core/Services/Telemetry/TelemetryConstants.cs
@@ -25,6 +25,7 @@ internal static class TelemetryConstants
     internal class ActivityName
     {
         public const string CommandExecuted = "CommandExecuted";
+        public const string ListToolsHandler = "ListToolsHandler";
         public const string ToolExecuted = "ToolExecuted";
     }
 }

--- a/core/tests/AzureMcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
+++ b/core/tests/AzureMcp.Core.UnitTests/Areas/Server/Commands/ToolLoading/CommandFactoryToolLoaderTests.cs
@@ -19,11 +19,10 @@ public class CommandFactoryToolLoaderTests
         var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
         var commandFactory = CommandFactoryHelpers.CreateCommandFactory(serviceProvider);
-        var telemetryService = new CommandFactoryHelpers.NoOpTelemetryService();
         var logger = loggerFactory.CreateLogger<CommandFactoryToolLoader>();
         var toolLoaderOptions = Microsoft.Extensions.Options.Options.Create(options ?? new ToolLoaderOptions());
 
-        var toolLoader = new CommandFactoryToolLoader(serviceProvider, commandFactory, toolLoaderOptions, telemetryService, logger);
+        var toolLoader = new CommandFactoryToolLoader(serviceProvider, commandFactory, toolLoaderOptions, logger);
         return (toolLoader, commandFactory);
     }
 


### PR DESCRIPTION
## What does this PR do?

* Remove unnecessary null-forgiving operator uses. (From the API these values are never expected to be null.)
* Remove extra invocation of ToolExecuted activity.
* Broaden MAC Address search to limit null values.

## GitHub issue number?

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [x] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes, updated:
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
