### PR TITLE
Add filter-path and recursive to Data Lake File System List Paths command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 - Added support for listing SQL databases via the command: `azmcp-sql-db-list`. [[#746](https://github.com/Azure/azure-mcp/pull/746)]
 
 - Read `AZURE_SUBSCRIPTION_ID` from the environment if the subscription is not provided. [[#533](https://github.com/Azure/azure-mcp/pull/533)]
+- Added `filter-path` and `recursive` capabilities to `azmcp-storage-datalake-file-system-list-paths`. [[#770](https://github.com/Azure/azure-mcp/issues/770)]
 
 ### Breaking Changes
 

--- a/areas/storage/src/AzureMcp.Storage/Options/DataLake/Directory/DirectoryCreateOptions.cs
+++ b/areas/storage/src/AzureMcp.Storage/Options/DataLake/Directory/DirectoryCreateOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Serialization;
-using AzureMcp.Storage.Options;
 
 namespace AzureMcp.Storage.Options.DataLake.Directory;
 

--- a/areas/storage/src/AzureMcp.Storage/Options/DataLake/FileSystem/ListPathsOptions.cs
+++ b/areas/storage/src/AzureMcp.Storage/Options/DataLake/FileSystem/ListPathsOptions.cs
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 namespace AzureMcp.Storage.Options.DataLake.FileSystem;
 
-public class ListPathsOptions : BaseFileSystemOptions;
+public class ListPathsOptions : BaseFileSystemOptions
+{
+    [JsonPropertyName(StorageOptionDefinitions.FilterPathName)]
+    public string? FilterPath { get; set; }
+
+    [JsonPropertyName(StorageOptionDefinitions.ResursiveName)]
+    public bool Recursive { get; set; } = false;
+}

--- a/areas/storage/src/AzureMcp.Storage/Options/StorageOptionDefinitions.cs
+++ b/areas/storage/src/AzureMcp.Storage/Options/StorageOptionDefinitions.cs
@@ -10,6 +10,8 @@ public static class StorageOptionDefinitions
     public const string TableName = "table-name";
     public const string FileSystemName = "file-system-name";
     public const string DirectoryPathName = "directory-path";
+    public const string FilterPathName = "filter-path";
+    public const string ResursiveName = "recursive";
 
     public static readonly Option<string> Account = new(
         $"--{AccountName}",
@@ -49,5 +51,22 @@ public static class StorageOptionDefinitions
     )
     {
         IsRequired = true
+    };
+
+    public static readonly Option<string> FilterPath = new(
+        $"--{FilterPathName}",
+        "The prefix to filter paths in the Data Lake. Only paths that start with this prefix will be listed."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<bool> Recursive = new(
+        $"--{ResursiveName}",
+        () => false,
+        "Flag to indicate whether the command will operate recursively on all subdirectories."
+    )
+    {
+        IsRequired = false
     };
 }

--- a/areas/storage/src/AzureMcp.Storage/Services/IStorageService.cs
+++ b/areas/storage/src/AzureMcp.Storage/Services/IStorageService.cs
@@ -28,7 +28,9 @@ public interface IStorageService
     Task<List<DataLakePathInfo>> ListDataLakePaths(
         string accountName,
         string fileSystemName,
+        bool recursive,
         string subscriptionId,
+        string? filterPath = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null);
     Task<DataLakePathInfo> CreateDirectory(

--- a/areas/storage/src/AzureMcp.Storage/Services/StorageService.cs
+++ b/areas/storage/src/AzureMcp.Storage/Services/StorageService.cs
@@ -316,7 +316,9 @@ public class StorageService(ISubscriptionService subscriptionService, ITenantSer
     public async Task<List<DataLakePathInfo>> ListDataLakePaths(
         string accountName,
         string fileSystemName,
+        bool recursive,
         string subscriptionId,
+        string? filterPath = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null)
     {
@@ -328,7 +330,7 @@ public class StorageService(ISubscriptionService subscriptionService, ITenantSer
 
         try
         {
-            await foreach (var pathItem in fileSystemClient.GetPathsAsync())
+            await foreach (var pathItem in fileSystemClient.GetPathsAsync(filterPath, recursive))
             {
                 var pathInfo = new DataLakePathInfo(
                     pathItem.Name,

--- a/areas/storage/tests/AzureMcp.Storage.LiveTests/StorageCommandTests.cs
+++ b/areas/storage/tests/AzureMcp.Storage.LiveTests/StorageCommandTests.cs
@@ -215,6 +215,40 @@ namespace AzureMcp.Storage.LiveTests
         }
 
         [Fact]
+        public async Task Should_list_datalake_filesystem_paths_with_filter_path()
+        {
+            var result = await CallToolAsync(
+                "azmcp_storage_datalake_file-system_list-paths",
+                new()
+                {
+                { "subscription", Settings.SubscriptionName },
+                { "account-name", Settings.ResourceBaseName },
+                { "file-system-name", "testfilesystem" },
+                { "filter-path", "test-directory" }
+                });
+
+            var actual = result.AssertProperty("paths");
+            Assert.Equal(JsonValueKind.Array, actual.ValueKind);
+        }
+
+        [Fact]
+        public async Task Should_list_datalake_filesystem_paths_recursively()
+        {
+            var result = await CallToolAsync(
+                "azmcp_storage_datalake_file-system_list-paths",
+                new()
+                {
+                { "subscription", Settings.SubscriptionName },
+                { "account-name", Settings.ResourceBaseName },
+                { "file-system-name", "testfilesystem" },
+                { "recursive", true }
+                });
+
+            var actual = result.AssertProperty("paths");
+            Assert.Equal(JsonValueKind.Array, actual.ValueKind);
+        }
+
+        [Fact]
         public async Task Should_create_datalake_directory()
         {
             var directoryPath = "testfilesystem/test-directory";

--- a/areas/storage/tests/AzureMcp.Storage.UnitTests/DataLake/FileSystem/FileSystemListPathsCommandTests.cs
+++ b/areas/storage/tests/AzureMcp.Storage.UnitTests/DataLake/FileSystem/FileSystemListPathsCommandTests.cs
@@ -9,7 +9,6 @@ using AzureMcp.Core.Options;
 using AzureMcp.Storage.Commands.DataLake.FileSystem;
 using AzureMcp.Storage.Models;
 using AzureMcp.Storage.Services;
-using AzureMcp.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -53,8 +52,8 @@ public class FileSystemListPathsCommandTests
             new("directory1", "directory", null, DateTimeOffset.Now, "\"etag2\"")
         };
 
-        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), Arg.Is(_knownSubscriptionId),
-            Arg.Any<string>(), Arg.Any<RetryPolicyOptions>()).Returns(expectedPaths);
+        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), false, Arg.Is(_knownSubscriptionId),
+            null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>()).Returns(expectedPaths);
 
         var args = _parser.Parse([
             "--account-name", _knownAccountName,
@@ -82,8 +81,8 @@ public class FileSystemListPathsCommandTests
     public async Task ExecuteAsync_ReturnsEmptyArray_WhenNoPaths()
     {
         // Arrange
-        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), Arg.Is(_knownSubscriptionId),
-            Arg.Any<string>(), Arg.Any<RetryPolicyOptions>()).Returns([]);
+        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), false, Arg.Is(_knownSubscriptionId),
+            null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>()).Returns([]);
 
         var args = _parser.Parse([
             "--account-name", _knownAccountName,
@@ -111,8 +110,8 @@ public class FileSystemListPathsCommandTests
         // Arrange
         var expectedError = "Test error";
 
-        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), Arg.Is(_knownSubscriptionId),
-            null, Arg.Any<RetryPolicyOptions>()).ThrowsAsync(new Exception(expectedError));
+        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), false, Arg.Is(_knownSubscriptionId),
+            null, null, Arg.Any<RetryPolicyOptions>()).ThrowsAsync(new Exception(expectedError));
 
         var args = _parser.Parse([
             "--account-name", _knownAccountName,
@@ -129,6 +128,198 @@ public class FileSystemListPathsCommandTests
         Assert.StartsWith(expectedError, response.Message);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WithFilterPath_FiltersResults()
+    {
+        // Arrange
+        var filterPath = "folder1/";
+        var expectedPaths = new List<DataLakePathInfo>
+        {
+            new("folder1/file1.txt", "file", 1024, DateTimeOffset.Now, "\"etag1\""),
+            new("folder1/subfolder", "directory", null, DateTimeOffset.Now, "\"etag2\"")
+        };
+
+        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), false, 
+            Arg.Is(_knownSubscriptionId), Arg.Is(filterPath), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(expectedPaths);
+
+        var args = _parser.Parse([
+            "--account-name", _knownAccountName,
+            "--file-system-name", _knownFileSystemName,
+            "--subscription", _knownSubscriptionId,
+            "--filter-path", filterPath
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<FileSystemListPathsResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedPaths.Count, result.Paths.Count);
+        Assert.All(result.Paths, path => Assert.StartsWith(filterPath, path.Name));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithRecursiveTrue_ReturnsAllPaths()
+    {
+        // Arrange
+        var expectedPaths = new List<DataLakePathInfo>
+        {
+            new("file1.txt", "file", 1024, DateTimeOffset.Now, "\"etag1\""),
+            new("folder1", "directory", null, DateTimeOffset.Now, "\"etag2\""),
+            new("folder1/file2.txt", "file", 2048, DateTimeOffset.Now, "\"etag3\""),
+            new("folder1/subfolder", "directory", null, DateTimeOffset.Now, "\"etag4\""),
+            new("folder1/subfolder/file3.txt", "file", 512, DateTimeOffset.Now, "\"etag5\"")
+        };
+
+        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), true, 
+            Arg.Is(_knownSubscriptionId), null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(expectedPaths);
+
+        var args = _parser.Parse([
+            "--account-name", _knownAccountName,
+            "--file-system-name", _knownFileSystemName,
+            "--subscription", _knownSubscriptionId,
+            "--recursive"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<FileSystemListPathsResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedPaths.Count, result.Paths.Count);
+        // Verify we get both top-level and nested paths
+        Assert.Contains(result.Paths, p => p.Name == "file1.txt");
+        Assert.Contains(result.Paths, p => p.Name == "folder1/file2.txt");
+        Assert.Contains(result.Paths, p => p.Name == "folder1/subfolder/file3.txt");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithRecursiveFalse_ReturnsOnlyTopLevelPaths()
+    {
+        // Arrange
+        var expectedPaths = new List<DataLakePathInfo>
+        {
+            new("file1.txt", "file", 1024, DateTimeOffset.Now, "\"etag1\""),
+            new("folder1", "directory", null, DateTimeOffset.Now, "\"etag2\"")
+        };
+
+        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), false, 
+            Arg.Is(_knownSubscriptionId), null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(expectedPaths);
+
+        var args = _parser.Parse([
+            "--account-name", _knownAccountName,
+            "--file-system-name", _knownFileSystemName,
+            "--subscription", _knownSubscriptionId
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<FileSystemListPathsResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedPaths.Count, result.Paths.Count);
+        // Verify we only get top-level paths (no nested paths)
+        Assert.All(result.Paths, path => Assert.DoesNotContain("/", path.Name.Substring(1)));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFilterPathAndRecursive_CombinesOptions()
+    {
+        // Arrange
+        var filterPath = "documents/";
+        var expectedPaths = new List<DataLakePathInfo>
+        {
+            new("documents/file1.pdf", "file", 1024, DateTimeOffset.Now, "\"etag1\""),
+            new("documents/archive", "directory", null, DateTimeOffset.Now, "\"etag2\""),
+            new("documents/archive/old.pdf", "file", 2048, DateTimeOffset.Now, "\"etag3\"")
+        };
+
+        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), true, 
+            Arg.Is(_knownSubscriptionId), Arg.Is(filterPath), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(expectedPaths);
+
+        var args = _parser.Parse([
+            "--account-name", _knownAccountName,
+            "--file-system-name", _knownFileSystemName,
+            "--subscription", _knownSubscriptionId,
+            "--filter-path", filterPath,
+            "--recursive"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<FileSystemListPathsResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedPaths.Count, result.Paths.Count);
+        Assert.All(result.Paths, path => Assert.StartsWith(filterPath, path.Name));
+        // Verify we get both filtered and nested paths
+        Assert.Contains(result.Paths, p => p.Name == "documents/file1.pdf");
+        Assert.Contains(result.Paths, p => p.Name == "documents/archive/old.pdf");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyFilterPath_ReturnsAllPaths()
+    {
+        // Arrange
+        var expectedPaths = new List<DataLakePathInfo>
+        {
+            new("file1.txt", "file", 1024, DateTimeOffset.Now, "\"etag1\""),
+            new("folder1", "directory", null, DateTimeOffset.Now, "\"etag2\"")
+        };
+
+        _storageService.ListDataLakePaths(Arg.Is(_knownAccountName), Arg.Is(_knownFileSystemName), false, 
+            Arg.Is(_knownSubscriptionId), Arg.Is(""), Arg.Any<string>(), Arg.Any<RetryPolicyOptions>())
+            .Returns(expectedPaths);
+
+        var args = _parser.Parse([
+            "--account-name", _knownAccountName,
+            "--file-system-name", _knownFileSystemName,
+            "--subscription", _knownSubscriptionId,
+            "--filter-path", ""
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+
+        var json = JsonSerializer.Serialize(response.Results);
+        var result = JsonSerializer.Deserialize<FileSystemListPathsResult>(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedPaths.Count, result.Paths.Count);
+    }
+
     [Theory]
     [InlineData("--file-system-name filesystem123 --subscription sub123", false)] // Missing account
     [InlineData("--account-name account123 --subscription sub123", false)] // Missing file-system
@@ -139,8 +330,8 @@ public class FileSystemListPathsCommandTests
         // Arrange
         if (shouldSucceed)
         {
-            _storageService.ListDataLakePaths(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<string>(), Arg.Any<RetryPolicyOptions>()).Returns([]);
+            _storageService.ListDataLakePaths(Arg.Any<string>(), Arg.Any<string>(), false, Arg.Any<string>(),
+                null, Arg.Any<string>(), Arg.Any<RetryPolicyOptions>()).Returns([]);
         }
 
         var parseResult = _parser.Parse(args.Split(' '));

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -786,7 +786,9 @@ azmcp storage blob container details --subscription <subscription> \
 # List paths in a Data Lake file system
 azmcp storage datalake file-system list-paths --subscription <subscription> \
                                               --account-name <account-name> \
-                                              --file-system-name <file-system-name>
+                                              --file-system-name <file-system-name> \
+                                              [--filter-path <filter-path>] \
+                                              [--recursive]
 
 # Create a directory in DataLake using a specific path
 azmcp storage datalake directory create --subscription <subscription> \

--- a/e2eTests/e2eTestPrompts.md
+++ b/e2eTests/e2eTestPrompts.md
@@ -308,6 +308,7 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp-storage-blob-list | Show me the blobs in the blob container <container_name> in the storage account <account_name> |
 | azmcp-storage-datalake-file-system-list-paths | List all paths in the Data Lake file system <file_system_name> in the storage account <account_name> |
 | azmcp-storage-datalake-file-system-list-paths | Show me the paths in the Data Lake file system <file_system_name> in the storage account <account_name> |
+| azmcp-storage-datalake-file-system-list-paths | Recusively list all paths in the Data Lake file system <file_system_name> in the storage account <account_name> filtered by <filter_path> |
 | azmcp-storage-datalake-directory-create | Create a new directory at the path <directory_path> in Data Lake in the storage account <account_name> |
 | azmcp-storage-table-list | List all tables in the storage account <account_name> |
 | azmcp-storage-table-list | Show me the tables in the storage account <account_name> |


### PR DESCRIPTION
## What does this PR do?

Adds missing options `filter-path` and `recursive` to the Data Lake File System List Paths command.

## GitHub issue number?

#770

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [x] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [x] For MCP tool changes, updated:
    - [x] Updated `README.md` documentation
    - [x] Updated command list in `/docs/azmcp-commands.md`
    - [x] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
