### PR TITLE
Let Build-* scripts stop on error

### DIFF
--- a/eng/scripts/Build-Local.ps1
+++ b/eng/scripts/Build-Local.ps1
@@ -12,6 +12,8 @@ param(
     [switch] $BuildNative
 )
 
+$ErrorActionPreference = 'Stop'
+
 . "$PSScriptRoot/../common/scripts/common.ps1"
 $root = $RepoRoot.Path.Replace('\', '/')
 

--- a/eng/scripts/Build-Module.ps1
+++ b/eng/scripts/Build-Module.ps1
@@ -18,6 +18,8 @@ param(
     [string] $Architecture
 )
 
+$ErrorActionPreference = 'Stop'
+
 . "$PSScriptRoot/../common/scripts/common.ps1"
 $RepoRoot = $RepoRoot.Path.Replace('\', '/')
 


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

Currently, build scripts (including the one for the npx package) run even after a project build failure, resulting in empty packages without script exiting with error code. This PR addresses the issue.

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionConfidenceScore` tool and obtained a result >= 0.4
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
