### PR TITLE
readability improvement to Test-Code.ps1

### DIFF
--- a/eng/scripts/Test-Code.ps1
+++ b/eng/scripts/Test-Code.ps1
@@ -165,13 +165,13 @@ function CreateTestSolution {
 $testsRootDirs = GetTestsRootDirs -areas $Areas
 
 if (!$testsRootDirs) {
-    return
+    exit 1
 }
 
 $solutionPath = CreateTestSolution -workPath $workPath -testsRootDirs $testsRootDirs -testType $TestType
 
 if (!$solutionPath) {
-    return
+    exit 1
 }
 
 Push-Location $workPath

--- a/eng/scripts/Test-Code.ps1
+++ b/eng/scripts/Test-Code.ps1
@@ -30,11 +30,35 @@ if (!$TestResultsPath) {
 # Clean previous results
 Remove-Item -Recurse -Force $TestResultsPath -ErrorAction SilentlyContinue
 
-$testProjects = @()
+# Identifies the root directories to be recursively scanned for tests in the specified areas.
+function GetTestsRootDirs {
+    param(
+        [string[]]$areas
+    )
+
+    if (!$areas) {
+        # Indicates that the scan for tests should start from the repository root, i.e., include all tests.
+        return @($RepoRoot)
+    }
+
+    $testsRootDirs = @()
+    foreach ($area in $areas) {
+        $areaName = $area.ToLower()
+        $testsPath = $areaName -eq 'core' ? "$RepoRoot/core/tests" : "$RepoRoot/areas/$areaName/tests"
+        if (Test-Path $testsPath) {
+            $testsRootDirs += $testsPath
+        } else {
+            Write-Error "Tests path '$testsPath' does not exist."
+            return $null
+        }
+    }
+    return $testsRootDirs
+}
 
 function BuildNativeBinaryAndPrepareTests {
     param(
-        [string[]]$areas = @()
+        [Parameter(Mandatory=$true)]
+        [string[]]$testsRootDirs
     )
 
     # Native AOT compilation only occurs during 'dotnet publish', not 'dotnet build'
@@ -45,7 +69,7 @@ function BuildNativeBinaryAndPrepareTests {
         -Command "dotnet build" `
         -AllowedExitCodes @(0)
 
-    CopyNativeBinaryToTestDirs -nativeBinaryPath $nativeBinaryPath -areas $areas
+    CopyNativeBinaryToTestDirs -nativeBinaryPath $nativeBinaryPath -testsRootDirs $testsRootDirs
 }
 
 function PublishNativeBinary {
@@ -73,67 +97,79 @@ function CopyNativeBinaryToTestDirs {
     param(
         [Parameter(Mandatory=$true)]
         [string]$nativeBinaryPath,
-        [string[]]$areas = @()
+        [string[]]$testsRootDirs
     )
     Write-Host "Copying native AzureMcp to test directories"
 
-    if (!$areas) {
-        $testDirectories = Get-ChildItem -Path $RepoRoot -Recurse -Filter "*.LiveTests" -Directory
-    } else {
-        $testDirectories = @()
-        foreach ($area in $areas) {
-            $areaName = $area.ToLower()
-            $areaPath = $areaName -eq 'core' ? "$RepoRoot/core/tests" : "$RepoRoot/areas/$areaName/tests"
-            if (Test-Path $areaPath) {
-                $areaTestDirectories = Get-ChildItem -Path $areaPath -Recurse -Filter "*.LiveTests" -Directory
-                $testDirectories += $areaTestDirectories
-            }
-        }
+    $testProjectDirs = @()
+    foreach ($testsRootDir in $testsRootDirs) {
+        $areaTestProjectDirs = Get-ChildItem -Path $testsRootDir -Recurse -Filter "*.LiveTests" -Directory
+        $testProjectDirs += $areaTestProjectDirs
     }
 
-    foreach ($testDir in $testDirectories) {
+    foreach ($testDir in $testProjectDirs) {
         $targetDirectory = "$($testDir.FullName)/bin/Debug/net9.0"
         Copy-Item $nativeBinaryPath $targetDirectory -Force
     }
 }
 
-function AddTestProjects($path) {
-    if($TestType -in @('Live', 'All')) {
-        $script:testProjects += Get-ChildItem $path -Recurse -File -Filter "*.LiveTests.csproj"
-    }
-    if($TestType -in @('Unit', 'All')) {
-        $script:testProjects += Get-ChildItem $path -Recurse -File -Filter "*.UnitTests.csproj"
-    }
-}
+function CreateTestSolution {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$workPath,
+        [Parameter(Mandatory=$true)]
+        [string[]]$testsRootDirs,
+        [Parameter(Mandatory=$true)]
+        [string]$testType
+    )
 
-if (!$Areas) {
-    AddTestProjects $RepoRoot
-} else {
-    foreach ($area in $Areas) {
-        $areaName = $area.ToLower()
-        $areaPath = $areaName -eq 'core' ? "$RepoRoot/core/tests" : "$RepoRoot/areas/$areaName/tests"
-        if (Test-Path $areaPath) {
-            AddTestProjects $areaPath
-        } else {
-            Write-Error "Area path '$areaPath' does not exist."
-            return
+    $testProjects = @()
+    foreach ($testsRootDir in $testsRootDirs) {
+        if($testType -in @('Live', 'All')) {
+            $testProjects += Get-ChildItem $testsRootDir -Recurse -File -Filter "*.LiveTests.csproj"
+        }
+        if($testType -in @('Unit', 'All')) {
+            $testProjects += Get-ChildItem $testsRootDir -Recurse -File -Filter "*.UnitTests.csproj"
         }
     }
+
+    if($testProjects.Count -eq 0) {
+        Write-Error "No test projects found in the specified areas for test type '$testType'."
+        return $false
+    }
+
+    # Create solution and add projects
+    Write-Host "Creating temporary solution file..."
+    Push-Location $workPath
+    try {
+        dotnet new sln -n "Tests" | Out-Null
+        dotnet sln add $testProjects --in-root
+    }
+    finally {
+        Pop-Location
+    }
+
+    return $true
 }
 
-if($testProjects.Count -eq 0) {
-    Write-Error "No test projects found in the specified areas for test type '$TestType'."
+# main
+
+$testsRootDirs = GetTestsRootDirs -areas $Areas
+
+if (!$testsRootDirs) {
+    return
+}
+
+$success = CreateTestSolution -workPath $workPath -testsRootDirs $testsRootDirs -testType $TestType
+
+if (!$success) {
     return
 }
 
 Push-Location $workPath
 try {
-    Write-Host "Creating temporary solution file..."
-    dotnet new sln -n "Tests" | Out-Null
-    dotnet sln add $testProjects --in-root
-
     if ($TestNativeBuild) {
-        BuildNativeBinaryAndPrepareTests -areas $Areas
+        BuildNativeBinaryAndPrepareTests -testsRootDirs $testsRootDirs
     }
 
     if($debugLogs) {

--- a/eng/scripts/Test-Code.ps1
+++ b/eng/scripts/Test-Code.ps1
@@ -101,14 +101,10 @@ function CopyNativeBinaryToTestDirs {
     )
     Write-Host "Copying native AzureMcp to test directories"
 
-    $testProjectDirs = @()
-    foreach ($testsRootDir in $testsRootDirs) {
-        $areaTestProjectDirs = Get-ChildItem -Path $testsRootDir -Recurse -Filter "*.LiveTests" -Directory
-        $testProjectDirs += $areaTestProjectDirs
-    }
-
-    foreach ($testDir in $testProjectDirs) {
-        $targetDirectory = "$($testDir.FullName)/bin/Debug/net9.0"
+    $testsRootDirs | ForEach-Object {
+        Get-ChildItem -Path $_ -Recurse -Filter "*.LiveTests" -Directory
+    } | ForEach-Object {
+        $targetDirectory = "$($_.FullName)/bin/Debug/net9.0"
         Copy-Item $nativeBinaryPath $targetDirectory -Force
     }
 }


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

Noticed some redundant logic after adding native-binary testing in earlier pr, consolidating it to make the Test-Code.ps1 script more readable.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionConfidenceScore` tool and obtained a result >= 0.4
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
