### PR TITLE
Move to .NET 10 preview 7 SDK to prepare for .NET tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The Azure MCP Server updates automatically by default whenever a new release com
 - Enhanced `BaseAzureService` with `EscapeKqlString` method for safe KQL query construction across all Azure services. [[#938](https://github.com/Azure/azure-mcp/pull/938)]
   - Fixed KQL string escaping in Workbooks service queries.
 - Standardized Azure Storage command descriptions, option names, and parameter names for consistency across all storage commands. Updated JSON serialization context to remove unused model types and improve organization. [[#1015](https://github.com/Azure/azure-mcp/pull/1015)]
+- Update to .NET 10 SDK to prepare for .NET tool packing.
 
 ## 0.5.7 (2025-08-19)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.5-bookworm-slim AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0.8-bookworm-slim AS runtime
 
 # Add build argument for publish directory
 ARG PUBLISH_DIR

--- a/areas/bicepschema/src/AzureMcp.BicepSchema/Services/ResourceProperties/Entities/UniqueResourceType.cs
+++ b/areas/bicepschema/src/AzureMcp.BicepSchema/Services/ResourceProperties/Entities/UniqueResourceType.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using AzureMcp.BicepSchema.Services.ResourceProperties.Helpers;
 
 namespace AzureMcp.BicepSchema.Services.ResourceProperties.Entities;
+
 public record UniqueResourceType
 {
     public UniqueResourceType(string resourceType)

--- a/areas/bicepschema/src/AzureMcp.BicepSchema/Services/ResourceProperties/Helpers/ApiVersionComparer.cs
+++ b/areas/bicepschema/src/AzureMcp.BicepSchema/Services/ResourceProperties/Helpers/ApiVersionComparer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace AzureMcp.BicepSchema.Services.ResourceProperties.Helpers;
+
 public class ApiVersionComparer : IComparer<string>
 {
     /// <summary>

--- a/areas/bicepschema/src/AzureMcp.BicepSchema/Services/ResourceProperties/Helpers/GuidHelper.cs
+++ b/areas/bicepschema/src/AzureMcp.BicepSchema/Services/ResourceProperties/Helpers/GuidHelper.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 
 namespace AzureMcp.BicepSchema.Services.ResourceProperties.Helpers;
+
 public static class GuidHelper
 {
     public static Guid GenerateDeterministicGuid(params string[] strings)

--- a/areas/bicepschema/src/AzureMcp.BicepSchema/Services/SchemaGenerator.cs
+++ b/areas/bicepschema/src/AzureMcp.BicepSchema/Services/SchemaGenerator.cs
@@ -9,6 +9,7 @@ using AzureMcp.BicepSchema.Services.Support;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AzureMcp.BicepSchema.Services;
+
 public static class SchemaGenerator
 {
     public static List<ComplexType> GetResponse(TypesDefinitionResult typesDefinitionResult)

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestCreateCommand.cs
@@ -9,6 +9,7 @@ using AzureMcp.LoadTesting.Services;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.LoadTesting.Commands.LoadTest;
+
 public sealed class TestCreateCommand(ILogger<TestCreateCommand> logger)
     : BaseLoadTestingCommand<TestCreateOptions>
 {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestGetCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTest/TestGetCommand.cs
@@ -8,6 +8,7 @@ using AzureMcp.LoadTesting.Services;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.LoadTesting.Commands.LoadTest;
+
 public sealed class TestGetCommand(ILogger<TestGetCommand> logger)
     : BaseLoadTestingCommand<TestGetOptions>
 {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceCreateCommand.cs
@@ -8,6 +8,7 @@ using AzureMcp.LoadTesting.Services;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.LoadTesting.Commands.LoadTestResource;
+
 public sealed class TestResourceCreateCommand(ILogger<TestResourceCreateCommand> logger)
     : BaseLoadTestingCommand<TestResourceCreateOptions>
 {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceListCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestResource/TestResourceListCommand.cs
@@ -8,6 +8,7 @@ using AzureMcp.LoadTesting.Services;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.LoadTesting.Commands.LoadTestResource;
+
 public sealed class TestResourceListCommand(ILogger<TestResourceListCommand> logger)
     : BaseLoadTestingCommand<TestResourceListOptions>
 {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunCreateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunCreateCommand.cs
@@ -9,6 +9,7 @@ using AzureMcp.LoadTesting.Services;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.LoadTesting.Commands.LoadTestRun;
+
 public sealed class TestRunCreateCommand(ILogger<TestRunCreateCommand> logger)
     : BaseLoadTestingCommand<TestRunCreateOptions>
 {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunGetCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunGetCommand.cs
@@ -9,6 +9,7 @@ using AzureMcp.LoadTesting.Services;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.LoadTesting.Commands.LoadTestRun;
+
 public sealed class TestRunGetCommand(ILogger<TestRunGetCommand> logger)
     : BaseLoadTestingCommand<TestRunGetOptions>
 {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunListCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunListCommand.cs
@@ -9,6 +9,7 @@ using AzureMcp.LoadTesting.Services;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.LoadTesting.Commands.LoadTestRun;
+
 public sealed class TestRunListCommand(ILogger<TestRunListCommand> logger)
     : BaseLoadTestingCommand<TestRunListOptions>
 {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunUpdateCommand.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Commands/LoadTestRun/TestRunUpdateCommand.cs
@@ -9,6 +9,7 @@ using AzureMcp.LoadTesting.Services;
 using Microsoft.Extensions.Logging;
 
 namespace AzureMcp.LoadTesting.Commands.LoadTestRun;
+
 public sealed class TestRunUpdateCommand(ILogger<TestRunUpdateCommand> logger)
     : BaseLoadTestingCommand<TestRunUpdateOptions>
 {

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/AdditionalFileInfo.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/AdditionalFileInfo.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class AdditionalFileInfo
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/AutoStopCriteria.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/AutoStopCriteria.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class AutoStopCriteria
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/InputArtifacts.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/InputArtifacts.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class InputArtifacts
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/LoadTestConfiguration.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/LoadTestConfiguration.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class LoadTestConfiguration
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/OptionalLoadTestConfig.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/OptionalLoadTestConfig.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class OptionalLoadTestConfig
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/PassFailCriteria.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/PassFailCriteria.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class PassFailCriteria
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/Test.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/Test.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class Test
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/TestRequestPaylaod.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/TestRequestPaylaod.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class TestRequestPayload
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/TestScriptFileInfo.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTest/TestScriptFileInfo.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTest;
+
 public class TestScriptFileInfo
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestResource/TestResource.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestResource/TestResource.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace AzureMcp.LoadTesting.Models.LoadTestResource;
+
 public class TestResource
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestRun/RequestDataLevel.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestRun/RequestDataLevel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace AzureMcp.LoadTesting.Models.LoadTestRun;
+
 public enum RequestDataLevel
 {
     NONE,

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestRun/TestRun.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestRun/TestRun.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Serialization;
 
 namespace AzureMcp.LoadTesting.Models.LoadTestRun;
+
 public class TestRun
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestRun/TestRunCreateRequest.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestRun/TestRunCreateRequest.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization;
 namespace AzureMcp.LoadTesting.Models.LoadTestRun;
+
 public class TestRunCreateRequest
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestRun/TestRunRequest.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Models/LoadTestRun/TestRunRequest.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using AzureMcp.LoadTesting.Models.LoadTest;
 
 namespace AzureMcp.LoadTesting.Models.LoadTestRun;
+
 public class TestRunRequest
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Options/BaseLoadTestingOptions.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Options/BaseLoadTestingOptions.cs
@@ -4,6 +4,7 @@
 using AzureMcp.Core.Options;
 
 namespace AzureMcp.LoadTesting.Options;
+
 public class BaseLoadTestingOptions : SubscriptionOptions
 {
     /// <summary>

--- a/areas/loadtesting/src/AzureMcp.LoadTesting/Options/LoadTestResource/TestResourceListOptions.cs
+++ b/areas/loadtesting/src/AzureMcp.LoadTesting/Options/LoadTestResource/TestResourceListOptions.cs
@@ -2,4 +2,5 @@
 // Licensed under the MIT License.
 
 namespace AzureMcp.LoadTesting.Options.LoadTestResource;
+
 public class TestResourceListOptions : BaseLoadTestingOptions;

--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -121,15 +121,6 @@ jobs:
       useGlobalJson: true
       workingDirectory: azure-sdk-tools
 
-  - task: UseDotNet@2
-    displayName: "Use .NET SDK 9.0.x"
-    retryCountOnTaskFailure: 3
-    inputs:
-      packageType: sdk
-      version: 9.0.x
-      performMultiLevelLookup: true
-      workingDirectory: azure-sdk-tools
-
   # Copied from eng/pipelines/templates/steps/install-dotnet.yml, but changed workingDirectory
   - task: UseDotNet@2
     displayName: "Use .NET SDK 8.0.x"

--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -121,6 +121,15 @@ jobs:
       useGlobalJson: true
       workingDirectory: azure-sdk-tools
 
+  - task: UseDotNet@2
+    displayName: "Use .NET SDK 9.0.x"
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: sdk
+      version: 9.0.x
+      performMultiLevelLookup: true
+      workingDirectory: azure-sdk-tools
+
   # Copied from eng/pipelines/templates/steps/install-dotnet.yml, but changed workingDirectory
   - task: UseDotNet@2
     displayName: "Use .NET SDK 8.0.x"

--- a/eng/pipelines/templates/jobs/analyze.yml
+++ b/eng/pipelines/templates/jobs/analyze.yml
@@ -18,6 +18,13 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: UseDotNet@2
+    displayName: "Use .NET SDK 9.0.x"
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: sdk
+      version: 9.0.x
+
   - task: Powershell@2
     displayName: "Run source analysis"
     inputs:

--- a/eng/pipelines/templates/jobs/build.yml
+++ b/eng/pipelines/templates/jobs/build.yml
@@ -36,6 +36,13 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: UseDotNet@2
+    displayName: "Use .NET SDK 9.0.x"
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: sdk
+      version: 9.0.x
+
   - task: Powershell@2
     displayName: "Build module"
     condition: and(succeeded(), ne(variables['NoPackagesChanged'],'true'))

--- a/eng/pipelines/templates/jobs/live-test.yml
+++ b/eng/pipelines/templates/jobs/live-test.yml
@@ -19,6 +19,12 @@ jobs:
     inputs:
       useGlobalJson: true
 
+  - task: UseDotNet@2
+    displayName: "Use .NET SDK 9.0.x"
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: sdk
+      version: 9.0.x
 
   - task: NodeTool@0
     displayName: "Install Node.js 22"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,5 @@
 {
     "sdk": {
-        // Keep the SDK (Major and Minor) version in sync with the .NET runtime version used in the Dockerfile
-        "version": "9.0.300",
-        "rollForward": "feature"
+        "version": "10.0.100-preview.7.25380.108"
     }
 }


### PR DESCRIPTION
## What does this PR do?

This splits out work from https://github.com/Azure/azure-mcp/pull/432 which moves the project to .NET 10 preview 7 SDK. The project still targets .NET 9 but will need new features in the .NET 10 SDK for .NET tool packing.

- Use .NET 10 Preview 7 in the global.json
- Install .NET 9 SDK side-by-side since the app targets .NET 9
- .NET 10 has more `dotnet format` rules, thus the whitespace changes.
- Bump to latest patch version of the Docker base image.

## GitHub issue number?

Progress on https://github.com/Azure/azure-mcp/issues/422

## Pre-merge Checklist

- [x] Required for All PRs
    - [x] **Read [contribution guidelines](https://github.com/Azure/azure-mcp/blob/main/CONTRIBUTING.md)**
    - [x] PR title clearly describes the change
    - [x] Commit history is clean with descriptive messages ([cleanup guide](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md))
    - [x] Added comprehensive tests for new/modified functionality
    - [x] Updated `CHANGELOG.md` for product changes (`features, bug fixes, UI/UX, updated dependencies`)
    - [x] Spelling check passes: `.\eng\common\spelling\Invoke-Cspell.ps1`
- [ ] For MCP tool changes:
    - [ ] **One tool per PR**: This PR adds or modifies only one MCP tool for faster review cycles
    - [ ] Updated `README.md` documentation
    - [ ] Updated command list in `/docs/azmcp-commands.md`
    - [ ] Updated test prompts in `/docs/e2eTestPrompts.md`
    - [ ] For new or modified tool descriptions, ran the `eng/tools/ToolDescriptionEvaluator` tool and obtained a result >= 0.4
- [ ] 👉 For Community (non-Azure team member) PRs:
    - [ ] **Security review**: Reviewed code for security vulnerabilities, malicious code, or suspicious activities before running tests (`crypto mining, spam, data exfiltration, etc.`)
    - [ ] **Manual tests run**: added comment `/azp run azure - mcp` to run *Live Test Pipeline*
