### PR TITLE
Monitor ingestion commands

### DIFF
--- a/areas/monitor/src/AzureMcp.Monitor/AzureMcp.Monitor.csproj
+++ b/areas/monitor/src/AzureMcp.Monitor/AzureMcp.Monitor.csproj
@@ -12,6 +12,7 @@
   <ItemGroup />
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Monitor.Ingestion" />
     <PackageReference Include="Azure.Monitor.Query" />
     <PackageReference Include="Azure.ResourceManager" />
     <PackageReference Include="Azure.ResourceManager.OperationalInsights" />

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/Ingestion/IngestionUploadCommand.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/Ingestion/IngestionUploadCommand.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Core.Commands;
+using AzureMcp.Core.Services.Telemetry;
+using AzureMcp.Monitor.Options;
+using AzureMcp.Monitor.Services;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Monitor.Commands.Ingestion;
+
+public sealed class IngestionUploadCommand(ILogger<IngestionUploadCommand> logger) : BaseMonitorCommand<IngestionUploadOptions>()
+{
+    private const string CommandTitle = "Upload Custom Log Data to Azure Monitor";
+    private readonly ILogger<IngestionUploadCommand> _logger = logger;
+    private readonly Option<string> _dataCollectionRuleOption = MonitorOptionDefinitions.Ingestion.DataCollectionRule;
+    private readonly Option<string> _logDataOption = MonitorOptionDefinitions.Ingestion.LogData;
+    private readonly Option<string> _streamNameOption = MonitorOptionDefinitions.Ingestion.StreamName;
+
+    public override string Name => "upload";
+
+    public override string Description =>
+        $"""
+        Upload custom log data to Azure Monitor workspaces using data collection rules. This tool sends structured log data to Azure Monitor with schema validation and transformation support for custom monitoring scenarios. 
+        Requires {WorkspaceOptionDefinitions.WorkspaceIdOrName}, {MonitorOptionDefinitions.DataCollectionRuleName}, {MonitorOptionDefinitions.StreamNameName}, and {MonitorOptionDefinitions.LogDataName} parameters.
+        Returns ingestion operation status and record count.
+        """;
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = false };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        command.AddOption(_dataCollectionRuleOption);
+        command.AddOption(_logDataOption);
+        command.AddOption(_streamNameOption);
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var monitorService = context.GetService<IMonitorService>();
+            var result = await monitorService.UploadLogs(
+                options.Workspace!,
+                options.DataCollectionRule!,
+                options.StreamName!,
+                options.LogData!,
+                options.Tenant,
+                options.RetryPolicy);
+
+            var commandResult = new IngestionUploadCommandResult(result.Status, result.RecordCount, result.Message);
+            context.Response.Results = ResponseResult.Create(commandResult, MonitorJsonContext.Default.IngestionUploadCommandResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error executing ingestion upload command for workspace {Workspace} with DCR {DataCollectionRule}",
+                options.Workspace, options.DataCollectionRule);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    protected override IngestionUploadOptions BindOptions(ParseResult parseResult)
+    {
+        var options = base.BindOptions(parseResult);
+        options.DataCollectionRule = parseResult.GetValueForOption(_dataCollectionRuleOption);
+        options.LogData = parseResult.GetValueForOption(_logDataOption);
+        options.StreamName = parseResult.GetValueForOption(_streamNameOption);
+        return options;
+    }
+
+    internal record IngestionUploadCommandResult(string Status, int RecordCount, string Message);
+}

--- a/areas/monitor/src/AzureMcp.Monitor/Commands/MonitorJsonContext.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Commands/MonitorJsonContext.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using AzureMcp.Monitor.Commands.Ingestion;
 using AzureMcp.Monitor.Commands.Metrics;
 using AzureMcp.Monitor.Commands.Table;
 using AzureMcp.Monitor.Commands.TableType;
@@ -16,6 +17,7 @@ namespace AzureMcp.Monitor.Commands;
 [JsonSerializable(typeof(TableTypeListCommand.TableTypeListCommandResult))]
 [JsonSerializable(typeof(MetricsQueryCommand.MetricsQueryCommandResult))]
 [JsonSerializable(typeof(MetricsDefinitionsCommand.MetricsDefinitionsCommandResult))]
+[JsonSerializable(typeof(IngestionUploadCommand.IngestionUploadCommandResult))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class MonitorJsonContext : JsonSerializerContext
 {

--- a/areas/monitor/src/AzureMcp.Monitor/MonitorSetup.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/MonitorSetup.cs
@@ -4,6 +4,7 @@
 using AzureMcp.Core.Areas;
 using AzureMcp.Core.Commands;
 using AzureMcp.Monitor.Commands.HealthModels.Entity;
+using AzureMcp.Monitor.Commands.Ingestion;
 using AzureMcp.Monitor.Commands.Log;
 using AzureMcp.Monitor.Commands.Metrics;
 using AzureMcp.Monitor.Commands.Table;
@@ -75,5 +76,11 @@ public class MonitorSetup : IAreaSetup
 
         metrics.AddCommand("query", new MetricsQueryCommand(loggerFactory.CreateLogger<MetricsQueryCommand>()));
         metrics.AddCommand("definitions", new MetricsDefinitionsCommand(loggerFactory.CreateLogger<MetricsDefinitionsCommand>()));
+
+        // Create Ingestion command group and register commands
+        var ingestion = new CommandGroup("ingestion", "Azure Monitor ingestion operations - Commands for uploading custom log data to Azure Monitor.");
+        monitor.AddSubGroup(ingestion);
+
+        ingestion.AddCommand("upload", new IngestionUploadCommand(loggerFactory.CreateLogger<IngestionUploadCommand>()));
     }
 }

--- a/areas/monitor/src/AzureMcp.Monitor/Options/IngestionUploadOptions.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Options/IngestionUploadOptions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace AzureMcp.Monitor.Options;
+
+public class IngestionUploadOptions : WorkspaceOptions
+{
+    [JsonPropertyName(MonitorOptionDefinitions.DataCollectionRuleName)]
+    public string? DataCollectionRule { get; set; }
+
+    [JsonPropertyName(MonitorOptionDefinitions.LogDataName)]
+    public string? LogData { get; set; }
+
+    [JsonPropertyName(MonitorOptionDefinitions.StreamNameName)]
+    public string? StreamName { get; set; }
+}

--- a/areas/monitor/src/AzureMcp.Monitor/Options/MonitorOptionDefinitions.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Options/MonitorOptionDefinitions.cs
@@ -14,6 +14,9 @@ public static class MonitorOptionDefinitions
     public const string LimitName = "limit";
     public const string EntityName = "entity";
     public const string HealthModelName = "health-model";
+    public const string DataCollectionRuleName = "data-collection-rule";
+    public const string LogDataName = "log-data";
+    public const string StreamNameName = "stream-name";
 
     public static readonly Option<string> TableType = new(
         $"--{TableTypeName}",
@@ -206,6 +209,33 @@ public static class MonitorOptionDefinitions
         public static readonly Option<string> HealthModel = new(
             $"--{HealthModelName}",
             "The name of the health model for which to get the health."
+        )
+        {
+            IsRequired = true
+        };
+    }
+
+    public static class Ingestion
+    {
+        public static readonly Option<string> DataCollectionRule = new(
+            $"--{DataCollectionRuleName}",
+            "The ID of the data collection rule (DCR) to use for log ingestion. This defines the schema and transformation rules for the uploaded data."
+        )
+        {
+            IsRequired = true
+        };
+
+        public static readonly Option<string> LogData = new(
+            $"--{LogDataName}",
+            "The log data to upload as a JSON string or JSON array. The data must conform to the schema defined in the data collection rule."
+        )
+        {
+            IsRequired = true
+        };
+
+        public static readonly Option<string> StreamName = new(
+            $"--{StreamNameName}",
+            "The name of the stream within the data collection rule to target for the log data upload."
         )
         {
             IsRequired = true

--- a/areas/monitor/src/AzureMcp.Monitor/Services/IMonitorService.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Services/IMonitorService.cs
@@ -54,4 +54,12 @@ public interface IMonitorService
         string workspace,
         string? tenant,
         RetryPolicyOptions? retryPolicy);
+
+    Task<(string Status, int RecordCount, string Message)> UploadLogs(
+        string workspace,
+        string dataCollectionRule,
+        string streamName,
+        string logData,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
 }

--- a/areas/monitor/src/AzureMcp.Monitor/Services/MonitorService.cs
+++ b/areas/monitor/src/AzureMcp.Monitor/Services/MonitorService.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Nodes;
 using Azure;
 using Azure.Core;
+using Azure.Monitor.Ingestion;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
 using Azure.ResourceManager.OperationalInsights;
@@ -382,5 +383,100 @@ public class MonitorService : BaseAzureService, IMonitorService
         }
 
         return (matchingWorkspace.CustomerId, matchingWorkspace.Name);
+    }
+
+    public async Task<(string Status, int RecordCount, string Message)> UploadLogs(
+        string workspace,
+        string dataCollectionRule,
+        string streamName,
+        string logData,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(workspace, dataCollectionRule, streamName, logData);
+
+        try
+        {
+            var credential = await GetCredential(tenant);
+
+            // Parse the data collection rule ID to get the endpoint
+            var dcrId = dataCollectionRule;
+            var endpointUrl = BuildIngestionEndpoint(dcrId);
+
+            var ingestionClientOptions = AddDefaultPolicies(new LogsIngestionClientOptions());
+
+            if (retryPolicy != null)
+            {
+                ingestionClientOptions.Retry.Delay = TimeSpan.FromSeconds(retryPolicy.DelaySeconds);
+                ingestionClientOptions.Retry.MaxDelay = TimeSpan.FromSeconds(retryPolicy.MaxDelaySeconds);
+                ingestionClientOptions.Retry.MaxRetries = retryPolicy.MaxRetries;
+            }
+
+            var ingestionClient = new LogsIngestionClient(new Uri(endpointUrl), credential, ingestionClientOptions);
+
+            // Parse the log data as JSON nodes to avoid AOT issues
+            JsonNode? jsonNode;
+            try
+            {
+                jsonNode = JsonNode.Parse(logData);
+            }
+            catch (Exception ex)
+            {
+                return ("Failed", 0, $"Invalid JSON format: {ex.Message}");
+            }
+
+            if (jsonNode is not JsonArray jsonArray)
+            {
+                return ("Failed", 0, "Log data must be a JSON array");
+            }
+
+            if (jsonArray.Count == 0)
+            {
+                return ("Failed", 0, "Log data array is empty");
+            }
+
+            // Convert JsonArray to object array for the ingestion client
+            var logEntries = new List<object>();
+            foreach (var item in jsonArray)
+            {
+                if (item != null)
+                {
+                    logEntries.Add(item);
+                }
+            }
+
+            // Upload the logs
+            var response = await ingestionClient.UploadAsync(dcrId, streamName, logEntries);
+
+            // Check if the upload was successful
+            var recordCount = logEntries.Count;
+            var status = response.Status >= 200 && response.Status < 300 ? "Success" : "Failed";
+            var message = status == "Success"
+                ? $"Successfully uploaded {recordCount} records to stream '{streamName}'"
+                : $"Upload failed with status {response.Status}";
+
+            return (status, recordCount, message);
+        }
+        catch (Exception ex)
+        {
+            return ("Failed", 0, $"Error uploading logs: {ex.Message}");
+        }
+    }
+
+    private static string BuildIngestionEndpoint(string dataCollectionRuleId)
+    {
+        // Extract the data collection endpoint from the DCR ID
+        // DCR ID format: /subscriptions/{subscription}/resourceGroups/{rg}/providers/Microsoft.Insights/dataCollectionRules/{name}
+        // We need to build the data collection endpoint URL
+        var parts = dataCollectionRuleId.Split('/');
+        if (parts.Length < 4)
+        {
+            throw new ArgumentException($"Invalid data collection rule ID format: {dataCollectionRuleId}");
+        }
+
+        // For simplicity, we'll assume the standard ingestion endpoint pattern
+        // In a real implementation, you might need to query the DCR to get the actual endpoint
+        var subscriptionId = parts[2];
+        return $"https://monitor.azure.com/";
     }
 }

--- a/areas/monitor/tests/AzureMcp.Monitor.UnitTests/Ingestion/IngestionUploadCommandTests.cs
+++ b/areas/monitor/tests/AzureMcp.Monitor.UnitTests/Ingestion/IngestionUploadCommandTests.cs
@@ -1,0 +1,254 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using AzureMcp.Core.Models.Command;
+using AzureMcp.Core.Options;
+using AzureMcp.Monitor.Commands.Ingestion;
+using AzureMcp.Monitor.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Monitor.UnitTests.Ingestion;
+
+[Trait("Area", "Monitor")]
+public sealed class IngestionUploadCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IMonitorService _monitorService;
+    private readonly ILogger<IngestionUploadCommand> _logger;
+    private readonly IngestionUploadCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    private const string _knownWorkspace = "knownWorkspace";
+    private const string _knownSubscription = "knownSubscription";
+    private const string _knownDataCollectionRule = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Insights/dataCollectionRules/dcr-test";
+    private const string _knownStreamName = "Custom-MyStream";
+    private const string _knownLogData = @"[{""TimeGenerated"": ""2023-01-01T12:00:00Z"", ""Message"": ""Test log entry"", ""Level"": ""Info""}]";
+    private const string _knownTenant = "knownTenant";
+
+    public IngestionUploadCommandTests()
+    {
+        _monitorService = Substitute.For<IMonitorService>();
+        _logger = Substitute.For<ILogger<IngestionUploadCommand>>();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton(_monitorService);
+        _serviceProvider = collection.BuildServiceProvider();
+
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
+    }
+
+    [Theory]
+    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --data-collection-rule {_knownDataCollectionRule} --stream-name {_knownStreamName} --log-data {_knownLogData}", true)]
+    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --data-collection-rule {_knownDataCollectionRule} --stream-name {_knownStreamName} --log-data {_knownLogData} --tenant {_knownTenant}", true)]
+    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --data-collection-rule {_knownDataCollectionRule} --stream-name {_knownStreamName}", false)] // missing log-data
+    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace} --data-collection-rule {_knownDataCollectionRule}", false)] // missing stream-name and log-data
+    [InlineData($"--subscription {_knownSubscription} --workspace {_knownWorkspace}", false)] // missing most parameters
+    [InlineData("", false)] // missing all parameters
+    public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
+    {
+        // Arrange
+        if (shouldSucceed)
+        {
+            var mockResult = ("Success", 1, "Successfully uploaded 1 records to stream 'Custom-MyStream'");
+            _monitorService.UploadLogs(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<RetryPolicyOptions>())
+                .Returns(mockResult);
+        }
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, _parser.Parse(args));
+
+        // Assert
+        Assert.Equal(shouldSucceed ? 200 : 400, response.Status);
+        if (shouldSucceed)
+        {
+            Assert.NotNull(response.Results);
+            Assert.Equal("Success", response.Message);
+        }
+        else
+        {
+            Assert.Contains("required", response.Message.ToLower());
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsIngestionResults()
+    {
+        // Arrange
+        var mockResult = ("Success", 3, "Successfully uploaded 3 records to stream 'Custom-MyStream'");
+        _monitorService.UploadLogs(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(mockResult);
+
+        var args = _parser.Parse([
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--data-collection-rule", _knownDataCollectionRule,
+            "--stream-name", _knownStreamName,
+            "--log-data", _knownLogData
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.NotNull(response.Results);
+
+        // Verify the mock was called
+        await _monitorService.Received(1).UploadLogs(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CallsServiceWithCorrectParameters()
+    {
+        // Arrange
+        var mockResult = ("Success", 1, "Successfully uploaded 1 records to stream 'Custom-MyStream'");
+        _monitorService.UploadLogs(
+            _knownWorkspace,
+            _knownDataCollectionRule,
+            _knownStreamName,
+            _knownLogData,
+            _knownTenant,
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(mockResult);
+
+        var args = _parser.Parse([
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--data-collection-rule", _knownDataCollectionRule,
+            "--stream-name", _knownStreamName,
+            "--log-data", _knownLogData,
+            "--tenant", _knownTenant
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        await _monitorService.Received(1).UploadLogs(
+            _knownWorkspace,
+            _knownDataCollectionRule,
+            _knownStreamName,
+            _knownLogData,
+            _knownTenant,
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceErrors()
+    {
+        // Arrange
+        _monitorService.UploadLogs(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(Task.FromException<(string, int, string)>(new Exception("Test ingestion error")));
+
+        var args = _parser.Parse([
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--data-collection-rule", _knownDataCollectionRule,
+            "--stream-name", _knownStreamName,
+            "--log-data", _knownLogData
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Test ingestion error", response.Message);
+        Assert.Contains("troubleshooting", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesInvalidJsonData()
+    {
+        // Arrange
+        var invalidLogData = "invalid json data";
+        var mockResult = ("Failed", 0, "Invalid JSON format: Unexpected character 'i' at position 0.");
+        _monitorService.UploadLogs(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            invalidLogData,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(mockResult);
+
+        var args = _parser.Parse([
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--data-collection-rule", _knownDataCollectionRule,
+            "--stream-name", _knownStreamName,
+            "--log-data", invalidLogData
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status); // Service handles the error, doesn't throw
+        Assert.NotNull(response.Results);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesEmptyLogData()
+    {
+        // Arrange
+        var emptyLogData = "[]";
+        var mockResult = ("Failed", 0, "Log data array is empty");
+        _monitorService.UploadLogs(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            emptyLogData,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>())
+            .Returns(mockResult);
+
+        var args = _parser.Parse([
+            "--subscription", _knownSubscription,
+            "--workspace", _knownWorkspace,
+            "--data-collection-rule", _knownDataCollectionRule,
+            "--stream-name", _knownStreamName,
+            "--log-data", emptyLogData
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.Equal(200, response.Status); // Service handles the error, doesn't throw
+        Assert.NotNull(response.Results);
+    }
+}

--- a/e2eTests/e2eTestPrompts.md
+++ b/e2eTests/e2eTestPrompts.md
@@ -201,6 +201,8 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | azmcp-monitor-workspace-list | Show me my Log Analytics workspaces |
 | azmcp-monitor-workspace-list | Show me the Log Analytics workspaces in my subscription |
 | azmcp-monitor-workspace-log-query | Show me the logs for the past hour in the Log Analytics workspace <workspace_name> |
+| azmcp-monitor-ingestion-logs-upload | Upload <logs-data> to the Log Analytics workspace <workspace_name> with the data collection rule <data_collection_rule> |
+| azmcp-monitor-ingestion-logs-upload | Using the dcr <data_collection_rule>, upload <logs-data> to the Log Analytics workspace <workspace_name> |
 
 ## Azure Native ISV
 


### PR DESCRIPTION
Adding the following MCP commands for Monitor Ingestion:
- `azmcp-monitor-ingestion-logs-upload`
- `azmcp-monitor-ingestion-data-validate`
- `azmcp-monitor-ingestion-status-check`


## GitHub issue number?
Closes #947
Closes #979
Closes #980


## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/e2eTests/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionConfidenceScore` tool and obtained a result >= 0.4
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
