### PR TITLE
Disable arm64 AOT cross compile on Linux x64

### DIFF
--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -78,14 +78,17 @@ jobs:
 
   - task: Powershell@2
     displayName: "(Native AOT) Install Linux arm64 cross compile toolchain"
-    condition: and(succeeded(), eq('${{ parameters.OSName }}', 'linux'), eq(variables['Architecture'], 'arm64'))
+    # The arm64 cross-compilation toolchain install on Linux x64 has glitches. This will be re-enabled once resolved.
+    # condition: and(succeeded(), eq('${{ parameters.OSName }}', 'linux'), eq(variables['Architecture'], 'arm64'))
+    condition: eq('false', 'true')
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Install-LinuxArm64CrossCompileToolchain.ps1
 
   - task: Powershell@2
     displayName: "(Native AOT) Build module"
-    condition: and(succeeded(), ne(variables['NoPackagesChanged'],'true'))
+    # Native build runs on all platforms except when targeting arm64 from Linux x64.
+    condition: and(succeeded(), ne(variables['NoPackagesChanged'],'true'), not(and(eq('${{ parameters.OSName }}', 'linux'), eq(variables['Architecture'], 'arm64'))))
     inputs:
       pwsh: true
       filePath: $(Build.SourcesDirectory)/eng/scripts/Build-Module.ps1


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

The arm64 cross compilation tool chain install on Linux x64 is unstable. Disabling the cross compile for now to unblock the pr merges. We still ensures no violations are not checked in as AOT compile will continue to be validated across other builds. I'll investigate tool chain install.

<img width="714" height="820" alt="image" src="https://github.com/user-attachments/assets/e43660c5-1bbc-4a26-bcb3-d1604574d350" />`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionEvaluator` tool and obtained a result >= 0.4
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
