### PR TITLE
Stop showing stack trace as it is not helpful to LLM

### DIFF
--- a/core/src/AzureMcp.Core/Commands/BaseCommand.cs
+++ b/core/src/AzureMcp.Core/Commands/BaseCommand.cs
@@ -44,7 +44,11 @@ public abstract class BaseCommand : IBaseCommand
         var response = context.Response;
         var result = new ExceptionResult(
             Message: ex.Message,
-            //StackTrace: ex.StackTrace,
+#if DEBUG
+            StackTrace: ex.StackTrace,
+#else
+            StackTrace: null,
+#endif
             Type: ex.GetType().Name);
 
         response.Status = GetStatusCode(ex);
@@ -54,7 +58,7 @@ public abstract class BaseCommand : IBaseCommand
 
     internal record ExceptionResult(
         string Message,
-        //string? StackTrace,
+        string? StackTrace,
         string Type);
 
     protected virtual string GetErrorMessage(Exception ex) => ex.Message;


### PR DESCRIPTION
## What does this PR do?
`[Provide a clear, concise description of the changes]`

Stop showing stack trace as it is not helpful to LLM

`[Any additional context, screenshots, or information that helps reviewers]`

## GitHub issue number?
`[Link to the GitHub issue this PR addresses]`

## Pre-merge Checklist

- [ ] Required for All PRs
    - [ ] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [ ] PR title clearly describes the change
    - [ ] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [ ] Added comprehensive tests for new/modified functionality
    - [ ] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [ ] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionEvaluator` tool and obtained a result >= 0.4
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
