### PR TITLE
Add tool calls for peeking messages from a queue or topic

### DIFF
--- a/AzureMcp.sln
+++ b/AzureMcp.sln
@@ -332,6 +332,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureMcp.Quota.LiveTests", "areas\quota\tests\AzureMcp.Quota.LiveTests\AzureMcp.Quota.LiveTests.csproj", "{1DC07369-9133-4B02-B2DD-A7E277163CB4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureMcp.Quota.UnitTests", "areas\quota\tests\AzureMcp.Quota.UnitTests\AzureMcp.Quota.UnitTests.csproj", "{0DDDCBF8-2DE9-466A-B94F-8A54687E1CC6}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "virtualdesktop", "virtualdesktop", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3F159DE4-1438-4821-AA38-9BC3441661F0}"
@@ -353,6 +354,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{75F7911D-A518-6F54-1978-62BEAF400CFE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureMcp.ResourceHealth.UnitTests", "areas\resourcehealth\tests\AzureMcp.ResourceHealth.UnitTests\AzureMcp.ResourceHealth.UnitTests.csproj", "{2A346B5F-D5FB-4454-ABBB-5E60280CBDF2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureMcp.ServiceBus.UnitTests", "areas\servicebus\tests\AzureMcp.ServiceBus.UnitTests\AzureMcp.ServiceBus.UnitTests.csproj", "{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1384,6 +1387,18 @@ Global
 		{2A346B5F-D5FB-4454-ABBB-5E60280CBDF2}.Release|x64.Build.0 = Release|Any CPU
 		{2A346B5F-D5FB-4454-ABBB-5E60280CBDF2}.Release|x86.ActiveCfg = Release|Any CPU
 		{2A346B5F-D5FB-4454-ABBB-5E60280CBDF2}.Release|x86.Build.0 = Release|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Debug|x64.Build.0 = Debug|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Debug|x86.Build.0 = Debug|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Release|x64.ActiveCfg = Release|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Release|x64.Build.0 = Release|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Release|x86.ActiveCfg = Release|Any CPU
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1563,5 +1578,6 @@ Global
 		{FD987DB2-B19B-42EE-99C9-BF743D1288E3} = {74490446-B0E8-F412-A296-BAE0BDC966AF}
 		{75F7911D-A518-6F54-1978-62BEAF400CFE} = {A29DD7BA-996D-C4EA-7CB3-91A08E5445CC}
 		{2A346B5F-D5FB-4454-ABBB-5E60280CBDF2} = {75F7911D-A518-6F54-1978-62BEAF400CFE}
+		{9BB9E6A8-206E-46FF-BB01-531720D4ECF5} = {E63ABCB2-96B7-1619-ED82-6BB2402F7B42}
 	EndGlobalSection
 EndGlobal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The Azure MCP Server updates automatically by default whenever a new release com
 
 ### Features Added
 
+- Added support for peeking at Service Bus messages without removing them via the following commands:
+    - `azmcp-servicebus-queue-peek` - Peek at messages in a Service Bus queue for diagnostic and debugging purposes. Returns message content, properties, and metadata while leaving messages in the queue.
+    - `azmcp-servicebus-topic-subscription-peek` - Peek at messages in a Service Bus topic subscription without removing them. Supports viewing active, locked, deferred, scheduled and dead letter messages.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueuePeekCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Queue/QueuePeekCommand.cs
@@ -18,6 +18,7 @@ public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger) : Subscri
     private readonly Option<string> _queueOption = ServiceBusOptionDefinitions.Queue;
     private readonly Option<int> _maxMessagesOption = ServiceBusOptionDefinitions.MaxMessages;
     private readonly Option<string> _namespaceOption = ServiceBusOptionDefinitions.Namespace;
+    private readonly Option<bool> _deadLetterOption = ServiceBusOptionDefinitions.DeadLetter;
     private readonly ILogger<QueuePeekCommand> _logger = logger;
     public override string Name => "peek";
 
@@ -32,6 +33,9 @@ public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger) : Subscri
         Required arguments:
         - namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)
         - queue: Queue name to peek messages from
+
+        Optional arguments:
+        - dead-letter: Peek messages from the dead letter queue instead of the active queue
         """;
 
     public override string Title => CommandTitle;
@@ -44,6 +48,7 @@ public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger) : Subscri
         command.AddOption(_namespaceOption);
         command.AddOption(_queueOption);
         command.AddOption(_maxMessagesOption);
+        command.AddOption(_deadLetterOption);
     }
 
     protected override QueuePeekOptions BindOptions(ParseResult parseResult)
@@ -52,6 +57,7 @@ public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger) : Subscri
         options.Name = parseResult.GetValueForOption(_queueOption);
         options.Namespace = parseResult.GetValueForOption(_namespaceOption);
         options.MaxMessages = parseResult.GetValueForOption(_maxMessagesOption);
+        options.DeadLetter = parseResult.GetValueForOption(_deadLetterOption);
         return options;
     }
 
@@ -71,6 +77,7 @@ public sealed class QueuePeekCommand(ILogger<QueuePeekCommand> logger) : Subscri
                 options.Namespace!,
                 options.Name!,
                 options.MaxMessages ?? 1,
+                options.DeadLetter,
                 options.Tenant,
                 options.RetryPolicy);
 

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionPeekCommand.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Commands/Topic/SubscriptionPeekCommand.cs
@@ -19,6 +19,7 @@ public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> log
     private readonly Option<string> _subscriptionNameOption = ServiceBusOptionDefinitions.Subscription;
     private readonly Option<int> _maxMessagesOption = ServiceBusOptionDefinitions.MaxMessages;
     private readonly Option<string> _namespaceOption = ServiceBusOptionDefinitions.Namespace;
+    private readonly Option<bool> _deadLetterOption = ServiceBusOptionDefinitions.DeadLetter;
     private readonly ILogger<SubscriptionPeekCommand> _logger = logger;
     public override string Name => "peek";
 
@@ -34,6 +35,9 @@ public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> log
         - namespace: The fully qualified Service Bus namespace host name. (This is usually in the form <namespace>.servicebus.windows.net)
         - topic: Topic name containing the subscription
         - subscription-name: Subscription name to peek messages from
+
+        Optional arguments:
+        - dead-letter: Peek messages from the dead letter queue instead of the active queue
         """;
 
     public override string Title => CommandTitle;
@@ -47,6 +51,7 @@ public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> log
         command.AddOption(_topicOption);
         command.AddOption(_subscriptionNameOption);
         command.AddOption(_maxMessagesOption);
+        command.AddOption(_deadLetterOption);
     }
 
     protected override SubscriptionPeekOptions BindOptions(ParseResult parseResult)
@@ -56,6 +61,7 @@ public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> log
         options.TopicName = parseResult.GetValueForOption(_topicOption);
         options.Namespace = parseResult.GetValueForOption(_namespaceOption);
         options.MaxMessages = parseResult.GetValueForOption(_maxMessagesOption);
+        options.DeadLetter = parseResult.GetValueForOption(_deadLetterOption);
         return options;
     }
 
@@ -76,6 +82,7 @@ public sealed class SubscriptionPeekCommand(ILogger<SubscriptionPeekCommand> log
                 options.TopicName!,
                 options.SubscriptionName!,
                 options.MaxMessages ?? 1,
+                options.DeadLetter,
                 options.Tenant,
                 options.RetryPolicy);
 

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Options/OptionDefinitions.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Options/OptionDefinitions.cs
@@ -10,6 +10,7 @@ public static class ServiceBusOptionDefinitions
     public const string MaxMessagesName = "max-messages";
     public const string TopicName = "topic";
     public const string SubscriptionName = "subscription-name";
+    public const string DeadLetterName = "dead-letter";
 
     public static readonly Option<string> Namespace = new(
         $"--{NamespaceName}",
@@ -47,6 +48,14 @@ public static class ServiceBusOptionDefinitions
         $"--{MaxMessagesName}",
         () => 1,
         "The maximum number of messages to return."
+    )
+    {
+        IsRequired = false
+    };
+
+    public static readonly Option<bool> DeadLetter = new(
+        $"--{DeadLetterName}",
+        "Peek messages from the dead letter queue instead of the active queue."
     )
     {
         IsRequired = false

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Options/Queue/QueuePeekOptions.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Options/Queue/QueuePeekOptions.cs
@@ -9,4 +9,9 @@ public class QueuePeekOptions : BaseQueueOptions
     /// Maximum number of messages to peek from queue.
     /// </summary>
     public int? MaxMessages { get; set; }
+
+    /// <summary>
+    /// Whether to peek from dead letter queue instead of active queue.
+    /// </summary>
+    public bool DeadLetter { get; set; }
 }

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Options/Topic/SubscriptionPeekOptions.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Options/Topic/SubscriptionPeekOptions.cs
@@ -14,4 +14,9 @@ public class SubscriptionPeekOptions : BaseTopicOptions
     /// Maximum number of messages to peek from subscription.
     /// </summary>
     public int? MaxMessages { get; set; }
+
+    /// <summary>
+    /// Whether to peek from dead letter queue instead of active queue.
+    /// </summary>
+    public bool DeadLetter { get; set; }
 }

--- a/areas/servicebus/src/AzureMcp.ServiceBus/ServiceBusSetup.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/ServiceBusSetup.cs
@@ -24,7 +24,8 @@ public class ServiceBusSetup : IAreaSetup
         rootGroup.AddSubGroup(serviceBus);
 
         var queue = new CommandGroup("queue", "Queue operations - Commands for using Azure Service Bus queues.");
-        // queue.AddCommand("peek", new QueuePeekCommand());
+        queue.AddCommand("peek", new QueuePeekCommand(
+            loggerFactory.CreateLogger<QueuePeekCommand>()));
         queue.AddCommand("details", new QueueDetailsCommand(
             loggerFactory.CreateLogger<QueueDetailsCommand>()));
 
@@ -33,7 +34,8 @@ public class ServiceBusSetup : IAreaSetup
             loggerFactory.CreateLogger<TopicDetailsCommand>()));
 
         var subscription = new CommandGroup("subscription", "Subscription operations - Commands for using subscriptions within a Service Bus topic.");
-        // subscription.AddCommand("peek", new SubscriptionPeekCommand());
+        subscription.AddCommand("peek", new SubscriptionPeekCommand(
+            loggerFactory.CreateLogger<SubscriptionPeekCommand>()));
         subscription.AddCommand("details", new SubscriptionDetailsCommand(
             loggerFactory.CreateLogger<SubscriptionDetailsCommand>()));
 

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Services/IServiceBusService.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Services/IServiceBusService.cs
@@ -63,7 +63,7 @@ public interface IServiceBusService
     /// <param name="namespaceName">The Service Bus namespace name</param>
     /// <param name="queueName">The queue name to peek messages from</param>
     /// <param name="maxMessages">Maximum number of messages to peek (default: 1)</param>
-    /// <param name="subscription">Subscription ID or name</param>
+    /// <param name="deadLetter">Whether to peek from Dead Letter Queue instead of Active Queue</param>
     /// <param name="tenantId">Optional tenant ID</param>
     /// <param name="retryPolicy">Optional retry policy</param>
     /// <returns>List of peeked messages</returns>
@@ -72,6 +72,7 @@ public interface IServiceBusService
         string namespaceName,
         string queueName,
         int maxMessages,
+        bool deadLetter = false,
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null);
 
@@ -82,7 +83,7 @@ public interface IServiceBusService
     /// <param name="topicName">The topic name containing the subscription</param>
     /// <param name="subscriptionName">The subscription name to peek messages from</param>
     /// <param name="maxMessages">Maximum number of messages to peek (default: 1)</param>
-    /// <param name="subscription">Subscription ID or name</param>
+    /// <param name="deadLetter">Whether to peek from Dead Letter Queue instead of active queue</param>
     /// <param name="tenantId">Optional tenant ID</param>
     /// <param name="retryPolicy">Optional retry policy</param>
     /// <returns>List of peeked messages</returns>
@@ -92,6 +93,7 @@ public interface IServiceBusService
         string topicName,
         string subscriptionName,
         int maxMessages,
+        bool deadLetter = false,
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null);
 }

--- a/areas/servicebus/src/AzureMcp.ServiceBus/Services/ServiceBusService.cs
+++ b/areas/servicebus/src/AzureMcp.ServiceBus/Services/ServiceBusService.cs
@@ -108,13 +108,16 @@ public class ServiceBusService : BaseAzureService, IServiceBusService
         string namespaceName,
         string queueName,
         int maxMessages,
+        bool deadLetter = false,
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
         var credential = await GetCredential(tenantId);
 
         await using (var client = new ServiceBusClient(namespaceName, credential))
-        await using (var receiver = client.CreateReceiver(queueName))
+        await using (var receiver = deadLetter 
+            ? client.CreateReceiver(queueName, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter })
+            : client.CreateReceiver(queueName))
         {
             var messages = await receiver.PeekMessagesAsync(maxMessages);
 
@@ -127,13 +130,16 @@ public class ServiceBusService : BaseAzureService, IServiceBusService
         string topicName,
         string subscriptionName,
         int maxMessages,
+        bool deadLetter = false,
         string? tenantId = null,
         RetryPolicyOptions? retryPolicy = null)
     {
         var credential = await GetCredential(tenantId);
 
         await using (var client = new ServiceBusClient(namespaceName, credential))
-        await using (var receiver = client.CreateReceiver(topicName, subscriptionName))
+        await using (var receiver = deadLetter 
+            ? client.CreateReceiver(topicName, subscriptionName, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter })
+            : client.CreateReceiver(topicName, subscriptionName))
         {
             var messages = await receiver.PeekMessagesAsync(maxMessages);
 

--- a/areas/servicebus/tests/AzureMcp.ServiceBus.UnitTests/Queue/QueuePeekCommandTests.cs
+++ b/areas/servicebus/tests/AzureMcp.ServiceBus.UnitTests/Queue/QueuePeekCommandTests.cs
@@ -1,0 +1,360 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using AzureMcp.ServiceBus.Commands.Queue;
+using AzureMcp.ServiceBus.Services;
+using AzureMcp.Core.Options;
+using AzureMcp.Core.Models.Command;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+using static AzureMcp.ServiceBus.Commands.Queue.QueuePeekCommand;
+
+namespace AzureMcp.ServiceBus.UnitTests.Queue;
+
+[Trait("Area", "ServiceBus")]
+public class QueuePeekCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IServiceBusService _serviceBusService;
+    private readonly ILogger<QueuePeekCommand> _logger;
+    private readonly QueuePeekCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    // Test constants
+    private const string SubscriptionId = "sub123";
+    private const string QueueName = "testQueue";
+    private const string NamespaceName = "test.servicebus.windows.net";
+
+    public QueuePeekCommandTests()
+    {
+        _serviceBusService = Substitute.For<IServiceBusService>();
+        _logger = Substitute.For<ILogger<QueuePeekCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_serviceBusService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsMessages()
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>
+        {
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 1")),
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 2"))
+        };
+
+        _serviceBusService.PeekQueueMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(QueueName),
+            Arg.Is(10),
+            Arg.Is(false),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--queue", QueueName,
+            "--max-messages", "10"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+        Assert.NotNull(response.Results);
+        
+        // Verify the service was called with correct parameters
+        await _serviceBusService.Received(1).PeekQueueMessages(
+            NamespaceName,
+            QueueName,
+            10,
+            false,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsDeadLetterMessages()
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>
+        {
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Dead Letter Message 1")),
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Dead Letter Message 2"))
+        };
+
+        _serviceBusService.PeekQueueMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(QueueName),
+            Arg.Is(5),
+            Arg.Is(true),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--queue", QueueName,
+            "--max-messages", "5",
+            "--dead-letter", "true"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+        Assert.NotNull(response.Results);
+        
+        // Verify the service was called with correct parameters for dead letter
+        await _serviceBusService.Received(1).PeekQueueMessages(
+            NamespaceName,
+            QueueName,
+            5,
+            true,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsEmptyListWhenNoMessages()
+    {
+        // Arrange
+        _serviceBusService.PeekQueueMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(QueueName),
+            Arg.Is(1),
+            Arg.Is(false),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(new List<ServiceBusReceivedMessage>());
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--queue", QueueName
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        var json = JsonSerializer.Serialize(response.Results, options);
+        var result = JsonSerializer.Deserialize<QueuePeekCommandResult>(json, options);
+        Assert.NotNull(result);
+        Assert.Empty(result.Messages);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesQueueNotFound()
+    {
+        // Arrange
+        var serviceBusException = new ServiceBusException("Queue not found", ServiceBusFailureReason.MessagingEntityNotFound);
+
+        _serviceBusService.PeekQueueMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(QueueName),
+            Arg.Any<int>(),
+            Arg.Any<bool>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).ThrowsAsync(serviceBusException);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--queue", QueueName
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(404, response.Status);
+        Assert.Contains("not found", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesGenericException()
+    {
+        // Arrange
+        var expectedError = "Test error";
+
+        _serviceBusService.PeekQueueMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(QueueName),
+            Arg.Any<int>(),
+            Arg.Any<bool>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).ThrowsAsync(new Exception(expectedError));
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--queue", QueueName
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(500, response.Status);
+        Assert.StartsWith(expectedError, response.Message);
+    }
+
+    [Theory]
+    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --queue testQueue", true)]
+    [InlineData("--namespace test.servicebus.windows.net --queue testQueue", false)]  // Missing subscription
+    [InlineData("--subscription sub123 --queue testQueue", false)]   // Missing namespace
+    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net", false)] // Missing queue
+    [InlineData("", false)]  // Missing all required options
+    public async Task ExecuteAsync_ValidatesRequiredParameters(string args, bool shouldSucceed)
+    {
+        // Arrange
+        if (shouldSucceed)
+        {
+            var expectedMessages = new List<ServiceBusReceivedMessage>
+            {
+                ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 1"))
+            };
+
+            _serviceBusService.PeekQueueMessages(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<int>(),
+                Arg.Any<bool>(),
+                Arg.Any<string>(),
+                Arg.Any<RetryPolicyOptions>())
+                .Returns(expectedMessages);
+        }
+
+        var parseResult = _parser.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        if (shouldSucceed)
+        {
+            Assert.Equal(200, response.Status);
+            Assert.Equal("Success", response.Message);
+        }
+        else
+        {
+            Assert.Equal(400, response.Status);
+            Assert.Contains("required", response.Message.ToLower());
+        }
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public async Task ExecuteAsync_RespectMaxMessagesParameter(int maxMessages)
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>();
+        for (int i = 0; i < maxMessages; i++)
+        {
+            expectedMessages.Add(ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData($"Message {i}")));
+        }
+
+        _serviceBusService.PeekQueueMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(QueueName),
+            Arg.Is(maxMessages),
+            Arg.Is(false),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--queue", QueueName,
+            "--max-messages", maxMessages.ToString()
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        await _serviceBusService.Received(1).PeekQueueMessages(
+            NamespaceName,
+            QueueName,
+            maxMessages,
+            false,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultsToOneMessageWhenMaxMessagesNotSpecified()
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>
+        {
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 1"))
+        };
+
+        _serviceBusService.PeekQueueMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(QueueName),
+            Arg.Is(1),
+            Arg.Is(false),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--queue", QueueName
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        await _serviceBusService.Received(1).PeekQueueMessages(
+            NamespaceName,
+            QueueName,
+            1,
+            false,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+}

--- a/areas/servicebus/tests/AzureMcp.ServiceBus.UnitTests/Topic/SubscriptionPeekCommandTests.cs
+++ b/areas/servicebus/tests/AzureMcp.ServiceBus.UnitTests/Topic/SubscriptionPeekCommandTests.cs
@@ -1,0 +1,433 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine.Parsing;
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using AzureMcp.ServiceBus.Commands.Topic;
+using AzureMcp.ServiceBus.Services;
+using AzureMcp.Core.Options;
+using AzureMcp.Core.Models.Command;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+using static AzureMcp.ServiceBus.Commands.Topic.SubscriptionPeekCommand;
+
+namespace AzureMcp.ServiceBus.UnitTests.Topic;
+
+[Trait("Area", "ServiceBus")]
+public class SubscriptionPeekCommandTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IServiceBusService _serviceBusService;
+    private readonly ILogger<SubscriptionPeekCommand> _logger;
+    private readonly SubscriptionPeekCommand _command;
+    private readonly CommandContext _context;
+    private readonly Parser _parser;
+
+    // Test constants
+    private const string SubscriptionId = "sub123";
+    private const string TopicName = "testTopic";
+    private const string SubscriptionName = "testSubscription";
+    private const string NamespaceName = "test.servicebus.windows.net";
+
+    public SubscriptionPeekCommandTests()
+    {
+        _serviceBusService = Substitute.For<IServiceBusService>();
+        _logger = Substitute.For<ILogger<SubscriptionPeekCommand>>();
+
+        var collection = new ServiceCollection().AddSingleton(_serviceBusService);
+
+        _serviceProvider = collection.BuildServiceProvider();
+        _command = new(_logger);
+        _context = new(_serviceProvider);
+        _parser = new(_command.GetCommand());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsMessages()
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>
+        {
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 1")),
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 2"))
+        };
+
+        _serviceBusService.PeekSubscriptionMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(TopicName),
+            Arg.Is(SubscriptionName),
+            Arg.Is(10),
+            Arg.Is(false),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--topic", TopicName,
+            "--subscription-name", SubscriptionName,
+            "--max-messages", "10"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+        Assert.NotNull(response.Results);
+        
+        // Verify the service was called with correct parameters
+        await _serviceBusService.Received(1).PeekSubscriptionMessages(
+            NamespaceName,
+            TopicName,
+            SubscriptionName,
+            10,
+            false,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsDeadLetterMessages()
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>
+        {
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Dead Letter Message 1")),
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Dead Letter Message 2"))
+        };
+
+        _serviceBusService.PeekSubscriptionMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(TopicName),
+            Arg.Is(SubscriptionName),
+            Arg.Is(5),
+            Arg.Is(true),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--topic", TopicName,
+            "--subscription-name", SubscriptionName,
+            "--max-messages", "5",
+            "--dead-letter", "true"
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        Assert.Equal("Success", response.Message);
+        Assert.NotNull(response.Results);
+        
+        // Verify the service was called with correct parameters for dead letter
+        await _serviceBusService.Received(1).PeekSubscriptionMessages(
+            NamespaceName,
+            TopicName,
+            SubscriptionName,
+            5,
+            true,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsEmptyListWhenNoMessages()
+    {
+        // Arrange
+        _serviceBusService.PeekSubscriptionMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(TopicName),
+            Arg.Is(SubscriptionName),
+            Arg.Is(1),
+            Arg.Is(false),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(new List<ServiceBusReceivedMessage>());
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--topic", TopicName,
+            "--subscription-name", SubscriptionName
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.NotNull(response.Results);
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        var json = JsonSerializer.Serialize(response.Results, options);
+        var result = JsonSerializer.Deserialize<SubscriptionPeekCommandResult>(json, options);
+        Assert.NotNull(result);
+        Assert.Empty(result.Messages);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesSubscriptionNotFound()
+    {
+        // Arrange
+        var serviceBusException = new ServiceBusException("Subscription not found", ServiceBusFailureReason.MessagingEntityNotFound);
+
+        _serviceBusService.PeekSubscriptionMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(TopicName),
+            Arg.Is(SubscriptionName),
+            Arg.Any<int>(),
+            Arg.Any<bool>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).ThrowsAsync(serviceBusException);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--topic", TopicName,
+            "--subscription-name", SubscriptionName
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(404, response.Status);
+        Assert.Contains("not found", response.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HandlesGenericException()
+    {
+        // Arrange
+        var expectedError = "Test error";
+
+        _serviceBusService.PeekSubscriptionMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(TopicName),
+            Arg.Is(SubscriptionName),
+            Arg.Any<int>(),
+            Arg.Any<bool>(),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).ThrowsAsync(new Exception(expectedError));
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--topic", TopicName,
+            "--subscription-name", SubscriptionName
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(500, response.Status);
+        Assert.StartsWith(expectedError, response.Message);
+    }
+
+    [Theory]
+    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --topic testTopic --subscription-name testSubscription", true)]
+    [InlineData("--namespace test.servicebus.windows.net --topic testTopic --subscription-name testSubscription", false)]  // Missing subscription
+    [InlineData("--subscription sub123 --topic testTopic --subscription-name testSubscription", false)]   // Missing namespace
+    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --subscription-name testSubscription", false)] // Missing topic
+    [InlineData("--subscription sub123 --namespace test.servicebus.windows.net --topic testTopic", false)] // Missing subscription-name
+    [InlineData("", false)]  // Missing all required options
+    public async Task ExecuteAsync_ValidatesRequiredParameters(string args, bool shouldSucceed)
+    {
+        // Arrange
+        if (shouldSucceed)
+        {
+            var expectedMessages = new List<ServiceBusReceivedMessage>
+            {
+                ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 1"))
+            };
+
+            _serviceBusService.PeekSubscriptionMessages(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<int>(),
+                Arg.Any<bool>(),
+                Arg.Any<string>(),
+                Arg.Any<RetryPolicyOptions>())
+                .Returns(expectedMessages);
+        }
+
+        var parseResult = _parser.Parse(args.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, parseResult);
+
+        // Assert
+        if (shouldSucceed)
+        {
+            Assert.Equal(200, response.Status);
+            Assert.Equal("Success", response.Message);
+        }
+        else
+        {
+            Assert.Equal(400, response.Status);
+            Assert.Contains("required", response.Message.ToLower());
+        }
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public async Task ExecuteAsync_RespectMaxMessagesParameter(int maxMessages)
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>();
+        for (int i = 0; i < maxMessages; i++)
+        {
+            expectedMessages.Add(ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData($"Message {i}")));
+        }
+
+        _serviceBusService.PeekSubscriptionMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(TopicName),
+            Arg.Is(SubscriptionName),
+            Arg.Is(maxMessages),
+            Arg.Is(false),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--topic", TopicName,
+            "--subscription-name", SubscriptionName,
+            "--max-messages", maxMessages.ToString()
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        await _serviceBusService.Received(1).PeekSubscriptionMessages(
+            NamespaceName,
+            TopicName,
+            SubscriptionName,
+            maxMessages,
+            false,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultsToOneMessageWhenMaxMessagesNotSpecified()
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>
+        {
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 1"))
+        };
+
+        _serviceBusService.PeekSubscriptionMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(TopicName),
+            Arg.Is(SubscriptionName),
+            Arg.Is(1),
+            Arg.Is(false),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var args = _parser.Parse([
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--topic", TopicName,
+            "--subscription-name", SubscriptionName
+        ]);
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        await _serviceBusService.Received(1).PeekSubscriptionMessages(
+            NamespaceName,
+            TopicName,
+            SubscriptionName,
+            1,
+            false,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ExecuteAsync_PassesDeadLetterParameterCorrectly(bool deadLetter)
+    {
+        // Arrange
+        var expectedMessages = new List<ServiceBusReceivedMessage>
+        {
+            ServiceBusModelFactory.ServiceBusReceivedMessage(body: new BinaryData("Message 1"))
+        };
+
+        _serviceBusService.PeekSubscriptionMessages(
+            Arg.Is(NamespaceName),
+            Arg.Is(TopicName),
+            Arg.Is(SubscriptionName),
+            Arg.Is(1),
+            Arg.Is(deadLetter),
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>()
+        ).Returns(expectedMessages);
+
+        var argsArray = new List<string>
+        {
+            "--subscription", SubscriptionId,
+            "--namespace", NamespaceName,
+            "--topic", TopicName,
+            "--subscription-name", SubscriptionName
+        };
+
+        if (deadLetter)
+        {
+            argsArray.AddRange(["--dead-letter", "true"]);
+        }
+
+        var args = _parser.Parse(argsArray.ToArray());
+
+        // Act
+        var response = await _command.ExecuteAsync(_context, args);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(200, response.Status);
+        await _serviceBusService.Received(1).PeekSubscriptionMessages(
+            NamespaceName,
+            TopicName,
+            SubscriptionName,
+            1,
+            deadLetter,
+            Arg.Any<string>(),
+            Arg.Any<RetryPolicyOptions>());
+    }
+}

--- a/docs/azmcp-commands.md
+++ b/docs/azmcp-commands.md
@@ -780,6 +780,13 @@ azmcp servicebus queue details --subscription <subscription> \
                                --namespace <service-bus-namespace> \
                                --queue <queue>
 
+# Peek messages from a Service Bus queue without removing them
+azmcp servicebus queue peek --subscription <subscription> \
+                            --namespace <service-bus-namespace> \
+                            --queue <queue> \
+                            [--max-messages <max-messages>] \
+                            [--dead-letter]
+
 # Gets runtime details a Service Bus topic
 azmcp servicebus topic details --subscription <subscription> \
                                --namespace <service-bus-namespace> \
@@ -790,6 +797,14 @@ azmcp servicebus topic subscription details --subscription <subscription> \
                                             --namespace <service-bus-namespace> \
                                             --topic <topic> \
                                             --subscription-name <subscription-name>
+
+# Peek messages from a Service Bus topic subscription without removing them
+azmcp servicebus topic subscription peek --subscription <subscription> \
+                                         --namespace <service-bus-namespace> \
+                                         --topic <topic> \
+                                         --subscription-name <subscription-name> \
+                                         [--max-messages <max-messages>] \
+                                         [--dead-letter]
 ```
 
 ### Azure SQL Database Operations

--- a/docs/e2eTestPrompts.md
+++ b/docs/e2eTestPrompts.md
@@ -294,8 +294,14 @@ This file contains prompts used for end-to-end testing to ensure each tool is in
 | Tool Name | Test Prompt |
 |:----------|:----------|
 | azmcp-servicebus-queue-details | Show me the details of service bus <service_bus_name> queue <queue_name> |
+| azmcp-servicebus-queue-peek | Peek messages from service bus <service_bus_name> queue <queue_name> |
+| azmcp-servicebus-queue-peek | Show me the messages in service bus <service_bus_name> queue <queue_name> without removing them |
+| azmcp-servicebus-queue-peek | Browse messages from the dead letter queue in service bus <service_bus_name> queue <queue_name> |
 | azmcp-servicebus-topic-details | Show me the details of service bus <service_bus_name> topic <topic_name> |
 | azmcp-servicebus-topic-subscription-details | Show me the details of service bus <service_bus_name> subscription <subscription_name> |
+| azmcp-servicebus-topic-subscription-peek | Peek messages from service bus <service_bus_name> topic <topic_name> subscription <subscription_name> |
+| azmcp-servicebus-topic-subscription-peek | Show me the messages in service bus <service_bus_name> topic <topic_name> subscription <subscription_name> without removing them |
+| azmcp-servicebus-topic-subscription-peek | Browse messages from the dead letter queue in service bus <service_bus_name> topic <topic_name> subscription <subscription_name> |
 
 ## Azure SQL Database
 


### PR DESCRIPTION
## What does this PR do?
The MCP docs for Service Bus mention two tools that are not available in the tool list:
- [Peek at queue messages](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/service-bus#peek-at-queue-messages)
- [Peek at topic subscription messages](https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/tools/service-bus#peek-at-topic-subscription-messages)

I added support for peeking the dead letter queue at the same time. 

## GitHub issue number?
- 

## Pre-merge Checklist

- [ ] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [x] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [x] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [x] Updated `README.md` documentation
    - [x] Updated command list in `/docs/azmcp-commands.md`
    - [x] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionEvaluator` tool and obtained a result >= 0.4
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
