### PR TITLE
Update Bicep Telemetry to use AddTag instead of SetTag

### DIFF
--- a/areas/bicepschema/src/AzureMcp.BicepSchema/Commands/BicepSchemaGetCommand.cs
+++ b/areas/bicepschema/src/AzureMcp.BicepSchema/Commands/BicepSchemaGetCommand.cs
@@ -20,7 +20,7 @@ namespace AzureMcp.BicepSchema.Commands
 
         public override string Description =>
        """
-       
+
         Provides the Bicep schema for the most recent apiVersion of an Azure resource. Do not call this command for Terraform IaC generation.
         If you are asked to create or modify resources in a Bicep ARM template, call this function multiple times,
         once for every resource type you are adding, even if you already have information about Bicep resources from other sources.
@@ -64,7 +64,7 @@ namespace AzureMcp.BicepSchema.Commands
                     // Only log the resource type if we are able to get the schema from it.
                     // There is a slight chance that the LLM hallucinates the resource type
                     // parameter with value containing data that we shouldn't log.
-                    context.Activity?.SetTag("resourceType", options.ResourceType);
+                    context.Activity?.AddTag("resourceType", options.ResourceType);
                     context.Response.Results = ResponseResult.Create(
                         new BicepSchemaGetCommandResult(response),
                         BicepSchemaJsonContext.Default.BicepSchemaGetCommandResult);


### PR DESCRIPTION
## What does this PR do?
Updates Bicep Telemetry to log resource type using AddTag method as opposed to the SetTag method, as SetTag method wasn't producing the results we were expecting.

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ x Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionConfidenceScore` tool and obtained a result >= 0.4
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
