### PR TITLE
Fixed broken links in `eng/common/mcp/README.md`

### DIFF
--- a/eng/common/mcp/README.md
+++ b/eng/common/mcp/README.md
@@ -24,15 +24,13 @@ The script will install the latest version of the azsdk cli executable from [too
 
 Azure SDK MCP server code is in [azure-sdk-tools/tools/azsdk-cli/Azure.Sdk.Tools.Cli](https://github.com/Azure/azure-sdk-tools/tree/main/tools/azsdk-cli/Azure.Sdk.Tools.Cli).
 
-Azure SDK MCP servers should support [stdio and sse transports](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse).
+Azure SDK MCP servers [**MUST** support stdio and **SHOULD** support streamable HTTP using latest OAuth 2.1 Best Current Practices (BCPs)](https://modelcontextprotocol.io/docs/concepts/transports).
 
-When running in copilot the default is stdio mode, but SSE is useful to support for external debugging.
+When running in copilot the default is stdio mode.
 
 ### Developing MCP servers in C#
 
 See the [C# MCP SDK](https://github.com/modelcontextprotocol/csharp-sdk)
-
-Add an [SSE transport](https://github.com/modelcontextprotocol/csharp-sdk/tree/main/samples/AspNetCoreSseServer)
 
 TODO: Add the azsdk-cli project to pull in MCP server dependencies from the repo
 


### PR DESCRIPTION
## What does this PR do?
The SSE protocol was removed from the MCP spec and it seems the link referring to it has also been removed from the spec docs.

This is essentially a manual PR because automation has not been set up to sync with the `azure-sdk-tools` repo. Here's [the issue](https://github.com/Azure/azure-sdk-tools/pull/11493) addressing this on there.

## GitHub issue number?
N/A

## Pre-merge Checklist

- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [x] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes, updated:
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
