### PR TITLE
Fix Storage Batch command failing all mode

### DIFF
--- a/areas/storage/src/AzureMcp.Storage/Commands/Blob/Batch/BatchSetTierCommand.cs
+++ b/areas/storage/src/AzureMcp.Storage/Commands/Blob/Batch/BatchSetTierCommand.cs
@@ -44,10 +44,7 @@ public sealed class BatchSetTierCommand(ILogger<BatchSetTierCommand> logger) : B
     {
         var options = base.BindOptions(parseResult);
         options.Tier = parseResult.GetValueForOption(_tierOption);
-        var blobNames = parseResult.GetValueForOption(_blobNamesOption) == default
-            ? StorageOptionDefinitions.BlobNames.GetDefaultValue()
-            : parseResult.GetValueForOption(_blobNamesOption);
-        options.BlobNames = blobNames;
+        options.BlobNames = parseResult.GetValueForOption(_blobNamesOption);
         return options;
     }
 
@@ -59,7 +56,7 @@ public sealed class BatchSetTierCommand(ILogger<BatchSetTierCommand> logger) : B
         {
             string blobNamesValue = commandResult.GetValueForOption(_blobNamesOption)!;
 
-            // Validate the metric names
+            // Validate the blob names
             string[] blobNames = blobNamesValue.Split(',').Select(t => t.Trim()).ToArray();
 
             if (blobNames.Length == 0 || blobNames.Any(string.IsNullOrWhiteSpace))

--- a/areas/storage/src/AzureMcp.Storage/Options/Blob/Batch/BatchSetTierOptions.cs
+++ b/areas/storage/src/AzureMcp.Storage/Options/Blob/Batch/BatchSetTierOptions.cs
@@ -10,6 +10,6 @@ public class BatchSetTierOptions : BaseContainerOptions
     [JsonPropertyName(StorageOptionDefinitions.TierName)]
     public string? Tier { get; set; }
 
-    [JsonPropertyName(StorageOptionDefinitions.BlobNamesParam)]
-    public string[]? BlobNames { get; set; }
+    [JsonPropertyName(StorageOptionDefinitions.BlobNamesName)]
+    public string? BlobNames { get; set; }
 }

--- a/areas/storage/src/AzureMcp.Storage/Options/StorageOptionDefinitions.cs
+++ b/areas/storage/src/AzureMcp.Storage/Options/StorageOptionDefinitions.cs
@@ -11,7 +11,7 @@ public static class StorageOptionDefinitions
     public const string FileSystemName = "file-system-name";
     public const string DirectoryPathName = "directory-path";
     public const string TierName = "tier-name";
-    public const string BlobNamesParam = "blob-names";
+    public const string BlobNamesName = "blob-names";
 
     public static readonly Option<string> Account = new(
         $"--{AccountName}",
@@ -61,9 +61,9 @@ public static class StorageOptionDefinitions
         IsRequired = true
     };
 
-    public static readonly Option<string[]> BlobNames = new(
-        $"--{BlobNamesParam}",
-        "The names of the blobs to set the access tier for. Provide multiple blob names separated by spaces. Each blob name should be the full path within the container (e.g., 'file1.txt' or 'folder/file2.txt')."
+    public static readonly Option<string> BlobNames = new(
+        $"--{BlobNamesName}",
+        "The names of the blobs to set the access tier for (comma-separated). Each blob name should be the full path within the container (e.g., 'file1.txt' or 'folder/file2.txt')."
     )
     {
         IsRequired = true,

--- a/areas/storage/tests/AzureMcp.Storage.LiveTests/StorageCommandTests.cs
+++ b/areas/storage/tests/AzureMcp.Storage.LiveTests/StorageCommandTests.cs
@@ -251,7 +251,7 @@ namespace AzureMcp.Storage.LiveTests
                     { "account-name", Settings.ResourceBaseName },
                     { "container-name", "bar" },
                     { "tier-name", "Cool" },
-                    { "blob-names", "blob1.txt blob2.txt" }
+                    { "blob-names", "blob1.txt,blob2.txt" }
                 });
 
             var successfulBlobs = result.AssertProperty("successfulBlobs");

--- a/areas/storage/tests/AzureMcp.Storage.UnitTests/Blob/Batch/BatchSetTierCommandTests.cs
+++ b/areas/storage/tests/AzureMcp.Storage.UnitTests/Blob/Batch/BatchSetTierCommandTests.cs
@@ -74,7 +74,7 @@ public class BatchSetTierCommandTests
             "--account-name", _knownAccountName,
             "--container-name", _knownContainerName,
             "--tier-name", _knownTier,
-            "--blob-names", "blob1.txt", "blob2.txt", "blob3.txt",
+            "--blob-names", "blob1.txt,blob2.txt,blob3.txt",
             "--subscription", _knownSubscriptionId
         ]);
 
@@ -119,7 +119,7 @@ public class BatchSetTierCommandTests
             "--account-name", _knownAccountName,
             "--container-name", _knownContainerName,
             "--tier-name", _knownTier,
-            "--blob-names", "blob1.txt", "blob2.txt", "blob3.txt",
+            "--blob-names", "blob1.txt,blob2.txt,blob3.txt",
             "--subscription", _knownSubscriptionId
         ]);
 

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -747,7 +747,7 @@ azmcp storage blob batch set-tier --subscription <subscription> \
                                   --account-name <account-name> \
                                   --container-name <container-name> \
                                   --tier-name <tier-name> \
-                                  --blob-names <blob-name1> <blob-name2> ... <blob-nameN>
+                                  --blob-names <blob-name1>,<blob-name2>,...,<blob-nameN>
 
 # List blobs in a Storage container
 azmcp storage blob list --subscription <subscription> \


### PR DESCRIPTION
## What does this PR do?

Fixes usage of array `Option` causing a failure when it `IsRequired`. Changes Blob Batch Set Tier to use a comma-separated string of `blob-names` instead.

## GitHub issue number?

#805

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [x] For MCP tool changes, updated:
    - [x] Updated `README.md` documentation
    - [x] Updated command list in `/docs/azmcp-commands.md`
    - [x] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
