### PR TITLE
Add `acr registry repository list`

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -12,6 +12,12 @@
     ],
     "useGitignore": true,
     "enableGlobDot": true,
+    "overrides": [
+        {
+            "filename": "**/*.trx",
+            "enabled": false
+        }
+    ],
     "ignorePaths": [
         "**/*.binlog",
         "**/.editorconfig",
@@ -23,6 +29,7 @@
         "**/eng/common/**",
         "**/obj/**",
         "**/bin/**",
+        "**/TestResults/**",
         "**/.work/**",
         "**/.dist/**",
         "**/eng/vscode/NOTICE.txt",
@@ -138,6 +145,7 @@
                 "myserver",
                 "mystorageaccount",
                 "mysvc",
+                "myacr",
                 "nativeproj",
                 "nettrace",
                 "nslookup",
@@ -169,6 +177,7 @@
                 "testcontainer",
                 "testdb",
                 "testfilesystem",
+                "testrepo",
                 "testpool",
                 "testproxy",
                 "testrg",
@@ -187,6 +196,7 @@
             ]
         }
     ],
+    "ignoreWords": ["testrepo", "myacr", "jong", "livetests", "netcore"],
     "words": [
         "1espt",
         "aarch",
@@ -370,6 +380,8 @@
         "timechart",
         "myapp",
         "mygroup",
-        "myworkbook"
+        "myworkbook",
+        "testrepo",
+        "myacr"
     ]
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.2.0" />
     <PackageVersion Include="Azure.AI.Projects" Version="1.0.0-beta.9" />
     <PackageVersion Include="Azure.Bicep.Types" Version="0.5.110" />
     <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.771" />

--- a/areas/acr/src/AzureMcp.Acr/AcrSetup.cs
+++ b/areas/acr/src/AzureMcp.Acr/AcrSetup.cs
@@ -25,5 +25,9 @@ public class AcrSetup : IAreaSetup
         acr.AddSubGroup(registry);
 
         registry.AddCommand("list", new RegistryListCommand(loggerFactory.CreateLogger<RegistryListCommand>()));
+
+        var repository = new CommandGroup("repository", "Container Registry repository operations - Commands for listing and managing repositories within a Container Registry.");
+        registry.AddSubGroup(repository);
+        repository.AddCommand("list", new RegistryRepositoryListCommand(loggerFactory.CreateLogger<RegistryRepositoryListCommand>()));
     }
 }

--- a/areas/acr/src/AzureMcp.Acr/AzureMcp.Acr.csproj
+++ b/areas/acr/src/AzureMcp.Acr/AzureMcp.Acr.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.ResourceManager" />
     <PackageReference Include="Azure.ResourceManager.ContainerRegistry" />
+    <PackageReference Include="Azure.Containers.ContainerRegistry" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="System.CommandLine" />

--- a/areas/acr/src/AzureMcp.Acr/Commands/AcrJsonContext.cs
+++ b/areas/acr/src/AzureMcp.Acr/Commands/AcrJsonContext.cs
@@ -7,6 +7,7 @@ using AzureMcp.Acr.Commands.Registry;
 namespace AzureMcp.Acr.Commands;
 
 [JsonSerializable(typeof(RegistryListCommand.RegistryListCommandResult))]
+[JsonSerializable(typeof(RegistryRepositoryListCommand.RegistryRepositoryListCommandResult))]
 [JsonSerializable(typeof(Models.AcrRegistryInfo))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class AcrJsonContext : JsonSerializerContext

--- a/areas/acr/src/AzureMcp.Acr/Commands/Registry/RegistryRepositoryListCommand.cs
+++ b/areas/acr/src/AzureMcp.Acr/Commands/Registry/RegistryRepositoryListCommand.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AzureMcp.Acr.Options;
+using AzureMcp.Acr.Options.Registry;
+using AzureMcp.Acr.Services;
+using AzureMcp.Core.Models.Command;
+using AzureMcp.Core.Services.Telemetry;
+using Microsoft.Extensions.Logging;
+
+namespace AzureMcp.Acr.Commands.Registry;
+
+public sealed class RegistryRepositoryListCommand(ILogger<RegistryRepositoryListCommand> logger)
+    : BaseAcrCommand<RegistryRepositoryListOptions>
+{
+    private const string CommandTitle = "List Container Registry Repositories";
+    private readonly ILogger<RegistryRepositoryListCommand> _logger = logger;
+
+    public override string Name => "list";
+
+    public override string Description =>
+        """
+        List repositories in Azure Container Registries. By default, lists repositories for all registries in the subscription.
+        You can narrow the scope using --resource-group and/or --registry to list repositories for a specific registry only.
+        """;
+
+    public override string Title => CommandTitle;
+
+    public override ToolMetadata Metadata => new() { Destructive = false, ReadOnly = true };
+
+    protected override void RegisterOptions(Command command)
+    {
+        base.RegisterOptions(command);
+        UseResourceGroup();
+        command.AddOption(AcrOptionDefinitions.Registry);
+    }
+
+    public override async Task<CommandResponse> ExecuteAsync(CommandContext context, ParseResult parseResult)
+    {
+        var options = BindOptions(parseResult);
+
+        try
+        {
+            if (!Validate(parseResult.CommandResult, context.Response).IsValid)
+            {
+                return context.Response;
+            }
+
+            var service = context.GetService<IAcrService>();
+            var map = await service.ListRegistryRepositories(
+                options.Subscription!,
+                options.ResourceGroup,
+                options.Registry,
+                options.Tenant,
+                options.RetryPolicy);
+
+            context.Response.Results = map.Count > 0
+                ? ResponseResult.Create(
+                    new RegistryRepositoryListCommandResult(map),
+                    AcrJsonContext.Default.RegistryRepositoryListCommandResult)
+                : null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error listing ACR repositories. Subscription: {Subscription}, ResourceGroup: {ResourceGroup}, Registry: {Registry}",
+                options.Subscription, options.ResourceGroup, options.Registry);
+            HandleException(context, ex);
+        }
+
+        return context.Response;
+    }
+
+    internal record RegistryRepositoryListCommandResult(Dictionary<string, List<string>> RepositoriesByRegistry);
+}

--- a/areas/acr/src/AzureMcp.Acr/Options/Registry/RegistryRepositoryListOptions.cs
+++ b/areas/acr/src/AzureMcp.Acr/Options/Registry/RegistryRepositoryListOptions.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AzureMcp.Acr.Options.Registry;
+
+public class RegistryRepositoryListOptions : BaseAcrOptions;

--- a/areas/acr/src/AzureMcp.Acr/Services/AcrService.cs
+++ b/areas/acr/src/AzureMcp.Acr/Services/AcrService.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure;
+using Azure.Containers.ContainerRegistry;
 using Azure.ResourceManager.ContainerRegistry;
 using AzureMcp.Core.Services.Azure;
 using AzureMcp.Core.Services.Azure.Subscription;
@@ -57,5 +59,91 @@ public sealed class AcrService(ISubscriptionService subscriptionService, ITenant
             data.LoginServer,
             data.Sku?.Name.ToString(),
             data.Sku?.Tier?.ToString()));
+    }
+
+    public async Task<Dictionary<string, List<string>>> ListRegistryRepositories(
+        string subscription,
+        string? resourceGroup = null,
+        string? registry = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null)
+    {
+        ValidateRequiredParameters(subscription);
+
+        var subscriptionResource = await _subscriptionService.GetSubscription(subscription, tenant, retryPolicy);
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        async Task AddRepositoriesForRegistryAsync(ContainerRegistryResource reg)
+        {
+            var data = reg.Data;
+            if (data?.LoginServer is null || string.IsNullOrWhiteSpace(data.Name))
+            {
+                return;
+            }
+
+            // Build data-plane client for this login server
+            var credential = await GetCredential(tenant);
+            var options = ConfigureRetryPolicy(AddDefaultPolicies(new ContainerRegistryClientOptions()), retryPolicy);
+            var acrEndpoint = new Uri($"https://{data.LoginServer}");
+            var client = new ContainerRegistryClient(acrEndpoint, credential, options);
+
+            var repoNames = new List<string>();
+            try
+            {
+                await foreach (var repo in client.GetRepositoryNamesAsync())
+                {
+                    if (!string.IsNullOrWhiteSpace(repo))
+                    {
+                        repoNames.Add(repo);
+                    }
+                }
+            }
+            catch (RequestFailedException)
+            {
+                // If we cannot enumerate repositories (e.g., permissions), return empty list for that registry
+            }
+
+            result[data.Name] = repoNames;
+        }
+
+        if (!string.IsNullOrWhiteSpace(registry))
+        {
+            // Fetch a single registry by name, optionally within the provided resource group
+            if (!string.IsNullOrWhiteSpace(resourceGroup))
+            {
+                var rg = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
+                var regRes = await rg.Value.GetContainerRegistries().GetAsync(registry);
+                await AddRepositoriesForRegistryAsync(regRes.Value);
+            }
+            else
+            {
+                // enumerate across subscription to find the registry name
+                await foreach (var regRes in subscriptionResource.GetContainerRegistriesAsync())
+                {
+                    if (string.Equals(regRes.Data?.Name, registry, StringComparison.OrdinalIgnoreCase))
+                    {
+                        await AddRepositoriesForRegistryAsync(regRes);
+                        break;
+                    }
+                }
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(resourceGroup))
+        {
+            var rg = await subscriptionResource.GetResourceGroupAsync(resourceGroup);
+            await foreach (var regRes in rg.Value.GetContainerRegistries().GetAllAsync())
+            {
+                await AddRepositoriesForRegistryAsync(regRes);
+            }
+        }
+        else
+        {
+            await foreach (var regRes in subscriptionResource.GetContainerRegistriesAsync())
+            {
+                await AddRepositoriesForRegistryAsync(regRes);
+            }
+        }
+
+        return result;
     }
 }

--- a/areas/acr/src/AzureMcp.Acr/Services/IAcrService.cs
+++ b/areas/acr/src/AzureMcp.Acr/Services/IAcrService.cs
@@ -10,4 +10,11 @@ public interface IAcrService
         string? resourceGroup = null,
         string? tenant = null,
         RetryPolicyOptions? retryPolicy = null);
+
+    Task<Dictionary<string, List<string>>> ListRegistryRepositories(
+        string subscription,
+        string? resourceGroup = null,
+        string? registry = null,
+        string? tenant = null,
+        RetryPolicyOptions? retryPolicy = null);
 }

--- a/areas/acr/tests/AzureMcp.Acr.UnitTests/Registry/RegistryRepositoryListCommandTests.cs
+++ b/areas/acr/tests/AzureMcp.Acr.UnitTests/Registry/RegistryRepositoryListCommandTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using AzureMcp.Acr.Commands.Registry;
+using AzureMcp.Acr.Services;
+using AzureMcp.Core.Models.Command;
+using AzureMcp.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AzureMcp.Acr.UnitTests.Registry;
+
+public class RegistryRepositoryListCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IAcrService _service;
+    private readonly ILogger<RegistryRepositoryListCommand> _logger;
+    private readonly RegistryRepositoryListCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    public RegistryRepositoryListCommandTests()
+    {
+        _service = Substitute.For<IAcrService>();
+        _logger = Substitute.For<ILogger<RegistryRepositoryListCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_service);
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
+    }
+
+    [Theory]
+    [InlineData("--subscription sub", true)]
+    [InlineData("--subscription sub --resource-group rg", true)]
+    [InlineData("--subscription sub --registry myacr", true)]
+    [InlineData("", false)]
+    public async Task ExecuteAsync_ValidatesInputCorrectly(string args, bool shouldSucceed)
+    {
+        // Arrange
+        if (shouldSucceed)
+        {
+            _service.ListRegistryRepositories(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+                .Returns(new Dictionary<string, List<string>>
+                {
+                    ["myacr"] = new List<string> { "repo1", "repo2" }
+                });
+        }
+
+        var parseResult = _parser.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(shouldSucceed ? 200 : 400, response.Status);
+        if (shouldSucceed)
+        {
+            Assert.NotNull(response.Results);
+        }
+        else
+        {
+            Assert.Contains("required", response.Message.ToLower());
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesServiceErrors()
+    {
+        // Arrange
+        _service.ListRegistryRepositories(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(Task.FromException<Dictionary<string, List<string>>>(new Exception("Test error")));
+
+        var parseResult = _parser.Parse(["--subscription", "sub"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(500, response.Status);
+        Assert.Contains("Test error", response.Message);
+        Assert.Contains("troubleshooting", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Empty_ReturnsNullResults()
+    {
+        // Arrange
+        _service.ListRegistryRepositories(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<RetryPolicyOptions?>())
+            .Returns(new Dictionary<string, List<string>>());
+
+        var parseResult = _parser.Parse(["--subscription", "sub"]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        Assert.Equal(200, response.Status);
+        Assert.Null(response.Results);
+    }
+}

--- a/areas/acr/tests/test-resources-post.ps1
+++ b/areas/acr/tests/test-resources-post.ps1
@@ -7,6 +7,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 
 . "$PSScriptRoot/../../../eng/common/scripts/common.ps1"
 . "$PSScriptRoot/../../../eng/scripts/helpers/TestResourcesHelpers.ps1"
@@ -24,4 +25,171 @@ $testSettings = New-TestSettings @PSBoundParameters -OutputPath $PSScriptRoot
 # $DeploymentOutputs keys are all UPPERCASE
 
 # Add your post deployment steps here
-# For example, you might want to configure resources or run additional scripts.
+# Seed a deterministic repository in the test ACR so live tests can validate existence
+
+function Ensure-AzModules {
+    # Make sure Az.Accounts and Az.ContainerRegistry are available; try to install if missing
+    $hasAccounts = [bool](Get-Module -ListAvailable Az.Accounts)
+    $hasAcr = [bool](Get-Module -ListAvailable Az.ContainerRegistry)
+    if ($hasAccounts -and $hasAcr) { return $true }
+
+    Write-Host "Required Az modules missing. Attempting installation (CurrentUser scope)..."
+    try {
+        if (-not $hasAccounts) { Install-Module -Name Az.Accounts -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop }
+        if (-not $hasAcr) { Install-Module -Name Az.ContainerRegistry -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop }
+    }
+    catch {
+        Write-Warning "Failed to install specific Az modules: $($_.Exception.Message). Attempting to install Az meta-module..."
+        try { Install-Module -Name Az -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop }
+        catch { Write-Warning "Failed to install Az modules: $($_.Exception.Message)"; return $false }
+    }
+
+    return ([bool](Get-Module -ListAvailable Az.Accounts) -and [bool](Get-Module -ListAvailable Az.ContainerRegistry))
+}
+
+function Test-IsCi {
+    return ($env:TF_BUILD -eq 'True' -or $env:GITHUB_ACTIONS -eq 'true' -or $env:CI -eq 'true')
+}
+
+function Connect-AzPowerShell {
+    param(
+        [Parameter(Mandatory = $false)] [string] $SubscriptionId,
+        [Parameter(Mandatory = $false)] [string] $TenantIdParam
+    )
+
+    # Ensure required Az modules are available
+    $azAccounts = Get-Module -ListAvailable Az.Accounts
+    $azAcr = Get-Module -ListAvailable Az.ContainerRegistry
+    if (-not $azAccounts -or -not $azAcr) {
+        Write-Host "Az PowerShell modules not available (Az.Accounts/Az.ContainerRegistry)."
+        return $false
+    }
+
+    $isCi = Test-IsCi
+    $connected = $false
+
+    try {
+        # Reuse session if already connected
+        Get-AzContext -ErrorAction Stop | Out-Null
+        $connected = $true
+    }
+    catch {
+        $connected = $false
+    }
+
+    if (-not $connected) {
+        # 1) GitHub OIDC (federated token)
+        if (-not $connected -and $env:AZURE_FEDERATED_TOKEN_FILE -and $env:AZURE_CLIENT_ID -and $env:AZURE_TENANT_ID) {
+            try {
+                $token = Get-Content -Raw -ErrorAction Stop $env:AZURE_FEDERATED_TOKEN_FILE
+                if ($token) {
+                    Write-Host "Connecting to Azure with Az PowerShell using federated credentials (OIDC)..."
+                    Connect-AzAccount -ServicePrincipal -Tenant $env:AZURE_TENANT_ID -ClientId $env:AZURE_CLIENT_ID -FederatedToken $token -ErrorAction Stop | Out-Null
+                    $connected = $true
+                }
+            }
+            catch { $connected = $false }
+        }
+
+        # 2) Service principal (client secret)
+        if (-not $connected -and $env:AZURE_CLIENT_ID -and $env:AZURE_CLIENT_SECRET -and $env:AZURE_TENANT_ID) {
+            try {
+                Write-Host "Connecting to Azure with Az PowerShell using service principal (client secret)..."
+                $secure = ConvertTo-SecureString $env:AZURE_CLIENT_SECRET -AsPlainText -Force
+                $cred = New-Object System.Management.Automation.PSCredential($env:AZURE_CLIENT_ID, $secure)
+                Connect-AzAccount -ServicePrincipal -Tenant $env:AZURE_TENANT_ID -Credential $cred -ErrorAction Stop | Out-Null
+                $connected = $true
+            }
+            catch { $connected = $false }
+        }
+
+        # 3) Managed identity
+        if (-not $connected) {
+            try {
+                Write-Host "Connecting to Azure with Az PowerShell using managed identity..."
+                Connect-AzAccount -Identity -ErrorAction Stop | Out-Null
+                $connected = $true
+            }
+            catch { $connected = $false }
+        }
+
+        # 4) Interactive (not in CI)
+        if (-not $connected -and -not $isCi) {
+            try {
+                $tenantArgs = if ([string]::IsNullOrWhiteSpace($TenantIdParam)) { @() } else { @('-Tenant', $TenantIdParam) }
+                Write-Host "Starting interactive Azure login via Az PowerShell..."
+                Connect-AzAccount @tenantArgs -ErrorAction Stop | Out-Null
+                $connected = $true
+            }
+            catch { $connected = $false }
+        }
+    }
+
+    if ($connected -and $SubscriptionId) {
+        try { Set-AzContext -Subscription $SubscriptionId -ErrorAction Stop | Out-Null } catch { $connected = $false }
+    }
+
+    if (-not $connected) { Write-Host "Az PowerShell authentication was not established." }
+    return $connected
+}
+
+function Import-AcrImageAz {
+    param(
+        [Parameter(Mandatory = $true)] [string] $ResourceGroupName,
+        [Parameter(Mandatory = $true)] [string] $RegistryName
+    )
+
+    try {
+        Write-Host "Importing testrepo:latest into $RegistryName from mcr.microsoft.com via Az PowerShell..."
+        Import-AzContainerRegistryImage -ResourceGroupName $ResourceGroupName -RegistryName $RegistryName -SourceImage "hello-world:latest" -SourceRegistryUri "mcr.microsoft.com" -Image "testrepo:latest" -ErrorAction Stop | Out-Null
+        Write-Host "Imported testrepo:latest from mcr.microsoft.com/hello-world:latest"
+        return $true
+    }
+    catch {
+        $msg = $_.Exception.Message
+        if ($msg -match 'already exists' -or $msg -match 'Conflict') {
+            Write-Host "Image already exists; proceeding."
+            return $true
+        }
+        Write-Warning "MCR import via Az PowerShell failed: $msg. Attempting Docker Hub alpine:latest..."
+    }
+
+    try {
+        Import-AzContainerRegistryImage -ResourceGroupName $ResourceGroupName -RegistryName $RegistryName -SourceImage "alpine:latest" -SourceRegistryUri "docker.io" -Image "testrepo:latest" -ErrorAction Stop | Out-Null
+        Write-Host "Imported testrepo:latest from docker.io/library/alpine:latest"
+        return $true
+    }
+    catch {
+        $msg = $_.Exception.Message
+        if ($msg -match 'already exists' -or $msg -match 'Conflict') {
+            Write-Host "Image already exists; proceeding."
+            return $true
+        }
+        Write-Warning "Docker Hub import via Az PowerShell failed: $msg."
+        return $false
+    }
+}
+
+try {
+    $subscriptionId = $testSettings.SubscriptionId
+    $registryName = $testSettings.ResourceBaseName
+    $rgName = $testSettings.ResourceGroupName
+
+    if (-not $subscriptionId -or -not $registryName) {
+        throw "Missing SubscriptionId or ResourceBaseName in test settings."
+    }
+
+    # Ensure Az modules are available and loaded
+    if (-not (Ensure-AzModules)) { Write-Warning "Az modules unavailable; skipping seeding."; return }
+    try { Import-Module Az.Accounts -ErrorAction Stop; Import-Module Az.ContainerRegistry -ErrorAction Stop } catch { Write-Warning "Failed to import Az modules: $($_.Exception.Message)"; return }
+
+    # Login and import using Az PowerShell only
+    $loginOk = Connect-AzPowerShell -SubscriptionId $subscriptionId -TenantIdParam $TenantId
+    if (-not $loginOk) { return }
+
+    Write-Host "Seeding ACR registry '$registryName' with repo 'testrepo:latest' via Az PowerShell image import..."
+    [void](Import-AcrImageAz -ResourceGroupName $rgName -RegistryName $registryName)
+}
+catch {
+    Write-Warning "ACR seeding step failed: $($_.Exception.Message). Live tests may skip repository assertions."
+}

--- a/areas/acr/tests/test-resources-post.ps1
+++ b/areas/acr/tests/test-resources-post.ps1
@@ -27,16 +27,18 @@ $testSettings = New-TestSettings @PSBoundParameters -OutputPath $PSScriptRoot
 # Add your post deployment steps here
 # Seed a deterministic repository in the test ACR so live tests can validate existence
 
-function Ensure-AzModules {
+function Install-AzModulesIfNeeded {
     # Make sure Az.Accounts and Az.ContainerRegistry are available; try to install if missing
     $hasAccounts = [bool](Get-Module -ListAvailable Az.Accounts)
     $hasAcr = [bool](Get-Module -ListAvailable Az.ContainerRegistry)
-    if ($hasAccounts -and $hasAcr) { return $true }
+    $hasResources = [bool](Get-Module -ListAvailable Az.Resources)
+    if ($hasAccounts -and $hasAcr -and $hasResources) { return $true }
 
     Write-Host "Required Az modules missing. Attempting installation (CurrentUser scope)..."
     try {
         if (-not $hasAccounts) { Install-Module -Name Az.Accounts -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop }
         if (-not $hasAcr) { Install-Module -Name Az.ContainerRegistry -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop }
+        if (-not $hasResources) { Install-Module -Name Az.Resources -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop }
     }
     catch {
         Write-Warning "Failed to install specific Az modules: $($_.Exception.Message). Attempting to install Az meta-module..."
@@ -44,7 +46,7 @@ function Ensure-AzModules {
         catch { Write-Warning "Failed to install Az modules: $($_.Exception.Message)"; return $false }
     }
 
-    return ([bool](Get-Module -ListAvailable Az.Accounts) -and [bool](Get-Module -ListAvailable Az.ContainerRegistry))
+    return ([bool](Get-Module -ListAvailable Az.Accounts) -and [bool](Get-Module -ListAvailable Az.ContainerRegistry) -and [bool](Get-Module -ListAvailable Az.Resources))
 }
 
 function Test-IsCi {
@@ -139,35 +141,62 @@ function Import-AcrImageAz {
         [Parameter(Mandatory = $true)] [string] $RegistryName
     )
 
-    try {
-        Write-Host "Importing testrepo:latest into $RegistryName from mcr.microsoft.com via Az PowerShell..."
-        Import-AzContainerRegistryImage -ResourceGroupName $ResourceGroupName -RegistryName $RegistryName -SourceImage "hello-world:latest" -SourceRegistryUri "mcr.microsoft.com" -Image "testrepo:latest" -ErrorAction Stop | Out-Null
-        Write-Host "Imported testrepo:latest from mcr.microsoft.com/hello-world:latest"
-        return $true
-    }
-    catch {
-        $msg = $_.Exception.Message
-        if ($msg -match 'already exists' -or $msg -match 'Conflict') {
-            Write-Host "Image already exists; proceeding."
-            return $true
+    $attempts = 5
+    for ($i = 1; $i -le $attempts; $i++) {
+        try {
+            Write-Host "[$i/$attempts] Importing testrepo:latest into $RegistryName from mcr.microsoft.com via Az PowerShell..."
+            Import-AzContainerRegistryImage -ResourceGroupName $ResourceGroupName -RegistryName $RegistryName -SourceImage "hello-world:latest" -SourceRegistryUri "mcr.microsoft.com" -Image "testrepo:latest" -ErrorAction Stop | Out-Null
+            Write-Host "Imported testrepo:latest from mcr.microsoft.com/hello-world:latest"
+            break
         }
-        Write-Warning "MCR import via Az PowerShell failed: $msg. Attempting Docker Hub alpine:latest..."
+        catch {
+            $msg = $_.Exception.Message
+            if ($msg -match 'already exists' -or $msg -match 'Conflict') {
+                Write-Host "Image already exists; proceeding."
+                break
+            }
+            if ($i -lt $attempts) { Write-Warning "MCR import failed: $msg. Retrying in 5s..."; Start-Sleep -Seconds 5 }
+            else { Write-Warning "MCR import failed after retries: $msg. Attempting Docker Hub alpine:latest..." }
+        }
     }
 
-    try {
-        Import-AzContainerRegistryImage -ResourceGroupName $ResourceGroupName -RegistryName $RegistryName -SourceImage "alpine:latest" -SourceRegistryUri "docker.io" -Image "testrepo:latest" -ErrorAction Stop | Out-Null
-        Write-Host "Imported testrepo:latest from docker.io/library/alpine:latest"
-        return $true
-    }
-    catch {
-        $msg = $_.Exception.Message
-        if ($msg -match 'already exists' -or $msg -match 'Conflict') {
-            Write-Host "Image already exists; proceeding."
-            return $true
+    $imported = $true
+    if ($i -gt $attempts) { $imported = $false }
+
+    if (-not $imported) {
+        $attempts2 = 3
+        for ($j = 1; $j -le $attempts2; $j++) {
+            try {
+                Write-Host "[$j/$attempts2] Importing testrepo:latest into $RegistryName from docker.io via Az PowerShell..."
+                Import-AzContainerRegistryImage -ResourceGroupName $ResourceGroupName -RegistryName $RegistryName -SourceImage "alpine:latest" -SourceRegistryUri "docker.io" -Image "testrepo:latest" -ErrorAction Stop | Out-Null
+                Write-Host "Imported testrepo:latest from docker.io/library/alpine:latest"
+                $imported = $true
+                break
+            }
+            catch {
+                $msg = $_.Exception.Message
+                if ($msg -match 'already exists' -or $msg -match 'Conflict') { Write-Host "Image already exists; proceeding."; $imported = $true; break }
+                if ($j -lt $attempts2) { Write-Warning "Docker Hub import failed: $msg. Retrying in 5s..."; Start-Sleep -Seconds 5 }
+                else { Write-Warning "Docker Hub import failed after retries: $msg." }
+            }
         }
-        Write-Warning "Docker Hub import via Az PowerShell failed: $msg."
-        return $false
     }
+
+    # Optional verification if the cmdlet exists
+    $verifyCmd = Get-Command -Name Get-AzContainerRegistryRepository -ErrorAction SilentlyContinue
+    if ($verifyCmd) {
+        try {
+            for ($k = 1; $k -le 6; $k++) {
+                $repos = Get-AzContainerRegistryRepository -RegistryName $RegistryName -ResourceGroupName $ResourceGroupName -ErrorAction Stop
+                if ($repos -and ($repos -contains 'testrepo')) { Write-Host "Verified repository 'testrepo' exists."; return $true }
+                Start-Sleep -Seconds 5
+            }
+            Write-Warning "Verification could not find repository 'testrepo' after waiting."
+        }
+        catch { Write-Warning "Verification step failed: $($_.Exception.Message)" }
+    }
+
+    return $imported
 }
 
 try {
@@ -180,15 +209,58 @@ try {
     }
 
     # Ensure Az modules are available and loaded
-    if (-not (Ensure-AzModules)) { Write-Warning "Az modules unavailable; skipping seeding."; return }
-    try { Import-Module Az.Accounts -ErrorAction Stop; Import-Module Az.ContainerRegistry -ErrorAction Stop } catch { Write-Warning "Failed to import Az modules: $($_.Exception.Message)"; return }
+    if (-not (Install-AzModulesIfNeeded)) { Write-Warning "Az modules unavailable; skipping seeding."; return }
+    try { Import-Module Az.Accounts -ErrorAction Stop; Import-Module Az.ContainerRegistry -ErrorAction Stop; Import-Module Az.Resources -ErrorAction Stop } catch { Write-Warning "Failed to import Az modules: $($_.Exception.Message)"; return }
 
     # Login and import using Az PowerShell only
     $loginOk = Connect-AzPowerShell -SubscriptionId $subscriptionId -TenantIdParam $TenantId
     if (-not $loginOk) { return }
 
+    # Ensure the current signed-in principal has data-plane access (AcrPull/AcrPush) on the registry for local runs
+    try {
+        $ctx = Get-AzContext -ErrorAction Stop
+        $principalId = $null
+        $principalType = $null
+        if ($ctx.Account.Type -eq 'User') {
+            $user = Get-AzADUser -UserPrincipalName $ctx.Account.Id -ErrorAction Stop
+            $principalId = $user.Id
+            $principalType = 'User'
+        }
+        elseif ($ctx.Account.Type -eq 'ServicePrincipal') {
+            # Account.Id is applicationId for SP logins
+            $sp = Get-AzADServicePrincipal -ApplicationId $ctx.Account.Id -ErrorAction Stop
+            $principalId = $sp.Id
+            $principalType = 'ServicePrincipal'
+        }
+        elseif ($ctx.Account.Type -eq 'ManagedService') {
+            # Managed identity object id is not exposed consistently; best-effort: try current context Tenant subscription assignments
+            Write-Host "Managed identity detected; skipping explicit RBAC grant."
+        }
+
+        if ($principalId) {
+            $scope = "/subscriptions/$subscriptionId/resourceGroups/$rgName/providers/Microsoft.ContainerRegistry/registries/$registryName"
+            $roles = @('AcrPull','AcrPush')
+            foreach ($role in $roles) {
+                try {
+                    New-AzRoleAssignment -ObjectId $principalId -RoleDefinitionName $role -Scope $scope -ErrorAction Stop | Out-Null
+                    Write-Host "Granted $role to $principalType $($ctx.Account.Id) on $scope"
+                }
+                catch {
+                    # Ignore if assignment exists
+                    if ($_.Exception.Message -notmatch 'already exists') { Write-Warning "Failed to grant role ${role}: $($_.Exception.Message)" }
+                }
+            }
+        }
+    }
+    catch {
+        Write-Warning "Skipping RBAC grant due to error: $($_.Exception.Message)"
+    }
+
     Write-Host "Seeding ACR registry '$registryName' with repo 'testrepo:latest' via Az PowerShell image import..."
-    [void](Import-AcrImageAz -ResourceGroupName $rgName -RegistryName $registryName)
+    $seedOk = Import-AcrImageAz -ResourceGroupName $rgName -RegistryName $registryName
+    if (-not $seedOk) {
+        throw "Failed to seed or verify repository 'testrepo' in registry '$registryName' after retries."
+    }
 }
 catch {
     Write-Warning "ACR seeding step failed: $($_.Exception.Message). Live tests may skip repository assertions."


### PR DESCRIPTION
Introduce a command to list repositories in Azure Container Registries, refactor image import logic for better error handling, and enhance the Import-AcrImageAz function with a TargetTag parameter. Improve repository verification logic as well.